### PR TITLE
Define known fields as allowed arguments for `wp post (create|update)`

### DIFF
--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -567,17 +567,18 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 * ---
 	 * default: publish
 	 * ---
+	 * 
+	 * [--post_title=<post_title>]		
+	 * : The post title.		
+	 * ---		
+	 * default:		
+	 * ---	
 	 *
 	 * [--post_author=<login>]
 	 * : The author of the generated posts.
 	 * ---
 	 * default:
 	 * ---
-	 * [--post_title=<post_title>]		
-	 * : The post title.		
-	 * ---		
-	 * default:		
-	 * ---		
 	 *
 	 * [--post_date=<yyyy-mm-dd-hh-ii-ss>]
 	 * : The date of the generated posts. Default: current date

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -573,6 +573,11 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 * ---
 	 * default:
 	 * ---
+	 * [--post_title=<post_title>]		
+	 * : The post title.		
+	 * ---		
+	 * default:		
+	 * ---		
 	 *
 	 * [--post_date=<yyyy-mm-dd-hh-ii-ss>]
 	 * : The date of the generated posts. Default: current date

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -66,7 +66,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 * [--post_type=<post_type>]
 	 * : The post type. Default 'post'.
 	 * 
-	 * [-comment_status=<comment_status>]
+	 * [--comment_status=<comment_status>]
 	 * : Whether the post can accept comments. Accepts 'open' or 'closed'. Default is the value of 'default_comment_status' option.
 	 * 
 	 * [--ping_status=<ping_status>]
@@ -203,7 +203,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 * [--post_type=<post_type>]
 	 * : The post type. Default 'post'.
 	 * 
-	 * [-comment_status=<comment_status>]
+	 * [--comment_status=<comment_status>]
 	 * : Whether the post can accept comments. Accepts 'open' or 'closed'. Default is the value of 'default_comment_status' option.
 	 * 
 	 * [--ping_status=<ping_status>]

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -630,6 +630,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 			'post_author' => false,
 			'post_date' => current_time( 'mysql' ),
 			'post_content' => '',
+			'post_title' => '',
 		);
 		extract( array_merge( $defaults, $assoc_args ), EXTR_SKIP );
 
@@ -650,7 +651,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 		// Get the total number of posts.
 		$total = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_type = %s", $post_type ) );
 
-		$label = get_post_type_object( $post_type )->labels->singular_name;
+		$label = ! empty( $post_title ) ? $post_title : get_post_type_object( $post_type )->labels->singular_name;
 
 		$hierarchical = get_post_type_object( $post_type )->hierarchical;
 
@@ -686,11 +687,11 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 
 			$args = array(
 				'post_type' => $post_type,
-				'post_title' => "$label $i",
+				'post_title' => ! empty( $post_title ) && $i === $total ? "$label" : "$label $i",
 				'post_status' => $post_status,
 				'post_author' => $post_author,
 				'post_parent' => $current_parent,
-				'post_name' => "post-$i",
+				'post_name' => ! empty( $post_title  ) ? sanitize_title( $post_title . ( $i === $total ) ? '' : '-$i' ) : "post-$i",
 				'post_date' => $post_date,
 				'post_content' => $post_content,
 			);

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -133,6 +133,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 * [--porcelain]
 	 * : Output just the new post id.
 	 *
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Create post and schedule for future
@@ -567,12 +568,12 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 * ---
 	 * default: publish
 	 * ---
-	 * 
-	 * [--post_title=<post_title>]		
-	 * : The post title.		
-	 * ---		
-	 * default:		
-	 * ---	
+	 *
+	 * [--post_title=<post_title>]
+	 * : The post title.
+	 * ---
+	 * default:
+	 * ---
 	 *
 	 * [--post_author=<login>]
 	 * : The author of the generated posts.

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -38,7 +38,82 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 * Create a new post.
 	 *
 	 * ## OPTIONS
+	 * 
+	 * [--post_author=<post_author>]
+	 * : The ID of the user who added the post. Default is the current user ID.
+	 * 
+	 * [--post_date=<post_date>]
+	 * : The date of the post. Default is the current time.
+	 * 
+	 * [--post_date_gmt=<post_date_gmt>]
+	 * : The date of the post in the GMT timezone. Default is the value of $post_date.
 	 *
