### PR TITLE
Update tests enable error reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ env:
 
 matrix:
   include:
+    - php: 7.2
+      env: WP_VERSION=nightly
     - php: 7.1
       env: WP_VERSION=latest
     - php: 7.0

--- a/bin/install-package-tests.sh
+++ b/bin/install-package-tests.sh
@@ -5,6 +5,7 @@ set -ex
 install_db() {
 	mysql -e 'CREATE DATABASE IF NOT EXISTS wp_cli_test;' -uroot
 	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
+	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
 }
 
 install_db

--- a/features/bootstrap/Process.php
+++ b/features/bootstrap/Process.php
@@ -115,4 +115,20 @@ class Process {
 
 		return $r;
 	}
+
+	/**
+	 * Run the command, but throw an Exception on error.
+	 * Same as `run_check()` above, but checks the correct stderr.
+	 *
+	 * @return ProcessRun
+	 */
+	public function run_check_stderr() {
+		$r = $this->run();
+
+		if ( $r->return_code || ! empty( $r->stderr ) ) {
+			throw new \RuntimeException( $r );
+		}
+
+		return $r;
+	}
 }

--- a/features/bootstrap/support.php
+++ b/features/bootstrap/support.php
@@ -2,6 +2,12 @@
 
 // Utility functions used by Behat steps
 
+function assertRegExp( $regex, $actual ) {
+	if ( ! preg_match( $regex, $actual ) ) {
+		throw new Exception( "Actual value: " . var_export( $actual, true ) );
+	}
+}
+
 function assertEquals( $expected, $actual ) {
 	if ( $expected != $actual ) {
 		throw new Exception( "Actual value: " . var_export( $actual, true ) );

--- a/features/bootstrap/utils.php
+++ b/features/bootstrap/utils.php
@@ -30,7 +30,9 @@ function extract_from_phar( $path ) {
 
 	register_shutdown_function(
 		function() use ( $tmp_path ) {
-			@unlink( $tmp_path );
+			if ( file_exists( $tmp_path ) ) {
+				unlink( $tmp_path );
+			}
 		}
 	);
 
@@ -58,7 +60,7 @@ function load_dependencies() {
 	}
 
 	if ( ! $has_autoload ) {
-		fputs( STDERR, "Internal error: Can't find Composer autoloader.\nTry running: composer install\n" );
+		fwrite( STDERR, "Internal error: Can't find Composer autoloader.\nTry running: composer install\n" );
 		exit( 3 );
 	}
 }
@@ -138,7 +140,7 @@ function find_file_upward( $files, $dir = null, $stop_check = null ) {
 	if ( is_null( $dir ) ) {
 		$dir = getcwd();
 	}
-	while ( @is_readable( $dir ) ) {
+	while ( is_readable( $dir ) ) {
 		// Stop walking up when the supplied callable returns true being passed the $dir
 		if ( is_callable( $stop_check ) && call_user_func( $stop_check, $dir ) ) {
 			return null;
@@ -166,7 +168,7 @@ function is_path_absolute( $path ) {
 		return true;
 	}
 
-	return $path[0] === '/';
+	return '/' === $path[0];
 }
 
 /**
@@ -227,12 +229,12 @@ function locate_wp_config() {
 	static $path;
 
 	if ( null === $path ) {
+		$path = false;
+
 		if ( file_exists( ABSPATH . 'wp-config.php' ) ) {
 			$path = ABSPATH . 'wp-config.php';
 		} elseif ( file_exists( ABSPATH . '../wp-config.php' ) && ! file_exists( ABSPATH . '/../wp-settings.php' ) ) {
 			$path = ABSPATH . '../wp-config.php';
-		} else {
-			$path = false;
 		}
 
 		if ( $path ) {
@@ -244,7 +246,9 @@ function locate_wp_config() {
 }
 
 function wp_version_compare( $since, $operator ) {
-	return version_compare( str_replace( array( '-src' ), '', $GLOBALS['wp_version'] ), $since, $operator );
+	$wp_version = str_replace( '-src', '', $GLOBALS['wp_version'] );
+	$since = str_replace( '-src', '', $since );
+	return version_compare( $wp_version, $since, $operator );
 }
 
 /**
@@ -358,9 +362,9 @@ function launch_editor_for_input( $input, $filename = 'WP-CLI' ) {
 	do {
 		$tmpfile = basename( $filename );
 		$tmpfile = preg_replace( '|\.[^.]*$|', '', $tmpfile );
-		$tmpfile .= '-' . substr( md5( rand() ), 0, 6 );
+		$tmpfile .= '-' . substr( md5( mt_rand() ), 0, 6 );
 		$tmpfile = $tmpdir . $tmpfile . '.tmp';
-		$fp = @fopen( $tmpfile, 'x' );
+		$fp = fopen( $tmpfile, 'xb' );
 		if ( ! $fp && is_writable( $tmpdir ) && file_exists( $tmpfile ) ) {
 			$tmpfile = '';
 			continue;
@@ -379,10 +383,10 @@ function launch_editor_for_input( $input, $filename = 'WP-CLI' ) {
 
 	$editor = getenv( 'EDITOR' );
 	if ( ! $editor ) {
+		$editor = 'vi';
+
 		if ( isset( $_SERVER['OS'] ) && false !== strpos( $_SERVER['OS'], 'indows' ) ) {
 			$editor = 'notepad';
-		} else {
-			$editor = 'vi';
 		}
 	}
 
@@ -416,9 +420,9 @@ function mysql_host_to_cli_args( $raw_host ) {
 		list( $assoc_args['host'], $extra ) = $host_parts;
 		$extra = trim( $extra );
 		if ( is_numeric( $extra ) ) {
-			$assoc_args['port'] = intval( $extra );
+			$assoc_args['port'] = (int) $extra;
 			$assoc_args['protocol'] = 'tcp';
-		} elseif ( $extra !== '' ) {
+		} elseif ( '' !== $extra ) {
 			$assoc_args['socket'] = $extra;
 		}
 	} else {
@@ -436,7 +440,9 @@ function run_mysql_command( $cmd, $assoc_args, $descriptors = null ) {
 	}
 
 	if ( isset( $assoc_args['host'] ) ) {
+		//@codingStandardsIgnoreStart
 		$assoc_args = array_merge( $assoc_args, mysql_host_to_cli_args( $assoc_args['host'] ) );
+		//@codingStandardsIgnoreEnd
 	}
 
 	$pass = $assoc_args['pass'];
@@ -581,6 +587,7 @@ function replace_path_consts( $source, $path ) {
 function http_request( $method, $url, $data = null, $headers = array(), $options = array() ) {
 
 	$cert_path = '/rmccue/requests/library/Requests/Transport/cacert.pem';
+	$halt_on_error = ! isset( $options['halt_on_error'] ) || (bool) $options['halt_on_error'];
 	if ( inside_phar() ) {
 		// cURL can't read Phar archives
 		$options['verify'] = extract_from_phar(
@@ -594,17 +601,24 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 			}
 		}
 		if ( empty( $options['verify'] ) ) {
-			WP_CLI::error( 'Cannot find SSL certificate.' );
+			$error_msg = 'Cannot find SSL certificate.';
+			if ( $halt_on_error ) {
+				WP_CLI::error( $error_msg );
+			}
+			throw new \RuntimeException( $error_msg );
 		}
 	}
 
 	try {
-		$request = \Requests::request( $url, $headers, $data, $method, $options );
-		return $request;
+		return \Requests::request( $url, $headers, $data, $method, $options );
 	} catch ( \Requests_Exception $ex ) {
 		// CURLE_SSL_CACERT_BADFILE only defined for PHP >= 7.
 		if ( 'curlerror' !== $ex->getType() || ! in_array( curl_errno( $ex->getData() ), array( CURLE_SSL_CONNECT_ERROR, CURLE_SSL_CERTPROBLEM, 77 /*CURLE_SSL_CACERT_BADFILE*/ ), true ) ) {
-			\WP_CLI::error( sprintf( "Failed to get url '%s': %s.", $url, $ex->getMessage() ) );
+			$error_msg = sprintf( "Failed to get url '%s': %s.", $url, $ex->getMessage() );
+			if ( $halt_on_error ) {
+				WP_CLI::error( $error_msg );
+			}
+			throw new \RuntimeException( $error_msg, null, $ex );
 		}
 		// Handle SSL certificate issues gracefully
 		\WP_CLI::warning( sprintf( "Re-trying without verify after failing to get verified url '%s' %s.", $url, $ex->getMessage() ) );
@@ -612,7 +626,11 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 		try {
 			return \Requests::request( $url, $headers, $data, $method, $options );
 		} catch ( \Requests_Exception $ex ) {
-			\WP_CLI::error( sprintf( "Failed to get non-verified url '%s' %s.", $url, $ex->getMessage() ) );
+			$error_msg = sprintf( "Failed to get non-verified url '%s' %s.", $url, $ex->getMessage() );
+			if ( $halt_on_error ) {
+				WP_CLI::error( $error_msg );
+			}
+			throw new \RuntimeException( $error_msg, null, $ex );
 		}
 	}
 }
