### PR TITLE
Generate 24 character password for new users

### DIFF
--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -351,7 +351,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 		if ( isset( $assoc_args['user_pass'] ) ) {
 			$user->user_pass = $assoc_args['user_pass'];
 		} else {
-			$user->user_pass = wp_generate_password();
+			$user->user_pass = wp_generate_password(24);
 			$generated_pass = true;
 		}
 


### PR DESCRIPTION
This matches the default password length for new users.

See also: https://github.com/wp-cli/wp-cli/pull/4002