### PR TITLE
Add a "network" command namespace.

### DIFF
--- a/entity-command.php
+++ b/entity-command.php
@@ -14,7 +14,6 @@ WP_CLI::add_command( 'comment meta', 'Comment_Meta_Command' );
 WP_CLI::add_command( 'menu', 'Menu_Command' );
 WP_CLI::add_command( 'menu item', 'Menu_Item_Command' );
 WP_CLI::add_command( 'menu location', 'Menu_Location_Command' );
-WP_CLI::add_command( 'network', 'Network_Namespace' );
 WP_CLI::add_command( 'network meta', 'Network_Meta_Command', array(
 	'before_invoke' => function () {
 		if ( !is_multisite() ) {
@@ -55,3 +54,7 @@ WP_CLI::add_command( 'user session', 'User_Session_Command', array(
 );
 
 WP_CLI::add_command( 'user term', 'User_Term_Command' );
+
+if ( class_exists( 'WP_CLI\Dispatcher\CommandNamespace' ) ) {
+	WP_CLI::add_command( 'network', 'Network_Namespace' );
+}

--- a/entity-command.php
+++ b/entity-command.php
@@ -14,6 +14,7 @@ WP_CLI::add_command( 'comment meta', 'Comment_Meta_Command' );
 WP_CLI::add_command( 'menu', 'Menu_Command' );
 WP_CLI::add_command( 'menu item', 'Menu_Item_Command' );
 WP_CLI::add_command( 'menu location', 'Menu_Location_Command' );
+WP_CLI::add_command( 'network', 'Network_Namespace' );
 WP_CLI::add_command( 'network meta', 'Network_Meta_Command', array(
 	'before_invoke' => function () {
 		if ( !is_multisite() ) {

--- a/src/Network_Namespace.php
+++ b/src/Network_Namespace.php
@@ -1,0 +1,18 @@
+<?php
+
+use WP_CLI\Dispatcher\CommandNamespace;
+
+/**
+ * Perform network-wide operations.
+ *
+ * ## EXAMPLES
+ *
+ *     # Get a list of super-admins
+ *     $ wp network meta get 1 site_admins
+ *     array (
+ *       0 => 'supervisor',
+ *     )
+ */
+class Network_Namespace extends CommandNamespace {
+
+}


### PR DESCRIPTION
This allows the addition of a description to show up in the help screen.

See https://github.com/wp-cli/wp-cli/issues/4385