@@ -698,11 +716,13 @@ function get_named_sem_ver( $new_version, $original_version ) {
 
 	if ( ! is_null( $minor ) && Semver::satisfies( $new_version, "{$major}.{$minor}.x" ) ) {
 		return 'patch';
-	} elseif ( Semver::satisfies( $new_version, "{$major}.x.x" ) ) {
-		return 'minor';
-	} else {
-		return 'major';
 	}
+
+	if ( Semver::satisfies( $new_version, "{$major}.x.x" ) ) {
+		return 'minor';
+	}
+
+	return 'major';
 }
 
 /**
@@ -770,16 +790,16 @@ function get_temp_dir() {
 		return $temp;
 	}
 
+	$temp = '/tmp/';
+
 	// `sys_get_temp_dir()` introduced PHP 5.2.1.
 	if ( $try = sys_get_temp_dir() ) {
 		$temp = trailingslashit( $try );
 	} elseif ( $try = ini_get( 'upload_tmp_dir' ) ) {
 		$temp = trailingslashit( $try );
-	} else {
-		$temp = '/tmp/';
 	}
 
-	if ( ! @is_writable( $temp ) ) {
+	if ( ! is_writable( $temp ) ) {
 		\WP_CLI::warning( "Temp directory isn't writable: {$temp}" );
 	}
 
@@ -813,6 +833,18 @@ function parse_ssh_url( $url, $component = -1 ) {
 			$bits[ $key ] = $matches[ $i ];
 		}
 	}
+
+	// Find the hostname from `vagrant ssh-config` automatically.
+	if ( preg_match( '/^vagrant:?/', $url ) ) {
+		if ( 'vagrant' === $bits['host'] && empty( $bits['scheme'] ) ) {
+			$ssh_config = shell_exec( 'vagrant ssh-config 2>/dev/null' );
+			if ( preg_match( '/Host\s(.+)/', $ssh_config, $matches ) ) {
+				$bits['scheme'] = 'vagrant';
+				$bits['host']   = $matches[1];
+			}
+		}
+	}
+
 	switch ( $component ) {
 		case PHP_URL_SCHEME:
 			return isset( $bits['scheme'] ) ? $bits['scheme'] : null;
@@ -835,25 +867,28 @@ function parse_ssh_url( $url, $component = -1 ) {
  * @access public
  * @category Input
  *
- * @param string  $noun      Resource being affected (e.g. plugin)
- * @param string  $verb      Type of action happening to the noun (e.g. activate)
- * @param integer $total     Total number of resource being affected.
- * @param integer $successes Number of successful operations.
- * @param integer $failures  Number of failures.
+ * @param string       $noun      Resource being affected (e.g. plugin)
+ * @param string       $verb      Type of action happening to the noun (e.g. activate)
+ * @param integer      $total     Total number of resource being affected.
+ * @param integer      $successes Number of successful operations.
+ * @param integer      $failures  Number of failures.
+ * @param null|integer $skips     Optional. Number of skipped operations. Default null (don't show skips).
  */
