### PR TITLE
Optional --skip-email flag for 'wp user update'

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -422,3 +422,41 @@ Feature: Manage WordPress users
       Error: Only spammed 1 of 2 users.
       """
     And the return code should be 1
+
+  @require-wp-4.3
+  Scenario: Sending emails on update
+    Given a WP install
+
+    When I run `wp user get 1 --field=user_email`
+    Then save STDOUT as {ORIGINAL_EMAIL}
+
+    When I run `wp user update 1 --user_email=different.mail@example.com`
+    Then STDOUT should contain:
+      """
+      Success: Updated user 1.
+      """
+    And an email should be sent
+
+    When I run `wp user update 1 --user_email={ORIGINAL_EMAIL} --skip-email`
+    Then STDOUT should contain:
+      """
+      Success: Updated user 1.
+      """
+    And an email should not be sent
+
+    When I run `wp user get 1 --field=user_pass`
+    Then save STDOUT as {ORIGINAL_PASSWORD}
+
+    When I run `wp user update 1 --user_pass=different_password`
+    Then STDOUT should contain:
+      """
+      Success: Updated user 1.
+      """
+    And an email should be sent
+
+    When I run `wp user update 1 --user_pass={ORIGINAL_PASSWORD} --skip-email`
+    Then STDOUT should contain:
+      """
+      Success: Updated user 1.
+      """
+    And an email should not be sent

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -501,13 +501,19 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 			$user_ids[] = $user->ID;
 		}
 
-		if ( Utils\get_flag_value( $assoc_args, 'skip-email' ) ) {
+		$skip_email = Utils\get_flag_value( $assoc_args, 'skip-email' );
+		if ( $skip_email ) {
 			add_filter( 'send_email_change_email', '__return_false' );
 			add_filter( 'send_password_change_email', '__return_false' );
 		}
 
 		$assoc_args = wp_slash( $assoc_args );
 		parent::_update( $user_ids, $assoc_args, 'wp_update_user' );
+
+		if ( $skip_email ) {
+			remove_filter( 'send_email_change_email', '__return_false' );
+			remove_filter( 'send_password_change_email', '__return_false' );
+		}
 	}
 
 	/**

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -501,7 +501,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 			$user_ids[] = $user->ID;
 		}
 
-		if ( isset( $assoc_args['skip-email'] ) ) {
+		if ( Utils\get_flag_value( $assoc_args, 'skip-email' ) ) {
 			add_filter( 'send_email_change_email', '__return_false' );
 			add_filter( 'send_password_change_email', '__return_false' );
 		}

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -481,6 +481,9 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 	 * --<field>=<value>
 	 * : One or more fields to update. For accepted fields, see wp_update_user().
 	 *
+	 * [--skip-email]
+	 * : Don't send an email notification to the user.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Update user
@@ -496,6 +499,11 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 		$user_ids = array();
 		foreach ( $this->fetcher->get_many( $args ) as $user ) {
 			$user_ids[] = $user->ID;
+		}
+
+		if ( isset( $assoc_args['skip-email'] ) ) {
+			add_filter( 'send_email_change_email', '__return_false' );
+			add_filter( 'send_password_change_email', '__return_false' );
 		}
 
 		$assoc_args = wp_slash( $assoc_args );


### PR DESCRIPTION
Sometimes (e.g. in our use case) it might be handy to update the user's details without bothering him with an email.

I would write some tests but I'm not really sure how to test it. I was looking for tests of `wp core install --skip-email` and they are missing as well. 

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
