### PR TITLE
Warn if use meta_input and WP < 4.4.

### DIFF
--- a/features/post.feature
+++ b/features/post.feature
@@ -370,3 +370,37 @@ Feature: Manage WordPress posts
       | {POST_ID} | key1     | value1     |
       | {POST_ID} | key2     | value2b    |
       | {POST_ID} | key3     | value3     |
+
+  @less-than-wp-4.4
+  Scenario: Creating/updating posts with meta keys for WP < 4.4 has no effect so should give warning
+    When I try `wp post create --post_title='Test Post' --post_content='Test post content' --meta_input='{"key1":"value1","key2":"value2"}' --porcelain`
+    Then the return code should be 0
+    And STDOUT should be a number
+    And save STDOUT as {POST_ID}
+    And STDERR should be:
+      """
+      Warning: The 'meta_input' field was only introduced in WordPress 4.4 so will have no effect.
+      """
+
+    When I run `wp post meta list {POST_ID} --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I try `wp post update {POST_ID} --meta_input='{"key2":"value2b","key3":"value3"}'`
+    Then the return code should be 0
+    And STDERR should be:
+      """
+      Warning: The 'meta_input' field was only introduced in WordPress 4.4 so will have no effect.
+      """
+    And STDOUT should be:
+      """
+      Success: Updated post {POST_ID}.
+      """
+
+    When I run `wp post meta list {POST_ID} --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -166,6 +166,10 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 			$assoc_args['post_category'] = $this->get_category_ids( $assoc_args['post_category'] );
 		}
 
+		if ( isset( $assoc_args['meta_input'] ) && \WP_CLI\Utils\wp_version_compare( '4.4', '<' ) ) {
+			WP_CLI::warning( "The 'meta_input' field was only introduced in WordPress 4.4 so will have no effect." );
+		}
+
 		$array_arguments = array( 'meta_input' );
 		$assoc_args      = \WP_CLI\Utils\parse_shell_arrays( $assoc_args, $array_arguments );
 
@@ -294,6 +298,10 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 
 		if ( isset( $assoc_args['post_category'] ) ) {
 			$assoc_args['post_category'] = $this->get_category_ids( $assoc_args['post_category'] );
+		}
+
+		if ( isset( $assoc_args['meta_input'] ) && \WP_CLI\Utils\wp_version_compare( '4.4', '<' ) ) {
+			WP_CLI::warning( "The 'meta_input' field was only introduced in WordPress 4.4 so will have no effect." );
 		}
 
 		$array_arguments = array( 'meta_input' );


### PR DESCRIPTION
Closes #134 

Warns when using meta_input on `post create` and `post update` if WP < 4.4.