+	 * [--post_content=<post_content>]
+	 * : The post content. Default empty.
+	 * 
+	 * [--post_content_filtered=<post_content_filtered>]
+	 * : The filtered post content. Default empty.
+	 * 
+	 * [--post_title=<post_title>]
+	 * : The post title. Default empty.
+	 * 
+	 * [--post_excerpt=<post_excerpt>]
+	 * : The post excerpt. Default empty.
+	 * 
+	 * [--post_status=<post_status>]
+	 * : The post status. Default 'draft'.
+	 * 
+	 * [--post_type=<post_type>]
+	 * : The post type. Default 'post'.
+	 * 
+	 * [-comment_status=<comment_status>]
+	 * : Whether the post can accept comments. Accepts 'open' or 'closed'. Default is the value of 'default_comment_status' option.
+	 * 
+	 * [--ping_status=<ping_status>]
+	 * : Whether the post can accept pings. Accepts 'open' or 'closed'. Default is the value of 'default_ping_status' option.
+	 * 
+	 * [--post_password=<post_password>]
+	 * : The password to access the post. Default empty.
+	 * 
+	 * [--post_name=<post_name>]
+	 * : The post name. Default is the sanitized post title when creating a new post.
+	 * 
+	 * [--to_ping=<to_ping>]
+	 * : Space or carriage return-separated list of URLs to ping. Default empty.
+	 * 
+	 * [--pinged=<pinged>]
+	 * : Space or carriage return-separated list of URLs that have been pinged. Default empty.
+	 * 
+	 * [--post_modified=<post_modified>]
+	 * : The date when the post was last modified. Default is the current time.
+	 * 
+	 * [--post_modified_gmt=<post_modified_gmt>]
+	 * : The date when the post was last modified in the GMT timezone. Default is the current time.
+	 * 
+	 * [--post_parent=<post_parent>]
+	 * : Set this for the post it belongs to, if any. Default 0.
+	 * 
+	 * [--menu_order=<menu_order>]
+	 * : The order the post should be displayed in. Default 0.
+	 * 
+	 * [--post_mime_type=<post_mime_type>]
+	 * : The mime type of the post. Default empty.
+	 * 
+	 * [--guid=<guid>]
+	 * : Global Unique ID for referencing the post. Default empty.
+	 * 
+	 * [--post_category=<post_category>]
+	 * : Array of category names, slugs, or IDs. Defaults to value of the 'default_category' option.
+	 * 
+	 * [--tags_input=<tags_input>]
+	 * : Array of tag names, slugs, or IDs. Default empty.
+	 * 
+	 * [--tax_input=<tax_input>]
+	 * : Array of taxonomy terms keyed by their taxonomy name. Default empty.
+	 * 
+	 * [--meta_input=<meta_input>]
+	 * : Array of post meta values keyed by their post meta key. Default empty.
+	 * 
 	 * [<file>]
 	 * : Read post content from <file>. If this value is present, the
 	 *     `--post_content` argument will be ignored.
@@ -99,6 +174,81 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 *
 	 * <id>...
 	 * : One or more IDs of posts to update.
