### PR TITLE
In taxonomy test use "nav_menu_item" to avoid WP 4.4 data change issue.

### DIFF
--- a/features/taxonomy.feature
+++ b/features/taxonomy.feature
@@ -11,10 +11,10 @@ Feature: Manage WordPress taxonomies
       | category | Categories |             | post        | 1             | 1            | 1      |
       | post_tag | Tags       |             | post        | 1             |              | 1      |
 
-    When I run `wp taxonomy list --object_type=link --format=csv`
+    When I run `wp taxonomy list --object_type=nav_menu_item --format=csv`
     Then STDOUT should be CSV containing:
-      | name          | label            | description | object_type | show_tagcloud | hierarchical | public |
-      | link_category | Link Categories  |             | link        |               |              |        |
+      | name     | label            | description | object_type   | show_tagcloud | hierarchical | public |
+      | nav_menu | Navigation Menus |             | nav_menu_item |               |              |        |
 
   Scenario: Get taxonomy
     When I try `wp taxonomy get invalid-taxonomy`


### PR DESCRIPTION
For https://github.com/wp-cli/wp-cli/issues/3971.

Use "nav_menu_item" as object_type in "taxonomy.feature" test instead of "link" to by-pass WP 4.4 data change issue (https://core.trac.wordpress.org/changeset/35153). 