### PR TITLE
Replace use of "install" with "installation"

### DIFF
--- a/entity-command.php
+++ b/entity-command.php
@@ -30,7 +30,7 @@ WP_CLI::add_command( 'site', 'Site_Command' );
 WP_CLI::add_command( 'site option', 'Site_Option_Command', array(
 	'before_invoke' => function() {
 		if ( !is_multisite() ) {
-			WP_CLI::error( 'This is not a multisite install.' );
+			WP_CLI::error( 'This is not a multisite installation.' );
 		}
 	}
 ) );

--- a/features/site-empty.feature
+++ b/features/site-empty.feature
@@ -1,7 +1,7 @@
 Feature: Empty a WordPress site of its data
 
   Scenario: Empty a site
-    Given a WP install
+    Given a WP installation
     And I run `wp option update uploads_use_yearmonth_folders 0`
     And download:
       | path                        | url                                              |
@@ -43,7 +43,7 @@ Feature: Empty a WordPress site of its data
     Then STDOUT should be empty
 
   Scenario: Empty a site and its uploads directory
-    Given a WP multisite install
+    Given a WP multisite installation
     And I run `wp site create --slug=foo`
     And I run `wp --url=example.com/foo option update uploads_use_yearmonth_folders 0`
     And download:

--- a/features/site-empty.feature
+++ b/features/site-empty.feature
@@ -13,7 +13,7 @@ Feature: Empty a WordPress site of its data
     When I try `wp site url 1`
     Then STDERR should be:
       """
-      Error: This is not a multisite install.
+      Error: This is not a multisite installation.
       """
     And the return code should be 1
 

--- a/features/site-option.feature
+++ b/features/site-option.feature
@@ -110,8 +110,8 @@ Feature: Manage WordPress site options
       }
       """
 
-  Scenario: Error on single installation
-    Given a WP installation
+  Scenario: Error on single install
+    Given a WP install
 
     When I try `wp site option get str_opt`
     Then STDERR should be:
@@ -128,7 +128,7 @@ Feature: Manage WordPress site options
     And the return code should be 1
 
   Scenario: Filter options by `--site_id`
-    Given a WP multisite installation
+    Given a WP multisite install
 
     When I run `wp db query "INSERT INTO wp_sitemeta (site_id,meta_key,meta_value) VALUES (2,'wp_cli_test_option','foobar');"`
     Then the return code should be 0

--- a/features/site-option.feature
+++ b/features/site-option.feature
@@ -110,8 +110,8 @@ Feature: Manage WordPress site options
       }
       """
 
-  Scenario: Error on single install
-    Given a WP install
+  Scenario: Error on single installation
+    Given a WP installation
 
     When I try `wp site option get str_opt`
     Then STDERR should be:
@@ -128,7 +128,7 @@ Feature: Manage WordPress site options
     And the return code should be 1
 
   Scenario: Filter options by `--site_id`
-    Given a WP multisite install
+    Given a WP multisite installation
 
     When I run `wp db query "INSERT INTO wp_sitemeta (site_id,meta_key,meta_value) VALUES (2,'wp_cli_test_option','foobar');"`
     Then the return code should be 0

--- a/features/site-option.feature
+++ b/features/site-option.feature
@@ -116,14 +116,14 @@ Feature: Manage WordPress site options
     When I try `wp site option get str_opt`
     Then STDERR should be:
       """
-      Error: This is not a multisite install.
+      Error: This is not a multisite installation.
       """
     And the return code should be 1
 
     When I try `wp site option add str_opt 'bar'`
     Then STDERR should be:
       """
-      Error: This is not a multisite install.
+      Error: This is not a multisite installation.
       """
     And the return code should be 1
 

--- a/features/site-option.feature
+++ b/features/site-option.feature
@@ -1,7 +1,7 @@
 Feature: Manage WordPress site options
 
   Scenario: Site Option CRUD
-    Given a WP multisite install
+    Given a WP multisite installation
 
     # String values
     When I run `wp site option add str_opt 'bar'`
@@ -111,7 +111,7 @@ Feature: Manage WordPress site options
       """
 
   Scenario: Error on single install
-    Given a WP install
+    Given a WP installation
 
     When I try `wp site option get str_opt`
     Then STDERR should be:
@@ -128,7 +128,7 @@ Feature: Manage WordPress site options
     And the return code should be 1
 
   Scenario: Filter options by `--site_id`
-    Given a WP multisite install
+    Given a WP multisite installation
 
     When I run `wp db query "INSERT INTO wp_sitemeta (site_id,meta_key,meta_value) VALUES (2,'wp_cli_test_option','foobar');"`
     Then the return code should be 0

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Creates, deletes, empties, moderates, and lists one or more sites on a multisite install.
+ * Creates, deletes, empties, moderates, and lists one or more sites on a multisite installation.
  *
  * ## EXAMPLES
  *
@@ -223,7 +223,7 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 	}
 
 	/**
-	 * Deletes a site in a multisite install.
+	 * Deletes a site in a multisite installation.
 	 *
 	 * ## OPTIONS
 	 *
@@ -247,7 +247,7 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 	 */
 	function delete( $args, $assoc_args ) {
 		if ( !is_multisite() ) {
-			WP_CLI::error( 'This is not a multisite install.' );
+			WP_CLI::error( 'This is not a multisite installation.' );
 		}
 
 		if ( isset( $assoc_args['slug'] ) ) {
@@ -280,7 +280,7 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 	}
 
 	/**
-	 * Creates a site in a multisite install.
+	 * Creates a site in a multisite installation.
 	 *
 	 * ## OPTIONS
 	 *
@@ -309,7 +309,7 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 	 */
 	public function create( $_, $assoc_args ) {
 		if ( !is_multisite() ) {
-			WP_CLI::error( 'This is not a multisite install.' );
+			WP_CLI::error( 'This is not a multisite installation.' );
 		}
 
 		global $wpdb, $current_site;
@@ -431,7 +431,7 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 	}
 
 	/**
-	 * Lists all sites in a multisite install.
+	 * Lists all sites in a multisite installation.
 	 *
 	 * ## OPTIONS
 	 *
@@ -496,7 +496,7 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 	 */
 	public function list_( $_, $assoc_args ) {
 		if ( !is_multisite() ) {
-			WP_CLI::error( 'This is not a multisite install.' );
+			WP_CLI::error( 'This is not a multisite installation.' );
 		}
 
 		global $wpdb;


### PR DESCRIPTION
here is the link to the [issue](https://github.com/wp-cli/wp-cli/issues/4541)
Replaced use of "install" with "installation" in `src/Site_Command.php`
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
