### PR TITLE
update docs for `wp post update`

### DIFF
--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -108,7 +108,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 *   be read from STDIN.
 	 *
 	 * --<field>=<value>
-	 * : One or more fields to update. See wp_update_post().
+	 * : One or more fields to update. See wp_insert_post().
 	 *
 	 * [--defer-term-counting]
 	 * : Recalculate term count in batch, for a performance boost.


### PR DESCRIPTION
There is no list of available fields on the ref page for `wp_update_post()`

* https://developer.wordpress.org/reference/functions/wp_update_post/
* https://developer.wordpress.org/reference/functions/wp_insert_post/
