### PR TITLE
Support emails in user_login field

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -306,3 +306,19 @@ Feature: Manage WordPress users
       http://example.com/?author=1
       http://example.com/?author=2
       """
+
+  Scenario: Get user with email as login
+    Given a WP install
+    And I run `wp user create testuser4@example.com testemail4@example.com`
+
+    When I run `wp user get testemail4@example.com --field=user_login`
+    Then STDOUT should be:
+      """
+      testuser4@example.com
+      """
+
+    When I run `wp user get testuser4@example.com --field=user_login`
+    Then STDOUT should be:
+      """
+      testuser4@example.com
+      """

--- a/src/WP_CLI/Fetchers/User.php
+++ b/src/WP_CLI/Fetchers/User.php
@@ -22,9 +22,11 @@ class User extends Base {
 
 		if ( is_numeric( $id_email_or_login ) )
 			$user = get_user_by( 'id', $id_email_or_login );
-		else if ( is_email( $id_email_or_login ) )
+		else if ( is_email( $id_email_or_login ) ) {
 			$user = get_user_by( 'email', $id_email_or_login );
-		else
+			if ( ! $user ) /** Logins can be emails */
+				$user = get_user_by( 'login', $id_email_or_login );
+		} else
 			$user = get_user_by( 'login', $id_email_or_login );
 
 		return $user;

--- a/src/WP_CLI/Fetchers/User.php
+++ b/src/WP_CLI/Fetchers/User.php
@@ -20,14 +20,17 @@ class User extends Base {
 	 */
 	public function get( $id_email_or_login ) {
 
-		if ( is_numeric( $id_email_or_login ) )
+		if ( is_numeric( $id_email_or_login ) ) {
 			$user = get_user_by( 'id', $id_email_or_login );
-		else if ( is_email( $id_email_or_login ) ) {
+		} elseif ( is_email( $id_email_or_login ) ) {
 			$user = get_user_by( 'email', $id_email_or_login );
-			if ( ! $user ) /** Logins can be emails */
+			// Logins can be emails
+			if ( ! $user ) {
 				$user = get_user_by( 'login', $id_email_or_login );
-		} else
+			}
+		} else {
 			$user = get_user_by( 'login', $id_email_or_login );
+		}
 
 		return $user;
 	}


### PR DESCRIPTION
Logins can be set to e-mails, and are often set this way. This is fine,
until the user changes the e-mail (logins can't be changed). What
happens then? `wp user get` doesn't find the user by login, because if
the login is an e-mail it shorts to checking only the user_email field.

Rectify this. Tests included.