### PR TITLE
Fix bug when checking for default option value.

### DIFF
--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -73,7 +73,7 @@ class Option_Command extends WP_CLI_Command {
 	public function get( $args, $assoc_args ) {
 		list( $key ) = $args;
 
-		$value = get_option( $key );
+		$value = get_option( $key, false );
 
 		if ( false === $value ) {
 			WP_CLI::error( "Could not get '$key' option. Does it exist?" );
@@ -466,7 +466,7 @@ class Option_Command extends WP_CLI_Command {
 	public function pluck( $args, $assoc_args ) {
 		list( $key ) = $args;
 
-		$value = get_option( $key );
+		$value = get_option( $key, false );
 
 		if ( false === $value ) {
 			WP_CLI::halt( 1 );


### PR DESCRIPTION
Since WordPress 4.7.0, WordPress has had an advanced `register_setting()` function that among other improvements allows to specify a default value. This value will then automatically returned by unsuccessful `get_option()` calls when no actual `$default` parameter was provided (checked via `func_num_args()`).

Because of this change, the feedback can easily go wrong at the moment, since the command only checks for `false`, while the default value could also be something entirely different. By actually passing `false` as the default, it is ensured that the default value detection triggers correctly.