### PR TITLE
Correct the example command for destroying all sessions for all users

### DIFF
--- a/src/User_Session_Command.php
+++ b/src/User_Session_Command.php
@@ -59,7 +59,7 @@ class User_Session_Command extends WP_CLI_Command {
 	 *     Success: Destroyed all sessions.
 	 *
 	 *     # Destroy all sessions for all users.
-	 *     $ wp user list --field=ID | xargs wp user session destroy --all
+	 *     $ wp user list --field=ID | xargs -n 1 wp user session destroy --all
 	 *     Success: Destroyed all sessions.
 	 *     Success: Destroyed all sessions.
 	 */


### PR DESCRIPTION
`wp user session destroy` only accepts one user argument at a time, so the example command does not work.