### PR TITLE
Return error if cap doesn't exist or is role cap on remove cap.

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -196,6 +196,38 @@ Feature: Manage WordPress users
       Success: Removed 'edit_vip_product' cap for admin (1).
       """
 
+    And I try the previous command again
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: No such 'edit_vip_product' cap for admin (1).
+      """
+    And STDOUT should be empty
+
+    When I run `wp user list-caps 1`
+    Then STDOUT should not contain:
+      """
+      edit_vip_product
+      """
+    And STDOUT should contain:
+      """
+      publish_posts
+      """
+
+    When I try `wp user remove-cap 1 publish_posts`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: The 'publish_posts' cap for admin (1) is inherited from a role.
+      """
+    And STDOUT should be empty
+
+    And I run `wp user list-caps 1`
+    Then STDOUT should contain:
+      """
+      publish_posts
+      """
+
   Scenario: Show password when creating a user
     Given a WP install
 

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -747,12 +747,24 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 	 *     $ wp user remove-cap 11 publish_newsletters
 	 *     Success: Removed 'publish_newsletters' cap for supervisor (11).
 	 *
+	 *     $ wp user remove-cap 11 publish_posts
+	 *     Error: The 'publish_posts' cap for supervisor (11) is inherited from a role.
+	 *
+	 *     $ wp user remove-cap 11 nonexistent_cap
+	 *     Error: No such 'nonexistent_cap' cap for supervisor (11).
+	 *
 	 * @subcommand remove-cap
 	 */
 	public function remove_cap( $args, $assoc_args ) {
 		$user = $this->fetcher->get_check( $args[0] );
 		if ( $user ) {
 			$cap = $args[1];
+			if ( ! isset( $user->caps[ $cap ] ) ) {
+				if ( isset( $user->allcaps[ $cap ] ) ) {
+					WP_CLI::error( sprintf( "The '%s' cap for %s (%d) is inherited from a role.", $cap, $user->user_login, $user->ID ) );
+				}
+				WP_CLI::error( sprintf( "No such '%s' cap for %s (%d).", $cap, $user->user_login, $user->ID ) );
+			}
 			$user->remove_cap( $cap );
 
 			WP_CLI::success( sprintf( "Removed '%s' cap for %s (%d).", $cap, $user->user_login, $user->ID ) );


### PR DESCRIPTION
Closes #97

Changes to return an error if the cap doesn't exist or is inherited from a role on `remove cap`.