### PR TITLE
Add --unserialize flag to 'option list' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1719,6 +1719,9 @@ wp option list [--search=<pattern>] [--exclude=<pattern>] [--autoload=<value>] [
 	[--transients]
 		List only transients. Use `--no-transients` to ignore all transients.
 
+	[--unserialize]
+		Unserialize option values in output.
+
 	[--field=<field>]
 		Prints the value of a single field.
 

--- a/features/option-list.feature
+++ b/features/option-list.feature
@@ -139,7 +139,7 @@ Feature: List WordPress options
     Given a WP install
 
     When I run `wp option add --format=json sample_test_field_one '{"value": 1}'`
-    And I run `wp option list --search="sample_test_field_*" --format=yaml`
+    And I run `wp option list --search="sample_test_field_*" --format=yaml --unserialize`
     Then STDOUT should be:
       """
       ---

--- a/features/option-list.feature
+++ b/features/option-list.feature
@@ -135,3 +135,16 @@ Feature: List WordPress options
       siteurl
       """
 
+  Scenario: Using the `--unserialize` flag
+    Given a WP install
+
+    When I run `wp option add --format=json sample_test_field_one '{"value": 1}'`
+    And I run `wp option list --search="sample_test_field_*" --format=yaml`
+    Then STDOUT should be:
+      """
+      ---
+      -
+        option_name: sample_test_field_one
+        option_value:
+          value: 1
+      """

--- a/features/option-list.feature
+++ b/features/option-list.feature
@@ -143,7 +143,7 @@ Feature: List WordPress options
     Then STDOUT should be:
       """
       ---
-      -
+      - 
         option_name: sample_test_field_one
         option_value:
           value: 1

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -154,6 +154,9 @@ class Option_Command extends WP_CLI_Command {
 	 * [--transients]
 	 * : List only transients. Use `--no-transients` to ignore all transients.
 	 *
+	 * [--unserialize]
+	 * : Unserialize option values in output.
+	 *
 	 * [--field=<field>]
 	 * : Prints the value of a single field.
 	 *
@@ -315,6 +318,12 @@ class Option_Command extends WP_CLI_Command {
 			});
 		} elseif ( 'option_id' === $orderby && 'desc' === $order ) { // Sort by default descending.
 			krsort( $results );
+		}
+
+		if ( true === Utils\get_flag_value( $assoc_args, 'unserialize', null ) ) {
+			foreach ($results as $k => &$v) {
+				if ( !empty($v->option_value) ) $v->option_value = maybe_unserialize($v->option_value);
+			}
 		}
 
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' ) === 'total_bytes' ) {

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -321,8 +321,10 @@ class Option_Command extends WP_CLI_Command {
 		}
 
 		if ( true === Utils\get_flag_value( $assoc_args, 'unserialize', null ) ) {
-			foreach ($results as $k => &$v) {
-				if ( !empty($v->option_value) ) $v->option_value = maybe_unserialize($v->option_value);
+			foreach ( $results as $k => &$v ) {
+				if ( ! empty( $v->option_value ) ) {
+					$v->option_value = maybe_unserialize( $v->option_value );
+				}
 			}
 		}
 


### PR DESCRIPTION
While `option get` unserializes values, `option list` does not, making the value data less useful.  This PR adds an `--unserialize` flag that unserializes the values, making the outputs more useful for e.g. diffing complex object values.