+	 * 
+	 * [--post_author=<post_author>]
+	 * : The ID of the user who added the post. Default is the current user ID.
+	 * 
+	 * [--post_date=<post_date>]
+	 * : The date of the post. Default is the current time.
+	 * 
+	 * [--post_date_gmt=<post_date_gmt>]
+	 * : The date of the post in the GMT timezone. Default is the value of $post_date.
+	 *
+	 * [--post_content=<post_content>]
+	 * : The post content. Default empty.
+	 * 
+	 * [--post_content_filtered=<post_content_filtered>]
+	 * : The filtered post content. Default empty.
+	 * 
+	 * [--post_title=<post_title>]
+	 * : The post title. Default empty.
+	 * 
+	 * [--post_excerpt=<post_excerpt>]
+	 * : The post excerpt. Default empty.
+	 * 
+	 * [--post_status=<post_status>]
+	 * : The post status. Default 'draft'.
+	 * 
+	 * [--post_type=<post_type>]
+	 * : The post type. Default 'post'.
+	 * 
+	 * [-comment_status=<comment_status>]
+	 * : Whether the post can accept comments. Accepts 'open' or 'closed'. Default is the value of 'default_comment_status' option.
+	 * 
+	 * [--ping_status=<ping_status>]
+	 * : Whether the post can accept pings. Accepts 'open' or 'closed'. Default is the value of 'default_ping_status' option.
+	 * 
+	 * [--post_password=<post_password>]
+	 * : The password to access the post. Default empty.
+	 * 
+	 * [--post_name=<post_name>]
+	 * : The post name. Default is the sanitized post title when creating a new post.
+	 * 
+	 * [--to_ping=<to_ping>]
+	 * : Space or carriage return-separated list of URLs to ping. Default empty.
+	 * 
+	 * [--pinged=<pinged>]
+	 * : Space or carriage return-separated list of URLs that have been pinged. Default empty.
+	 * 
+	 * [--post_modified=<post_modified>]
+	 * : The date when the post was last modified. Default is the current time.
+	 * 
+	 * [--post_modified_gmt=<post_modified_gmt>]
+	 * : The date when the post was last modified in the GMT timezone. Default is the current time.
+	 * 
+	 * [--post_parent=<post_parent>]
+	 * : Set this for the post it belongs to, if any. Default 0.
+	 * 
+	 * [--menu_order=<menu_order>]
+	 * : The order the post should be displayed in. Default 0.
+	 * 
+	 * [--post_mime_type=<post_mime_type>]
+	 * : The mime type of the post. Default empty.
+	 * 
+	 * [--guid=<guid>]
+	 * : Global Unique ID for referencing the post. Default empty.
+	 * 
+	 * [--post_category=<post_category>]
+	 * : Array of category names, slugs, or IDs. Defaults to value of the 'default_category' option.
+	 * 
+	 * [--tags_input=<tags_input>]
+	 * : Array of tag names, slugs, or IDs. Default empty.
+	 * 
+	 * [--tax_input=<tax_input>]
+	 * : Array of taxonomy terms keyed by their taxonomy name. Default empty.
+	 * 
+	 * [--meta_input=<meta_input>]
+	 * : Array of post meta values keyed by their post meta key. Default empty.
 	 *
 	 * [<file>]
 	 * : Read post content from <file>. If this value is present, the
@@ -418,12 +568,6 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 * default: publish
 	 * ---
 	 *
-	 * [--post_title=<post_title>]
-	 * : The post title.
-	 * ---
-	 * default:
-	 * ---
-	 *
 	 * [--post_author=<login>]
 	 * : The author of the generated posts.
 	 * ---
@@ -481,7 +625,6 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 			'post_author' => false,
 			'post_date' => current_time( 'mysql' ),
 			'post_content' => '',
-			'post_title' => '',
 		);
 		extract( array_merge( $defaults, $assoc_args ), EXTR_SKIP );
 
@@ -502,7 +645,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 		// Get the total number of posts.
 		$total = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_type = %s", $post_type ) );
 
-		$label = ! empty( $post_title ) ? $post_title : get_post_type_object( $post_type )->labels->singular_name;
+		$label = get_post_type_object( $post_type )->labels->singular_name;
 
 		$hierarchical = get_post_type_object( $post_type )->hierarchical;
 
@@ -538,11 +681,11 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 
 			$args = array(
 				'post_type' => $post_type,
-				'post_title' => ! empty( $post_title ) && $i === $total ? "$label" : "$label $i",
+				'post_title' => "$label $i",
 				'post_status' => $post_status,
 				'post_author' => $post_author,
 				'post_parent' => $current_parent,
-				'post_name' => ! empty( $post_title  ) ? sanitize_title( $post_title . ( $i === $total ) ? '' : '-$i' ) : "post-$i",
+				'post_name' => "post-$i",
 				'post_date' => $post_date,
 				'post_content' => $post_content,
 			);


### PR DESCRIPTION
* Added available parameters for `create` function
* Added available parameters for `update` function

Parameters and descriptions from: https://developer.wordpress.org/reference/functions/wp_insert_post/

Fixes #44 