-function report_batch_operation_results( $noun, $verb, $total, $successes, $failures ) {
+function report_batch_operation_results( $noun, $verb, $total, $successes, $failures, $skips = null ) {
 	$plural_noun = $noun . 's';
 	$past_tense_verb = past_tense_verb( $verb );
 	$past_tense_verb_upper = ucfirst( $past_tense_verb );
 	if ( $failures ) {
+		$failed_skipped_message = null === $skips ? '' : " ({$failures} failed" . ( $skips ? ", {$skips} skipped" : '' ) . ')';
 		if ( $successes ) {
-			WP_CLI::error( "Only {$past_tense_verb} {$successes} of {$total} {$plural_noun}." );
+			WP_CLI::error( "Only {$past_tense_verb} {$successes} of {$total} {$plural_noun}{$failed_skipped_message}." );
 		} else {
-			WP_CLI::error( "No {$plural_noun} {$past_tense_verb}." );
+			WP_CLI::error( "No {$plural_noun} {$past_tense_verb}{$failed_skipped_message}." );
 		}
 	} else {
-		if ( $successes ) {
-			WP_CLI::success( "{$past_tense_verb_upper} {$successes} of {$total} {$plural_noun}." );
+		$skipped_message = $skips ? " ({$skips} skipped)" : '';
+		if ( $successes || $skips ) {
+			WP_CLI::success( "{$past_tense_verb_upper} {$successes} of {$total} {$plural_noun}{$skipped_message}." );
 		} else {
 			$message = $total > 1 ? ucfirst( $plural_noun ) : ucfirst( $noun );
 			WP_CLI::success( "{$message} already {$past_tense_verb}." );
@@ -876,7 +911,7 @@ function parse_str_to_argv( $arguments ) {
 	$argv = array_map(
 		function( $arg ) {
 			foreach ( array( '"', "'" ) as $char ) {
-				if ( $char === substr( $arg, 0, 1 ) && $char === substr( $arg, -1 ) ) {
+				if ( substr( $arg, 0, 1 ) === $char && substr( $arg, -1 ) === $char ) {
 					$arg = substr( $arg, 1, -1 );
 					break;
 				}
@@ -916,14 +951,15 @@ function basename( $path, $suffix = '' ) {
  *
  * @return bool
  */
+// @codingStandardsIgnoreLine
 function isPiped() {
 	$shellPipe = getenv( 'SHELL_PIPE' );
 
-	if ( $shellPipe !== false ) {
+	if ( false !== $shellPipe ) {
 		return filter_var( $shellPipe, FILTER_VALIDATE_BOOLEAN );
-	} else {
-		return (function_exists( 'posix_isatty' ) && ! posix_isatty( STDOUT ));
 	}
+
+	return (function_exists( 'posix_isatty' ) && ! posix_isatty( STDOUT ));
 }
 
 /**
@@ -992,9 +1028,11 @@ function glob_brace( $pattern, $dummy_flags = null ) {
 					}
 					$current++;
 				} else {
-					if ( ( '}' === $pattern[ $current ] && $depth-- === 0 ) || ( ',' === $pattern[ $current ] && 0 === $depth ) ) {
+					if ( ( '}' === $pattern[ $current ] && 0 === $depth-- ) || ( ',' === $pattern[ $current ] && 0 === $depth ) ) {
 						break;
-					} elseif ( '{' === $pattern[ $current++ ] ) {
+					}
+
+					if ( '{' === $pattern[ $current++ ] ) {
 						$depth++;
 					}
 				}
@@ -1038,7 +1076,7 @@ function glob_brace( $pattern, $dummy_flags = null ) {
 					. substr( $pattern, $p, $next - $p )
 					. substr( $pattern, $rest + 1 );
 
-		if ( ( $result = glob_brace( $subpattern ) ) ) {
+		if ( $result = glob_brace( $subpattern ) ) {
 			$paths = array_merge( $paths, $result );
 		}
 
@@ -1070,6 +1108,31 @@ function glob_brace( $pattern, $dummy_flags = null ) {
  * @return string
  */
 function get_suggestion( $target, array $options, $threshold = 2 ) {
+
+	$suggestion_map = array(
+		'check' => 'check-update',
+		'clear' => 'flush',
+		'decrement' => 'decr',
+		'del' => 'delete',
+		'directory' => 'dir',
+		'exec' => 'eval',
+		'exec-file' => 'eval-file',
+		'increment' => 'incr',
+		'language' => 'locale',
+		'lang' => 'locale',
+		'new' => 'create',
+		'number' => 'count',
+		'remove' => 'delete',
+		'regen' => 'regenerate',
+		'rep' => 'replace',
+		'repl' => 'replace',
+		'v' => 'version',
+	);
+
+	if ( array_key_exists( $target, $suggestion_map ) ) {
+		return $suggestion_map[ $target ];
+	}
+
 	if ( empty( $options ) ) {
 		return '';
 	}
@@ -1217,4 +1280,41 @@ function past_tense_verb( $verb ) {
 		$verb .= $last;
 	}
 	return $verb . 'ed';
+}
+
+/**
+ * Get the path to the PHP binary used when executing WP-CLI.
+ *
+ * Environment values permit specific binaries to be indicated.
+ *
+ * @access public
+ * @category System
+ *
+ * @return string
+ */
+function get_php_binary() {
+	if ( $wp_cli_php_used = getenv( 'WP_CLI_PHP_USED' ) ) {
+		return $wp_cli_php_used;
+	}
+
+	if ( $wp_cli_php = getenv( 'WP_CLI_PHP' ) ) {
+		return $wp_cli_php;
+	}
+
+	// Available since PHP 5.4.
+	if ( defined( 'PHP_BINARY' ) ) {
+		return PHP_BINARY;
+	}
+
+	// @codingStandardsIgnoreLine
+	if ( @is_executable( PHP_BINDIR . '/php' ) ) {
+		return PHP_BINDIR . '/php';
+	}
+
+	// @codingStandardsIgnoreLine
+	if ( is_windows() && @is_executable( PHP_BINDIR . '/php.exe' ) ) {
+		return PHP_BINDIR . '/php.exe';
+	}
+
+	return 'php';
 }

--- a/features/comment-meta.feature
+++ b/features/comment-meta.feature
@@ -17,6 +17,7 @@ Feature: Manage comment custom fields
       """
       Error: Could not find the comment with ID 999999.
       """
+    And the return code should be 1
 
     When I run `wp comment-meta set 1 foo '[ "1", "2" ]' --format=json`
     Then STDOUT should not be empty
@@ -42,6 +43,7 @@ Feature: Manage comment custom fields
       Error: Parameter errors:
        unknown -- hi parameter
       """
+    And the return code should be 1
 
     When I run `wp comment meta add 1 foo '"-- hi"' --format=json`
     Then STDOUT should contain:

--- a/features/comment.feature
+++ b/features/comment.feature
@@ -46,6 +46,7 @@ Feature: Manage WordPress comments
       """
       Error: Invalid comment ID.
       """
+    And the return code should be 1
 
     When I run `wp comment create --comment_post_ID=1`
     And I run `wp comment create --comment_post_ID=1`
@@ -67,6 +68,7 @@ Feature: Manage WordPress comments
       """
       Error: Invalid comment ID.
       """
+    And the return code should be 1
 
   Scenario: Get details about an existing comment
     When I run `wp comment get 1`
@@ -154,7 +156,7 @@ Feature: Manage WordPress comments
     Given I run `wp comment create --comment_post_ID=1 --comment_approved=0 --porcelain`
     And save STDOUT as {COMMENT_ID}
 
-    When I run `wp comment approve {COMMENT_ID}`
+    When I run `wp comment approve {COMMENT_ID} --url=www.example.com`
     Then STDOUT should contain:
       """
       Approved comment {COMMENT_ID}
@@ -166,11 +168,45 @@ Feature: Manage WordPress comments
       1
       """
 
-    When I run `wp comment unapprove {COMMENT_ID}`
+    When I run `wp comment unapprove {COMMENT_ID} --url=www.example.com`
     Then STDOUT should contain:
       """
       Unapproved comment {COMMENT_ID}
       """
+
+    When I run `wp comment get --field=comment_approved {COMMENT_ID}`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I try `wp comment approve {COMMENT_ID}`
+    Then STDOUT should contain:
+      """
+      Approved comment {COMMENT_ID}
+      """
+    And STDERR should contain:
+      """
+      Warning: `$_SERVER['SERVER_NAME']` not set. Setting to 'example.com'. Notification email sent to post author may appear to come from 'example.com'.
+      """
+    And the return code should be 0
+
+    When I run `wp comment get --field=comment_approved {COMMENT_ID}`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I try `wp comment unapprove {COMMENT_ID}`
+    Then STDOUT should contain:
+      """
+      Unapproved comment {COMMENT_ID}
+      """
+    And STDERR should contain:
+      """
+      Warning: `$_SERVER['SERVER_NAME']` not set. Setting to 'example.com'. Notification email sent to post author may appear to come from 'example.com'.
+      """
+    And the return code should be 0
 
     When I run `wp comment get --field=comment_approved {COMMENT_ID}`
     Then STDOUT should be:
@@ -184,7 +220,7 @@ Feature: Manage WordPress comments
     And I run `wp comment create --porcelain`
     And save STDOUT as {COMMENT_ID}
 
-    When I run `wp comment unapprove {COMMENT_ID}`
+    When I run `wp comment unapprove {COMMENT_ID} --url=www.example.com`
     Then STDOUT should contain:
       """
       Unapproved comment {COMMENT_ID}
@@ -196,7 +232,7 @@ Feature: Manage WordPress comments
       10
       """
 
-    When I run `wp comment approve {COMMENT_ID}`
+    When I run `wp comment approve {COMMENT_ID} --url=www.example.com`
     Then STDOUT should contain:
       """
       Approved comment {COMMENT_ID}

--- a/features/comment.feature
+++ b/features/comment.feature
@@ -156,11 +156,20 @@ Feature: Manage WordPress comments
     Given I run `wp comment create --comment_post_ID=1 --comment_approved=0 --porcelain`
     And save STDOUT as {COMMENT_ID}
 
+	# With site url set.
     When I run `wp comment approve {COMMENT_ID} --url=www.example.com`
-    Then STDOUT should contain:
+    Then STDOUT should be:
       """
-      Approved comment {COMMENT_ID}
+      Success: Approved comment {COMMENT_ID}.
       """
+
+    When I try the previous command again
+    Then STDERR should be:
+      """
+      Error: Could not update comment status
+      """
+    And STDOUT should be empty
+    And the return code should be 1
 
     When I run `wp comment get --field=comment_approved {COMMENT_ID}`
     Then STDOUT should be:
@@ -169,9 +178,9 @@ Feature: Manage WordPress comments
       """
 
     When I run `wp comment unapprove {COMMENT_ID} --url=www.example.com`
-    Then STDOUT should contain:
+    Then STDOUT should be:
       """
-      Unapproved comment {COMMENT_ID}
+      Success: Unapproved comment {COMMENT_ID}.
       """
 
     When I run `wp comment get --field=comment_approved {COMMENT_ID}`
@@ -180,50 +189,40 @@ Feature: Manage WordPress comments
       0
       """
 
+	# Without site url set.
     When I try `wp comment approve {COMMENT_ID}`
-    Then STDOUT should contain:
-      """
-      Approved comment {COMMENT_ID}
-      """
-    And STDERR should contain:
-      """
-      Warning: `$_SERVER['SERVER_NAME']` not set. Setting to 'example.com'. Notification email sent to post author may appear to come from 'example.com'.
-      """
-    And the return code should be 0
-
-    When I run `wp comment get --field=comment_approved {COMMENT_ID}`
     Then STDOUT should be:
       """
-      1
+      Success: Approved comment {COMMENT_ID}.
       """
+    And STDERR should be:
+      """
+      Warning: Site url not set - defaulting to 'example.com'. Any notification emails sent to post author may appear to come from 'example.com'.
+      """
+    And the return code should be 0
 
     When I try `wp comment unapprove {COMMENT_ID}`
-    Then STDOUT should contain:
-      """
-      Unapproved comment {COMMENT_ID}
-      """
-    And STDERR should contain:
-      """
-      Warning: `$_SERVER['SERVER_NAME']` not set. Setting to 'example.com'. Notification email sent to post author may appear to come from 'example.com'.
-      """
-    And the return code should be 0
-
-    When I run `wp comment get --field=comment_approved {COMMENT_ID}`
     Then STDOUT should be:
       """
-      0
+      Success: Unapproved comment {COMMENT_ID}.
       """
+    And STDERR should be:
+      """
+      Warning: Site url not set - defaulting to 'example.com'. Any notification emails sent to post author may appear to come from 'example.com'.
+      """
+    And the return code should be 0
 
   Scenario: Approving/unapproving comments with multidigit comment ID
     Given I run `wp comment delete $(wp comment list --field=ID)`
     And I run `wp comment generate --count=10 --quiet`
-    And I run `wp comment create --porcelain`
+    And I run `wp comment create --comment_post_ID=1 --porcelain`
     And save STDOUT as {COMMENT_ID}
 
+	# With site url set.
     When I run `wp comment unapprove {COMMENT_ID} --url=www.example.com`
-    Then STDOUT should contain:
+    Then STDOUT should be:
       """
-      Unapproved comment {COMMENT_ID}
+      Success: Unapproved comment {COMMENT_ID}.
       """
 
     When I run `wp comment list --format=count --status=approve`
@@ -233,9 +232,9 @@ Feature: Manage WordPress comments
       """
 
     When I run `wp comment approve {COMMENT_ID} --url=www.example.com`
-    Then STDOUT should contain:
+    Then STDOUT should be:
       """
-      Approved comment {COMMENT_ID}
+      Success: Approved comment {COMMENT_ID}.
       """
 
     When I run `wp comment list --format=count --status=approve`
@@ -244,16 +243,40 @@ Feature: Manage WordPress comments
       11
       """
 
+	# Without site url set.
+    When I try `wp comment unapprove {COMMENT_ID}`
+    Then STDOUT should be:
+      """
+      Success: Unapproved comment {COMMENT_ID}.
+      """
+    And STDERR should be:
+      """
+      Warning: Site url not set - defaulting to 'example.com'. Any notification emails sent to post author may appear to come from 'example.com'.
+      """
+    And the return code should be 0
+
+    When I try `wp comment approve {COMMENT_ID}`
+    Then STDOUT should be:
+      """
+      Success: Approved comment {COMMENT_ID}.
+      """
+    And STDERR should be:
+      """
+      Warning: Site url not set - defaulting to 'example.com'. Any notification emails sent to post author may appear to come from 'example.com'.
+      """
+    And the return code should be 0
+
   Scenario: Spam/unspam comments with multidigit comment ID
     Given I run `wp comment delete $(wp comment list --field=ID)`
     And I run `wp comment generate --count=10 --quiet`
-    And I run `wp comment create --porcelain`
+    And I run `wp comment create --comment_post_ID=1 --porcelain`
     And save STDOUT as {COMMENT_ID}
 
+	# With site url set.
     When I run `wp comment spam {COMMENT_ID}`
-    Then STDOUT should contain:
+    Then STDOUT should be:
       """
-      Marked as spam comment {COMMENT_ID}.
+      Success: Marked as spam comment {COMMENT_ID}.
       """
 
     When I run `wp comment list --format=count --status=spam`
@@ -262,10 +285,10 @@ Feature: Manage WordPress comments
       1
       """
 
-    When I run `wp comment unspam {COMMENT_ID}`
-    Then STDOUT should contain:
+    When I run `wp comment unspam {COMMENT_ID} --url=www.example.com`
+    Then STDOUT should be:
       """
-      Unspammed comment {COMMENT_ID}.
+      Success: Unspammed comment {COMMENT_ID}.
       """
 
     When I run `wp comment list --format=count --status=spam`
@@ -274,14 +297,33 @@ Feature: Manage WordPress comments
       0
       """
 
+	# Without site url set.
+    When I run `wp comment spam {COMMENT_ID}`
+    Then STDOUT should be:
+      """
+      Success: Marked as spam comment {COMMENT_ID}.
+      """
+
+    When I try `wp comment unspam {COMMENT_ID}`
+    Then STDOUT should be:
+      """
+      Success: Unspammed comment {COMMENT_ID}.
+      """
+    And STDERR should be:
+      """
+      Warning: Site url not set - defaulting to 'example.com'. Any notification emails sent to post author may appear to come from 'example.com'.
+      """
+    And the return code should be 0
+
   Scenario: Trash/untrash comments with multidigit comment ID
     Given I run `wp comment delete $(wp comment list --field=ID) --force`
     And I run `wp comment generate --count=10 --quiet`
-    And I run `wp comment create --porcelain`
+    And I run `wp comment create --comment_post_ID=1 --porcelain`
     And save STDOUT as {COMMENT_ID}
 
+	# With site url set.
     When I run `wp comment trash {COMMENT_ID}`
-    Then STDOUT should contain:
+    Then STDOUT should be:
       """
       Success: Trashed comment {COMMENT_ID}.
       """
@@ -292,10 +334,10 @@ Feature: Manage WordPress comments
       1
       """
 
-    When I run `wp comment untrash {COMMENT_ID}`
-    Then STDOUT should contain:
+    When I run `wp comment untrash {COMMENT_ID} --url=www.example.com`
+    Then STDOUT should be:
       """
-      Untrashed comment {COMMENT_ID}.
+      Success: Untrashed comment {COMMENT_ID}.
       """
 
     When I run `wp comment list --format=count --status=trash`
@@ -303,6 +345,24 @@ Feature: Manage WordPress comments
       """
       0
       """
+
+	# Without site url set.
+    When I run `wp comment trash {COMMENT_ID}`
+    Then STDOUT should be:
+      """
+      Success: Trashed comment {COMMENT_ID}.
+      """
+
+    When I try `wp comment untrash {COMMENT_ID}`
+    Then STDOUT should be:
+      """
+      Success: Untrashed comment {COMMENT_ID}.
+      """
+    And STDERR should be:
+      """
+      Warning: Site url not set - defaulting to 'example.com'. Any notification emails sent to post author may appear to come from 'example.com'.
+      """
+    And the return code should be 0
 
   Scenario: Make sure WordPress receives the slashed data it expects
     When I run `wp comment create --comment_content='My\Comment' --porcelain`
@@ -322,3 +382,16 @@ Feature: Manage WordPress comments
       """
       My\New\Comment
       """
+
+  @require-wp-4.4
+  Scenario: Approving/unapproving/unspamming/untrashing (approved) comments with no comment post id should not produce PHP notices for WP >= 4.4
+    Given I run `wp comment create --comment_approved=0 --porcelain`
+    And save STDOUT as {COMMENT_ID}
+    When I run `wp comment approve {COMMENT_ID} --url=www.example.com`
+    And I run `wp comment unapprove {COMMENT_ID} --url=www.example.com`
+
+    Given I run `wp comment approve {COMMENT_ID} --url=www.example.com`
+    When I run `wp comment spam {COMMENT_ID} --url=www.example.com`
+    And I run `wp comment unspam {COMMENT_ID} --url=www.example.com`
+    And I run `wp comment trash {COMMENT_ID} --url=www.example.com`
+    And I run `wp comment untrash {COMMENT_ID} --url=www.example.com`

--- a/features/menu-location.feature
+++ b/features/menu-location.feature
@@ -35,6 +35,7 @@ Feature: Manage WordPress menu locations
       """
       Error: Invalid menu secondary-menu.
       """
+    And the return code should be 1
 
     When I run `wp menu create "Secondary Menu"`
     And I try `wp menu location assign secondary-menu secondary`
@@ -42,6 +43,7 @@ Feature: Manage WordPress menu locations
       """
       Error: Invalid location secondary.
       """
+    And the return code should be 1
 
     When I run `wp menu location assign secondary-menu primary`
     Then STDOUT should be:

--- a/features/menu.feature
+++ b/features/menu.feature
@@ -62,6 +62,7 @@ Feature: Manage WordPress menus
       Warning: Couldn't delete menu 'Your menu'.
       Error: No menus deleted.
       """
+    And the return code should be 1
 
     When I run `wp menu create "My Menu"`
     And I run `wp menu list --fields=name,slug`

--- a/features/network-meta.feature
+++ b/features/network-meta.feature
@@ -3,7 +3,7 @@ Feature: Manage network-wide custom fields.
   Scenario: Non-multisite
     Given a WP install
 
-    When I try `wp network-meta`
+    When I run `wp network-meta`
     Then STDOUT should contain:
       """
       usage: wp network meta
@@ -15,3 +15,4 @@ Feature: Manage network-wide custom fields.
       """
       This is not a multisite install.
       """
+    And the return code should be 1

--- a/features/option.feature
+++ b/features/option.feature
@@ -48,7 +48,7 @@ Feature: Manage WordPress options
     When I run `wp option add auto_opt --autoload=no 'bar'`
     Then STDOUT should not be empty
 
-    When I run `wp option list --search='auto_opt' --autoload`
+    When I run `wp option list --search='auto_opt' --autoload=off`
     Then STDOUT should not be empty
 
     When I run `wp option list | grep -q "str_opt"`
@@ -65,6 +65,7 @@ Feature: Manage WordPress options
 
     When I try `wp option get str_opt`
     Then the return code should be 1
+    And STDERR should be empty
 
     # Integer values
     When I run `wp option update blog_public 1`
@@ -216,3 +217,40 @@ Feature: Manage WordPress options
       """
       Success: Value passed for 'home' option is unchanged.
       """
+
+  Scenario: Bad values for autoload
+    Given a WP install
+    When I run `wp option add str_opt 'bar'`
+    Then STDOUT should not be empty
+
+    When I try `wp option list --search='auto_opt' --autoload`
+    Then STDOUT should not be empty
+	And STDERR should be:
+      """
+      Warning: --autoload parameter needs a value
+      """
+    And the return code should be 0
+
+    When I try `wp option list --search='auto_opt' --autoload=no`
+    Then STDOUT should be empty
+	And STDERR should be:
+      """
+      Error: Value of '--autoload' should be on or off.
+      """
+    And the return code should be 1
+
+    When I try `wp option add str_opt_foo 'bar' --autoload`
+    Then STDOUT should not be empty
+	And STDERR should be:
+      """
+      Warning: --autoload parameter needs a value
+      """
+    And the return code should be 0
+
+    When I try `wp option add str_opt_foo 'bar' --autoload=off`
+    Then STDOUT should be empty
+	And STDERR should contain:
+      """
+      Error: Parameter errors:
+      """
+    And the return code should be 1

--- a/features/post-meta.feature
+++ b/features/post-meta.feature
@@ -17,6 +17,7 @@ Feature: Manage post custom fields
       """
       Error: Could not find the post with ID 999999.
       """
+    And the return code should be 1
 
     When I run `wp post-meta set 1 foo '[ "1", "2" ]' --format=json`
     Then STDOUT should not be empty
@@ -116,6 +117,7 @@ Feature: Manage post custom fields
       """
       Error: Please specify a meta key, or use the --all flag.
       """
+    And the return code should be 1
 
     When I run `wp post meta delete 1 --all`
     Then STDOUT should contain:

--- a/features/post-term.feature
+++ b/features/post-term.feature
@@ -37,6 +37,7 @@ Feature: Manage post term
       """
       Error: Invalid taxonomy foo2.
       """
+    And the return code should be 1
 
     When I run `wp post term set 1 category new`
     Then STDOUT should be:
@@ -214,3 +215,4 @@ Feature: Manage post term
       """
       Error: No need to specify terms while removing all terms.
       """
+    And the return code should be 1

--- a/features/post-type.feature
+++ b/features/post-type.feature
@@ -16,6 +16,7 @@ Feature: Manage WordPress post types
       """
       Error: Post type invalid-post-type doesn't exist.
       """
+    And the return code should be 1
 
     When I run `wp post-type get page`
     Then STDOUT should be a table containing rows:

--- a/features/post.feature
+++ b/features/post.feature
@@ -88,7 +88,7 @@ Feature: Manage WordPress posts
       """
     And the return code should be 0
 
-    When I try `EDITOR='ex -i NONE -c %s/content/bunkum -c wq' wp post edit {POST_ID}`
+    When I run `EDITOR='ex -i NONE -c %s/content/bunkum -c wq' wp post edit {POST_ID}`
     Then STDERR should be empty
     Then STDOUT should contain:
       """
@@ -155,6 +155,7 @@ Feature: Manage WordPress posts
       """
       Error: Unable to read content from 'invalid-file.html'.
       """
+    And the return code should be 1
 
   Scenario: Creating/listing posts
     When I run `wp post create --post_title='Publish post' --post_content='Publish post content' --post_status='publish' --porcelain`

--- a/features/site-create.feature
+++ b/features/site-create.feature
@@ -22,11 +22,13 @@ Feature: Create a new site on a WP multisite
       Success: Generated 'wp-config.php' file.
       """
 
-    When I run `wp core multisite-install --url=localhost/dev/ --title=Test --admin_user=admin --admin_email=admin@example.org`
+    # Old versions of WP can generate wpdb database errors if the WP tables don't exist, so STDERR may or may not be empty
+    When I try `wp core multisite-install --url=localhost/dev/ --title=Test --admin_user=admin --admin_email=admin@example.org`
     Then STDOUT should contain:
       """
       Success: Network installed. Don't forget to set up rewrite rules
       """
+    And the return code should be 0
 
     When I run `wp site list --fields=blog_id,url`
     Then STDOUT should be a table containing rows:

--- a/features/site-empty.feature
+++ b/features/site-empty.feature
@@ -15,6 +15,7 @@ Feature: Empty a WordPress site of its data
       """
       Error: This is not a multisite install.
       """
+    And the return code should be 1
 
     When I run `wp post create --post_title='Test post' --post_content='Test content.' --porcelain`
     Then STDOUT should be:

--- a/features/site-option.feature
+++ b/features/site-option.feature
@@ -118,12 +118,14 @@ Feature: Manage WordPress site options
       """
       Error: This is not a multisite install.
       """
+    And the return code should be 1
 
     When I try `wp site option add str_opt 'bar'`
     Then STDERR should be:
       """
       Error: This is not a multisite install.
       """
+    And the return code should be 1
 
   Scenario: Filter options by `--site_id`
     Given a WP multisite install

--- a/features/site.feature
+++ b/features/site.feature
@@ -176,7 +176,7 @@ Feature: Manage sites in a multisite installation
       Success: Site {FIRST_SITE} unarchived.
       """
 
-    When I try `wp site list --fields=blog_id,archived`
+    When I run `wp site list --fields=blog_id,archived`
     Then STDOUT should be a table containing rows:
       | blog_id      | archived |
       | {FIRST_SITE} | 0        |

--- a/features/site.feature
+++ b/features/site.feature
@@ -8,6 +8,8 @@ Feature: Manage sites in a multisite installation
       """
       Network with id 1000 does not exist.
       """
+    And STDOUT should be empty
+    And the return code should be 1
 
   Scenario: Create a subdomain site
     Given a WP multisite subdomain install
@@ -61,6 +63,7 @@ Feature: Manage sites in a multisite installation
       """
       Error: You cannot delete the root site.
       """
+    And STDOUT should be empty
     And the return code should be 1
 
     When I run `wp site delete {SITE_ID} --yes`
@@ -151,7 +154,7 @@ Feature: Manage sites in a multisite installation
       | blog_id      | archived |
       | {FIRST_SITE} | 1        |
 
-    When I run `wp site archive {FIRST_SITE} {SECOND_SITE}`
+    When I try `wp site archive {FIRST_SITE} {SECOND_SITE}`
     Then STDERR should be:
       """
       Warning: Site {FIRST_SITE} already archived.
@@ -160,6 +163,7 @@ Feature: Manage sites in a multisite installation
       """
       Success: Site {SECOND_SITE} archived.
       """
+    And the return code should be 0
 
     When I run `wp site list --fields=blog_id,archived`
     Then STDOUT should be a table containing rows:
@@ -172,7 +176,7 @@ Feature: Manage sites in a multisite installation
       Success: Site {FIRST_SITE} unarchived.
       """
 
-    When I run `wp site list --fields=blog_id,archived`
+    When I try `wp site list --fields=blog_id,archived`
     Then STDOUT should be a table containing rows:
       | blog_id      | archived |
       | {FIRST_SITE} | 0        |
@@ -182,6 +186,8 @@ Feature: Manage sites in a multisite installation
       """
       Warning: You are not allowed to change the main site.
       """
+    And STDOUT should be empty
+    And the return code should be 0
 
   Scenario: Activate/deactivate a site
     Given a WP multisite install
@@ -201,7 +207,7 @@ Feature: Manage sites in a multisite installation
       | blog_id      | deleted |
       | {FIRST_SITE} | 1       |
 
-    When I run `wp site deactivate {FIRST_SITE} {SECOND_SITE}`
+    When I try `wp site deactivate {FIRST_SITE} {SECOND_SITE}`
     Then STDERR should be:
       """
       Warning: Site {FIRST_SITE} already deactivated.
@@ -210,6 +216,7 @@ Feature: Manage sites in a multisite installation
       """
       Success: Site {SECOND_SITE} deactivated.
       """
+    And the return code should be 0
 
     When I run `wp site list --fields=blog_id,deleted`
     Then STDOUT should be a table containing rows:
@@ -227,11 +234,13 @@ Feature: Manage sites in a multisite installation
       | blog_id      | deleted |
       | {FIRST_SITE} | 0       |
 
-    When I run `wp site deactivate 1`
+    When I try `wp site deactivate 1`
     Then STDERR should be:
       """
       Warning: You are not allowed to change the main site.
       """
+    And STDOUT should be empty
+    And the return code should be 0
 
   Scenario: Mark/remove a site from spam
     Given a WP multisite install
@@ -251,7 +260,7 @@ Feature: Manage sites in a multisite installation
       | blog_id      | spam |
       | {FIRST_SITE} | 1    |
 
-    When I run `wp site spam {FIRST_SITE} {SECOND_SITE}`
+    When I try `wp site spam {FIRST_SITE} {SECOND_SITE}`
     Then STDERR should be:
       """
       Warning: Site {FIRST_SITE} already marked as spam.
@@ -260,6 +269,7 @@ Feature: Manage sites in a multisite installation
       """
       Success: Site {SECOND_SITE} marked as spam.
       """
+    And the return code should be 0
 
     When I run `wp site list --fields=blog_id,spam`
     Then STDOUT should be a table containing rows:
@@ -277,11 +287,13 @@ Feature: Manage sites in a multisite installation
       | blog_id      | spam |
       | {FIRST_SITE} | 0    |
 
-    When I run `wp site spam 1`
+    When I try `wp site spam 1`
     Then STDERR should be:
       """
       Warning: You are not allowed to change the main site.
       """
+    And STDOUT should be empty
+    And the return code should be 0
 
   Scenario: Mark/remove a site as mature
     Given a WP multisite install
@@ -301,7 +313,7 @@ Feature: Manage sites in a multisite installation
       | blog_id      | mature |
       | {FIRST_SITE} | 1    |
 
-    When I run `wp site mature {FIRST_SITE} {SECOND_SITE}`
+    When I try `wp site mature {FIRST_SITE} {SECOND_SITE}`
     Then STDERR should be:
       """
       Warning: Site {FIRST_SITE} already marked as mature.
@@ -310,6 +322,7 @@ Feature: Manage sites in a multisite installation
       """
       Success: Site {SECOND_SITE} marked as mature.
       """
+    And the return code should be 0
 
     When I run `wp site list --fields=blog_id,mature`
     Then STDOUT should be a table containing rows:
@@ -327,11 +340,13 @@ Feature: Manage sites in a multisite installation
       | blog_id      | mature |
       | {FIRST_SITE} | 0    |
 
-    When I run `wp site unmature 1`
+    When I try `wp site unmature 1`
     Then STDERR should be:
       """
       Warning: You are not allowed to change the main site.
       """
+    And STDOUT should be empty
+    And the return code should be 0
 
   Scenario: Set/Unset a site as public
     Given a WP multisite install
@@ -351,7 +366,7 @@ Feature: Manage sites in a multisite installation
       | blog_id      | public |
       | {FIRST_SITE} | 0    |
 
-    When I run `wp site private {FIRST_SITE} {SECOND_SITE}`
+    When I try `wp site private {FIRST_SITE} {SECOND_SITE}`
     Then STDERR should be:
       """
       Warning: Site {FIRST_SITE} already marked as private.
@@ -360,6 +375,7 @@ Feature: Manage sites in a multisite installation
       """
       Success: Site {SECOND_SITE} marked as private.
       """
+    And the return code should be 0
 
     When I run `wp site list --fields=blog_id,public`
     Then STDOUT should be a table containing rows:
@@ -377,11 +393,13 @@ Feature: Manage sites in a multisite installation
       | blog_id      | public |
       | {FIRST_SITE} | 1    |
 
-    When I run `wp site private 1`
+    When I try `wp site private 1`
     Then STDERR should be:
       """
       Warning: You are not allowed to change the main site.
       """
+    And STDOUT should be empty
+    And the return code should be 0
 
   Scenario: Permit CLI operations against archived and suspended sites
     Given a WP multisite install

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -3,9 +3,9 @@
 use Behat\Gherkin\Node\PyStringNode,
     Behat\Gherkin\Node\TableNode;
 
-$steps->Then( '/^the return code should be (\d+)$/',
-	function ( $world, $return_code ) {
-		if ( $return_code != $world->result->return_code ) {
+$steps->Then( '/^the return code should( not)? be (\d+)$/',
+	function ( $world, $not, $return_code ) {
+		if ( ( ! $not && $return_code != $world->result->return_code ) || ( $not && $return_code == $world->result->return_code ) ) {
 			throw new RuntimeException( $world->result );
 		}
 	}
@@ -153,7 +153,7 @@ $steps->Then( '/^(STDOUT|STDERR) should be a version string (<|<=|>|>=|==|=|!=|<
 			throw new Exception( $world->result );
 		}
 	}
-);	
+);
 
 $steps->Then( '/^the (.+) (file|directory) should (exist|not exist|be:|contain:|not contain:)$/',
 	function ( $world, $path, $type, $action, $expected = null ) {
@@ -197,6 +197,25 @@ $steps->Then( '/^the (.+) (file|directory) should (exist|not exist|be:|contain:|
 			}
 			checkString( $contents, $expected, $action );
 		}
+	}
+);
+
+$steps->Then( '/^the contents of the (.+) file should match (((\/.+\/)|(#.+#))([a-z]+)?)$/',
+	function ( $world, $path, $expected ) {
+		$path = $world->replace_variables( $path );
+		// If it's a relative path, make it relative to the current test dir
+		if ( '/' !== $path[0] ) {
+			$path = $world->variables['RUN_DIR'] . "/$path";
+		}
+		$contents = file_get_contents( $path );
+		assertRegExp( $expected, $contents );
+	}
+);
+
+$steps->Then( '/^(STDOUT|STDERR) should match (((\/.+\/)|(#.+#))([a-z]+)?)$/',
+	function ( $world, $stream, $expected ) {
+		$stream = strtolower( $stream );
+		assertRegExp( $expected, $world->result->$stream );
 	}
 );
 

--- a/features/steps/when.php
+++ b/features/steps/when.php
@@ -6,7 +6,7 @@ use Behat\Gherkin\Node\PyStringNode,
 
 function invoke_proc( $proc, $mode ) {
 	$map = array(
-		'run' => 'run_check',
+		'run' => 'run_check_stderr',
 		'try' => 'run'
 	);
 	$method = $map[ $mode ];

--- a/features/taxonomy.feature
+++ b/features/taxonomy.feature
@@ -22,6 +22,7 @@ Feature: Manage WordPress taxonomies
       """
       Error: Taxonomy invalid-taxonomy doesn't exist.
       """
+    And the return code should be 1
 
     When I run `wp taxonomy get category`
     Then STDOUT should be a table containing rows:

--- a/features/term-meta.feature
+++ b/features/term-meta.feature
@@ -18,6 +18,7 @@ Feature: Manage term custom fields
       """
       Error: Could not find the term with ID 999999.
       """
+    And the return code should be 1
 
     When I run `wp term meta set 1 foo '[ "1", "2" ]' --format=json`
     Then STDOUT should not be empty

--- a/features/term-recount.feature
+++ b/features/term-recount.feature
@@ -10,16 +10,17 @@ Feature: Recount terms on a taxonomy
       """
       Warning: Taxonomy some-fake-taxonomy does not exist.
       """
+    And the return code should be 0
 
   Scenario: Term recount with a valid taxonomy
-    When I try `wp term recount category`
+    When I run `wp term recount category`
     Then STDOUT should be:
       """
       Success: Updated category term count.
       """
 
   Scenario: Term recount with a multiple taxonomies
-    When I try `wp term recount category post_tag`
+    When I run `wp term recount category post_tag`
     Then STDOUT should be:
       """
       Success: Updated category term count.

--- a/features/term.feature
+++ b/features/term.feature
@@ -78,7 +78,7 @@ Feature: Manage WordPress terms
       """
     And the return code should be 0
 
-    When I run the previous command again
+    When I try the previous command again
     Then STDOUT should be:
       """
       Success: Term already deleted.
@@ -89,7 +89,7 @@ Feature: Manage WordPress terms
       """
     And the return code should be 0
 
-    When I run `wp term delete post_tag {TERM_ID} {TERM_ID_TWO}`
+    When I try `wp term delete post_tag {TERM_ID} {TERM_ID_TWO}`
     Then STDOUT should be:
       """
       Deleted post_tag {TERM_ID_TWO}.

--- a/features/term.feature
+++ b/features/term.feature
@@ -10,6 +10,7 @@ Feature: Manage WordPress terms
 
     When I try the previous command again
     Then STDERR should not be empty
+    And the return code should be 1
 
     When I run `wp term list post_tag --format=json`
     Then STDOUT should be JSON containing:
@@ -54,6 +55,7 @@ Feature: Manage WordPress terms
       """
       Error: Taxonomy nonexistent_taxonomy doesn't exist.
       """
+    And the return code should be 1
 
   Scenario: Creating/deleting a term
     When I run `wp term create post_tag 'Test delete term' --slug=test-delete --description='This is a test term to be deleted' --porcelain`
@@ -107,6 +109,7 @@ Feature: Manage WordPress terms
       """
       Error: Parent term does not exist.
       """
+    And the return code should be 1
 
   Scenario: Filter terms by term_id
     When I run `wp term generate category --count=10`

--- a/features/user-generate.feature
+++ b/features/user-generate.feature
@@ -18,7 +18,17 @@ Feature: Generate WP users
       """
 
     When I try `wp user list --field=ID | xargs wp user delete invalid-user --yes`
-    And I run `wp user list --format=count`
+    Then STDOUT should contain:
+      """
+      Success: Removed user
+      """
+    And STDERR should be:
+      """
+      Warning: Invalid user ID, email or login: 'invalid-user'
+      """
+    And the return code should be 0
+
+    When I run `wp user list --format=count`
     Then STDOUT should be:
       """
       0

--- a/features/user-import-csv.feature
+++ b/features/user-import-csv.feature
@@ -15,6 +15,7 @@ Feature: Import users from CSV
       """
       Error: Missing file: users-incorrect.csv
       """
+    And the return code should be 1
 
     When I run `wp user import-csv users.csv`
     Then STDOUT should not be empty
@@ -51,10 +52,11 @@ Feature: Import users from CSV
       """
 
     When I try `wp user import-csv user-invalid.csv`
-    Then STDERR should contain:
+    Then STDERR should be:
       """
-      lowercase letters (a-z) and numbers
+      Warning: Usernames can only contain lowercase letters (a-z) and numbers.
       """
+    And the return code should be 0
 
     When I run `wp user import-csv user-valid.csv`
     Then STDOUT should not be empty
@@ -151,6 +153,7 @@ Feature: Import users from CSV
       """
       Error: Unable to read content from STDIN.
       """
+    And the return code should be 1
 
     When I run `cat users.csv | wp user import-csv -`
     Then STDOUT should be:

--- a/features/user-import-csv.feature
+++ b/features/user-import-csv.feature
@@ -52,9 +52,10 @@ Feature: Import users from CSV
       """
 
     When I try `wp user import-csv user-invalid.csv`
-    Then STDERR should be:
+	# Message changed from "Only lowercase..." to "Usernames can contain only lowercase..." in `wpmu_validate_user_signup()` WP 4.4 https://core.trac.wordpress.org/ticket/33336
+    Then STDERR should contain:
       """
-      Warning: Usernames can only contain lowercase letters (a-z) and numbers.
+      lowercase letters (a-z) and numbers
       """
     And the return code should be 0
 

--- a/features/user-meta.feature
+++ b/features/user-meta.feature
@@ -17,6 +17,7 @@ Feature: Manage user custom fields
       """
       Error: Invalid user ID, email or login: '2'
       """
+    And the return code should be 1
 
     When I run `wp user-meta set admin foo '[ "1", "2" ]' --format=json`
     Then STDOUT should not be empty

--- a/features/user.feature
+++ b/features/user.feature
@@ -101,6 +101,7 @@ Feature: Manage WordPress users
 
     When I try `wp user get bobjones`
     Then STDERR should not be empty
+    And the return code should be 1
 
   Scenario: Create new users on multisite
     Given a WP multisite install
@@ -110,6 +111,7 @@ Feature: Manage WordPress users
       """
       lowercase letters (a-z) and numbers
       """
+    And the return code should be 1
 
     When I run `wp user create bobjones bobjones@example.com --display_name="Bob Jones"`
     Then STDOUT should not be empty
@@ -136,18 +138,21 @@ Feature: Manage WordPress users
       """
       Role doesn't exist
       """
+    And the return code should be 1
 
     When I try `wp user set-role 1 edit`
     Then STDERR should contain:
       """
       Role doesn't exist
       """
+    And the return code should be 1
 
     When I try `wp user remove-role 1 edit`
     Then STDERR should contain:
       """
       Role doesn't exist
       """
+    And the return code should be 1
 
     When I run `wp user set-role 1 author`
     Then STDOUT should not be empty
@@ -350,6 +355,7 @@ Feature: Manage WordPress users
       """
       Success: User already spammed.
       """
+    And the return code should be 0
 
     When I try `wp user spam {OP_ID} 9999`
     Then STDOUT should be:

--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -128,7 +128,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	 * ---
 	 *
 	 * [--post_id=<post-id>]
-	 * : Assign comments to a specific post.
+	 * : Assign comments to a specific post. Defaults to post_id 1.
 	 *
 	 * [--format=<format>]
 	 * : Render output in a particular format.
@@ -167,7 +167,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 		}
 
 		// Make sure comment_post_ID set for older WP versions else get undefined PHP notice.
-		$comment_post_ID = isset( $assoc_args['post_id'] ) ? $assoc_args['post_id'] : 0;
+		$comment_post_ID = isset( $assoc_args['post_id'] ) ? $assoc_args['post_id'] : 1;
 
 		$comment_count = wp_count_comments();
 		$total = (int )$comment_count->total_comments;

--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -69,6 +69,9 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 				if ( !$post ) {
 					return new WP_Error( 'no_post', "Can't find post $post_id." );
 				}
+			} else {
+				// Make sure it's set for older WP versions else get undefined PHP notice.
+				$params['comment_post_ID'] = 0;
 			}
 
 			// We use wp_insert_comment() instead of wp_new_comment() to stay at a low level and
@@ -163,7 +166,9 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 			$notify = \WP_CLI\Utils\make_progress_bar( 'Generating comments', $assoc_args['count'] );
 		}
 
-		$comment_post_ID = empty( $assoc_args['post_id'] ) ? 1 : $assoc_args['post_id'];
+		// Make sure comment_post_ID set for older WP versions else get undefined PHP notice.
+		$comment_post_ID = isset( $assoc_args['post_id'] ) ? $assoc_args['post_id'] : 0;
+
 		$comment_count = wp_count_comments();
 		$total = (int )$comment_count->total_comments;
 		$limit = $total + $assoc_args['count'];

--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -163,6 +163,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 			$notify = \WP_CLI\Utils\make_progress_bar( 'Generating comments', $assoc_args['count'] );
 		}
 
+		$comment_post_ID = empty( $assoc_args['post_id'] ) ? 1 : $assoc_args['post_id'];
 		$comment_count = wp_count_comments();
 		$total = (int )$comment_count->total_comments;
 		$limit = $total + $assoc_args['count'];
@@ -170,7 +171,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 		for ( $i = $total; $i < $limit; $i++ ) {
 			$comment_id = wp_insert_comment( array(
 				'comment_content'       => "Comment {$i}",
-				'comment_post_ID'       => $assoc_args['post_id'],
+				'comment_post_ID'       => $comment_post_ID,
 				) );
 			if ( 'progress' === $format ) {
 				$notify->tick();

--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -128,7 +128,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	 * ---
 	 *
 	 * [--post_id=<post-id>]
-	 * : Assign comments to a specific post. Defaults to post_id 1.
+	 * : Assign comments to a specific post.
 	 *
 	 * [--format=<format>]
 	 * : Render output in a particular format.
@@ -155,7 +155,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 
 		$defaults = array(
 			'count'    => 100,
-			'post_id'  => null,
+			'post_id'  => 0,
 		);
 		$assoc_args = array_merge( $defaults, $assoc_args );
 
@@ -166,9 +166,6 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 			$notify = \WP_CLI\Utils\make_progress_bar( 'Generating comments', $assoc_args['count'] );
 		}
 
-		// Make sure comment_post_ID set for older WP versions else get undefined PHP notice.
-		$comment_post_ID = isset( $assoc_args['post_id'] ) ? $assoc_args['post_id'] : 1;
-
 		$comment_count = wp_count_comments();
 		$total = (int )$comment_count->total_comments;
 		$limit = $total + $assoc_args['count'];
@@ -176,7 +173,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 		for ( $i = $total; $i < $limit; $i++ ) {
 			$comment_id = wp_insert_comment( array(
 				'comment_content'       => "Comment {$i}",
-				'comment_post_ID'       => $comment_post_ID,
+				'comment_post_ID'       => $assoc_args['post_id'],
 				) );
 			if ( 'progress' === $format ) {
 				$notify->tick();
@@ -438,7 +435,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	 */
 	private function check_server_name() {
 		if ( empty( $_SERVER['SERVER_NAME'] ) ) {
-			WP_CLI::warning( '`$_SERVER[\'SERVER_NAME\']` not set. Setting to \'example.com\'. Notification email sent to post author may appear to come from \'example.com\'.' );
+			WP_CLI::warning( 'Site url not set - defaulting to \'example.com\'. Any notification emails sent to post author may appear to come from \'example.com\'.' );
 			$_SERVER['SERVER_NAME'] = 'example.com';
 		}
 	}
@@ -478,6 +475,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	 *     Success: Untrashed comment 1337.
 	 */
 	public function untrash( $args, $assoc_args ) {
+		$this->check_server_name();
 		foreach( $args as $id ) {
 			$this->call( $id, __FUNCTION__, 'Untrashed', 'Failed untrashing' );
 		}
@@ -518,6 +516,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	 *     Success: Unspammed comment 1337.
 	 */
 	public function unspam( $args, $assoc_args ) {
+		$this->check_server_name();
 		foreach( $args as $id ) {
 			$this->call( $id, __FUNCTION__, 'Unspammed', 'Failed unspamming' );
 		}

--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -429,6 +429,16 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	}
 
 	/**
+	 * Warn if `$_SERVER['SERVER_NAME']` not set as used in email from-address sent to post author in `wp_notify_postauthor()`.
+	 */
+	private function check_server_name() {
+		if ( empty( $_SERVER['SERVER_NAME'] ) ) {
+			WP_CLI::warning( '`$_SERVER[\'SERVER_NAME\']` not set. Setting to \'example.com\'. Notification email sent to post author may appear to come from \'example.com\'.' );
+			$_SERVER['SERVER_NAME'] = 'example.com';
+		}
+	}
+
+	/**
 	 * Trash a comment.
 	 *
 	 * ## OPTIONS
@@ -523,6 +533,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	 *     Success: Approved comment 1337.
 	 */
 	public function approve( $args, $assoc_args ) {
+		$this->check_server_name();
 		foreach( $args as $id ) {
 			$this->set_status( $id, 'approve', "Approved" );
 		}
@@ -543,6 +554,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	 *     Success: Unapproved comment 1337.
 	 */
 	public function unapprove( $args, $assoc_args ) {
+		$this->check_server_name();
 		foreach( $args as $id ) {
 			$this->set_status( $id, 'hold', "Unapproved" );
 		}

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -195,10 +195,11 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 			);
 
 			$files_to_unlink = $directories_to_delete = array();
+			$is_main_site = is_main_site();
 			foreach ( $files as $fileinfo ) {
 				$realpath = $fileinfo->getRealPath();
 				// Don't clobber subsites when operating on the main site
-				if ( is_main_site() && false !== stripos( $realpath, '/sites/' ) ) {
+				if ( $is_main_site && false !== stripos( $realpath, '/sites/' ) ) {
 					continue;
 				}
 				if ( $fileinfo->isDir() ) {
@@ -211,9 +212,11 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 				unlink( $file );
 			}
 			foreach( $directories_to_delete as $directory ) {
-				rmdir( $directory );
+				// Directory could be main sites directory '/sites' which may be non-empty.
+				@rmdir( $directory ); // @codingStandardsIgnoreLine
 			}
-			rmdir( $upload_dir['basedir'] );
+			// May be non-empty if '/sites' still around.
+			@rmdir( $upload_dir['basedir'] ); // @codingStandardsIgnoreLine
 		}
 
 		WP_CLI::success( "The site at '" . site_url() . "' was emptied." );

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -1147,10 +1147,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 			$successes++;
 		}
 
-		if ( ! $this->chained_command ) {
-			Utils\report_batch_operation_results( 'user', $verb, count( $user_ids ), $successes, $errors );
-		}
-
+		Utils\report_batch_operation_results( 'user', $verb, count( $user_ids ), $successes, $errors );
 	}
 
 }

--- a/utils/behat-tags.php
+++ b/utils/behat-tags.php
@@ -44,8 +44,10 @@ $skip_tags = array_merge(
 	version_tags( 'less-than-php', PHP_VERSION, '>' )
 );
 
-# Skip Github API tests by default because of rate limiting. See https://github.com/wp-cli/wp-cli/issues/1612
-$skip_tags[] = '@github-api';
+# Skip Github API tests if `GITHUB_TOKEN` not available because of rate limiting. See https://github.com/wp-cli/wp-cli/issues/1612
+if ( ! getenv( 'GITHUB_TOKEN' ) ) {
+	$skip_tags[] = '@github-api';
+}
 
 # Skip tests known to be broken.
 $skip_tags[] = '@broken';


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/pull/4515

Fixes test breakages run -> try.

Makes sure `comment_post_ID` is non-null in `Comment_Command::generate()`.

Suppresses errors on `rmdir()` in `Site_command::_empty()` as the main sites directory `/sites` could still exist.

Adds options scenario for bad values of `--autoload`.