### PR TITLE
Properly clone objects for comparison

### DIFF
--- a/features/option-pluck-patch.feature
+++ b/features/option-pluck-patch.feature
@@ -269,3 +269,33 @@ Feature: Option commands have pluck and patch.
       """
       [ "new", "bar" ]
       """
+
+  @patch @pluck
+  Scenario: An object value can be updated
+    Given a WP install
+    And a setup.php file:
+      """
+      <?php
+      $option = new stdClass;
+      $option->test_mode = 0;
+      $ret = update_option( 'wp_cli_test', $option );
+      """
+    And I run `wp eval-file setup.php`
+
+    When I run `wp option pluck wp_cli_test test_mode`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `wp option patch update wp_cli_test test_mode 1`
+    Then STDOUT should be:
+      """
+      Success: Updated 'wp_cli_test' option.
+      """
+
+    When I run `wp option pluck wp_cli_test test_mode`
+    Then STDOUT should be:
+      """
+      1
+      """

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -543,6 +543,9 @@ class Option_Command extends WP_CLI_Command {
 
 		/* Need to make a copy of $current_value here as it is modified by reference */
 		$old_value = $current_value = sanitize_option( $key, get_option( $key ) );
+		if ( is_object( $current_value ) ) {
+			$old_value = clone $current_value;
+		}
 
 		$traverser = new RecursiveDataStructureTraverser( $current_value );
 

--- a/src/Site_Option_Command.php
+++ b/src/Site_Option_Command.php
@@ -372,6 +372,9 @@ class Site_Option_Command extends WP_CLI_Command {
 
 		/* Need to make a copy of $current_value here as it is modified by reference */
 		$old_value = $current_value = sanitize_option( $key, get_site_option( $key ) );
+		if ( is_object( $current_value ) ) {
+			$old_value = clone $current_value;
+		}
 
 		$traverser = new RecursiveDataStructureTraverser( $current_value );
 

--- a/src/WP_CLI/CommandWithMeta.php
+++ b/src/WP_CLI/CommandWithMeta.php
@@ -390,6 +390,9 @@ abstract class CommandWithMeta extends \WP_CLI_Command {
 
 		/* Need to make a copy of $current_meta_value here as it is modified by reference */
 		$current_meta_value = $old_meta_value = sanitize_meta( $meta_key, get_metadata( $this->meta_type, $object_id, $meta_key, true ), $this->meta_type );
+		if ( is_object( $current_meta_value ) ) {
+			$old_meta_value = clone $current_meta_value;
+		}
 
 		$traverser = new RecursiveDataStructureTraverser( $current_meta_value );
 

--- a/tests/RecursiveDataStructureTraverserTest.php
+++ b/tests/RecursiveDataStructureTraverserTest.php
@@ -87,6 +87,19 @@ class RecursiveDataStructureTraverserTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/** @test */
+	function it_can_update_an_integer_object_value() {
+		$object = (object) array(
+			'test_mode' => 0,
+		);
+		$this->assertEquals( 0, $object->test_mode );
+
+		$traverser = new RecursiveDataStructureTraverser( $object );
+		$traverser->update( array( 'test_mode' ), 1 );
+
+		$this->assertEquals( 1, $object->test_mode );
+	}
+
+	/** @test */
 	function it_can_delete_a_nested_array_value() {
 		$array = array(
 			'foo' => array(


### PR DESCRIPTION
Otherwise, they're handled by reference and transformed on update

Fixes #151