### PR TITLE
Add wp site meta sub-command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
       echo "xdebug.ini does not exist"
     fi
   - |
-    # Raise PHP memory limit to 2048MB.
+    # Raise PHP memory limit to 2048MB
     echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 install:

--- a/README.md
+++ b/README.md
@@ -4380,7 +4380,7 @@ wp user add-role <user> <role>
 Creates a new user.
 
 ~~~
-wp user create <user-login> <user-email> [--role=<role>] [--user_pass=<password>] [--user_registered=<yyyy-mm-dd-hh-ii-ss>] [--display_name=<name>] [--user_nicename=<nice_name>] [--user_url=<url>] [--user_email=<email>] [--nickname=<nickname>] [--first_name=<first_name>] [--last_name=<last_name>] [--description=<description>] [--rich_editing=<rich_editing>] [--send-email] [--porcelain]
+wp user create <user-login> <user-email> [--role=<role>] [--user_pass=<password>] [--user_registered=<yyyy-mm-dd-hh-ii-ss>] [--display_name=<name>] [--user_nicename=<nice_name>] [--user_url=<url>] [--nickname=<nickname>] [--first_name=<first_name>] [--last_name=<last_name>] [--description=<description>] [--rich_editing=<rich_editing>] [--send-email] [--porcelain]
 ~~~
 
 **OPTIONS**
@@ -4409,9 +4409,6 @@ wp user create <user-login> <user-email> [--role=<role>] [--user_pass=<password>
 
 	[--user_url=<url>]
 		A string containing the user's URL for the user's web site.
-
-	[--user_email=<email>]
-		A string containing the user's email address.
 
 	[--nickname=<nickname>]
 		The user's nickname, defaults to the user's username.

--- a/README.md
+++ b/README.md
@@ -1997,7 +1997,7 @@ wp post
 Creates a new post.
 
 ~~~
-wp post create [--post_author=<post_author>] [--post_date=<post_date>] [--post_date_gmt=<post_date_gmt>] [--post_content=<post_content>] [--post_content_filtered=<post_content_filtered>] [--post_title=<post_title>] [--post_excerpt=<post_excerpt>] [--post_status=<post_status>] [--post_type=<post_type>] [--comment_status=<comment_status>] [--ping_status=<ping_status>] [--post_password=<post_password>] [--post_name=<post_name>] [--to_ping=<to_ping>] [--pinged=<pinged>] [--post_modified=<post_modified>] [--post_modified_gmt=<post_modified_gmt>] [--post_parent=<post_parent>] [--menu_order=<menu_order>] [--post_mime_type=<post_mime_type>] [--guid=<guid>] [--post_category=<post_category>] [--tags_input=<tags_input>] [--tax_input=<tax_input>] [--meta_input=<meta_input>] [<file>] [--<field>=<value>] [--edit] [--porcelain]
+wp post create [--post_author=<post_author>] [--post_date=<post_date>] [--post_date_gmt=<post_date_gmt>] [--post_content=<post_content>] [--post_content_filtered=<post_content_filtered>] [--post_title=<post_title>] [--post_excerpt=<post_excerpt>] [--post_status=<post_status>] [--post_type=<post_type>] [--comment_status=<comment_status>] [--ping_status=<ping_status>] [--post_password=<post_password>] [--post_name=<post_name>] [--from-post=<post_id>] [--to_ping=<to_ping>] [--pinged=<pinged>] [--post_modified=<post_modified>] [--post_modified_gmt=<post_modified_gmt>] [--post_parent=<post_parent>] [--menu_order=<menu_order>] [--post_mime_type=<post_mime_type>] [--guid=<guid>] [--post_category=<post_category>] [--tags_input=<tags_input>] [--tax_input=<tax_input>] [--meta_input=<meta_input>] [<file>] [--<field>=<value>] [--edit] [--porcelain]
 ~~~
 
 **OPTIONS**
@@ -2040,6 +2040,9 @@ wp post create [--post_author=<post_author>] [--post_date=<post_date>] [--post_d
 
 	[--post_name=<post_name>]
 		The post name. Default is the sanitized post title when creating a new post.
+
+	[--from-post=<post_id>]
+		Post id of a post to be duplicated.
 
 	[--to_ping=<to_ping>]
 		Space or carriage return-separated list of URLs to ping. Default empty.
@@ -2110,6 +2113,10 @@ wp post create [--post_author=<post_author>] [--post_date=<post_date>] [--post_d
     # Create a post with multiple meta values.
     $ wp post create --post_title='A post' --post_content='Just a small post.' --meta_input='{"key1":"value1","key2":"value2"}
     Success: Created post 1923.
+
+	# Create a duplicate post from existing posts.
+	$ wp post create --from-post=123 --post_title='Different Title'
+	Success: Created post 2350.
 
 
 

--- a/entity-command.php
+++ b/entity-command.php
@@ -32,9 +32,6 @@ WP_CLI::add_command( 'site meta', 'Site_Meta_Command', array(
 		if ( !is_multisite() ) {
 			WP_CLI::error( 'This is not a multisite installation.' );
 		}
-		if ( \WP_CLI\Utils\wp_version_compare( '5.0', '<' ) ) {
-			WP_CLI::error( "Requires WordPress 5.0 or greater." );
-		}
 		if( function_exists('is_site_meta_supported') && !is_site_meta_supported() ){
 			WP_CLI::error( sprintf( 'The %s table is not installed. Please run the network database upgrade.', $GLOBALS['wpdb']->blogmeta ) );
 		}

--- a/entity-command.php
+++ b/entity-command.php
@@ -27,6 +27,19 @@ WP_CLI::add_command( 'post meta', 'Post_Meta_Command' );
 WP_CLI::add_command( 'post term', 'Post_Term_Command' );
 WP_CLI::add_command( 'post-type', 'Post_Type_Command' );
 WP_CLI::add_command( 'site', 'Site_Command' );
+WP_CLI::add_command( 'site meta', 'Site_Meta_Command', array(
+	'before_invoke' => function() {
+		if ( !is_multisite() ) {
+			WP_CLI::error( 'This is not a multisite installation.' );
+		}
+		if ( \WP_CLI\Utils\wp_version_compare( '5.0', '<' ) ) {
+			WP_CLI::error( "Requires WordPress 5.0 or greater." );
+		}
+		if( function_exists('is_site_meta_supported') && !is_site_meta_supported() ){
+			WP_CLI::error( sprintf( 'The %s table is not installed. Please run the network database upgrade.', $GLOBALS['wpdb']->blogmeta ) );
+		}
+	}
+) );
 WP_CLI::add_command( 'site option', 'Site_Option_Command', array(
 	'before_invoke' => function() {
 		if ( !is_multisite() ) {

--- a/features/bootstrap/utils.php
+++ b/features/bootstrap/utils.php
@@ -24,7 +24,7 @@ function extract_from_phar( $path ) {
 
 	$fname = basename( $path );
 
-	$tmp_path = get_temp_dir() . "wp-cli-$fname";
+	$tmp_path = get_temp_dir() . uniqid( 'wp-cli-extract-from-phar-', true ) . "-$fname";
 
 	copy( $path, $tmp_path );
 
@@ -351,19 +351,21 @@ function pick_fields( $item, $fields ) {
  * @category Input
  *
  * @param  string  $content  Some form of text to edit (e.g. post content)
+ * @param  string  $title    Title to display in the editor.
+ * @param  string  $ext      Extension to use with the temp file.
  * @return string|bool       Edited text, if file is saved from editor; false, if no change to file.
  */
-function launch_editor_for_input( $input, $filename = 'WP-CLI' ) {
+function launch_editor_for_input( $input, $title = 'WP-CLI', $ext = 'tmp' ) {
 
 	check_proc_available( 'launch_editor_for_input' );
 
 	$tmpdir = get_temp_dir();
 
 	do {
-		$tmpfile = basename( $filename );
+		$tmpfile = basename( $title );
 		$tmpfile = preg_replace( '|\.[^.]*$|', '', $tmpfile );
 		$tmpfile .= '-' . substr( md5( mt_rand() ), 0, 6 );
-		$tmpfile = $tmpdir . $tmpfile . '.tmp';
+		$tmpfile = $tmpdir . $tmpfile . '.' . $ext;
 		$fp = fopen( $tmpfile, 'xb' );
 		if ( ! $fp && is_writable( $tmpdir ) && file_exists( $tmpfile ) ) {
 			$tmpfile = '';
@@ -771,6 +773,31 @@ function get_home_dir() {
 function trailingslashit( $string ) {
 	return rtrim( $string, '/\\' ) . '/';
 }
+
+/**
+ * Normalize a filesystem path.
+ *
+ * On Windows systems, replaces backslashes with forward slashes
+ * and forces upper-case drive letters.
+ * Allows for two leading slashes for Windows network shares, but
+ * ensures that all other duplicate slashes are reduced to a single one.
+ * Ensures upper-case drive letters on Windows systems.
+ *
+ * @access public
+ * @category System
+ *
+ * @param string $path Path to normalize.
+ * @return string Normalized path.
+ */
+function normalize_path( $path ) {
+	$path = str_replace( '\\', '/', $path );
+	$path = preg_replace( '|(?<=.)/+|', '/', $path );
+	if ( ':' === substr( $path, 1, 1 ) ) {
+		$path = ucfirst( $path );
+	}
+	return $path;
+}
+
 
 /**
  * Convert Windows EOLs to *nix.
@@ -1307,6 +1334,7 @@ function get_php_binary() {
 
 	// Available since PHP 5.4.
 	if ( defined( 'PHP_BINARY' ) ) {
+		// @codingStandardsIgnoreLine
 		return PHP_BINARY;
 	}
 

--- a/features/post-create-duplicate.feature
+++ b/features/post-create-duplicate.feature
@@ -1,0 +1,82 @@
+Feature: Create Duplicate WordPress post from existing posts.
+
+  Background:
+	Given a WP install
+
+  Scenario: Generate duplicate post.
+	When I run `wp term create category "Test Category" --porcelain`
+	Then save STDOUT as {TERM_ID}
+
+	When I run `wp term create post_tag "Test Tag" --porcelain`
+	Then save STDOUT as {TAG_ID}
+
+	When I run `wp post create --post_title='Test Duplicate Post' --post_category={TERM_ID} --porcelain`
+	And save STDOUT as {POST_ID}
+
+	When I run `wp post term add {POST_ID} post_tag {TAG_ID} --by=id`
+	Then STDOUT should contain:
+      """
+      Success: Added term.
+      """
+
+	When I run `wp post create --from-post={POST_ID} --porcelain`
+	Then STDOUT should be a number
+	And save STDOUT as {DUPLICATE_POST_ID}
+
+	When I run `wp post get {DUPLICATE_POST_ID} --field=title`
+	Then STDOUT should be:
+	  """
+	  Test Duplicate Post
+	  """
+
+	When I run `wp post term list {DUPLICATE_POST_ID} category --field=term_id`
+	Then STDOUT should be:
+      """
+      {TERM_ID}
+      """
+
+	When I run `wp post term list {DUPLICATE_POST_ID} post_tag --field=term_id`
+	Then STDOUT should be:
+      """
+      {TAG_ID}
+      """
+
+  @require-wp-4.4
+  Scenario: Generate duplicate post with post metadata.
+	When I run `wp post create --post_title='Test Post' --meta_input='{"key1":"value1","key2":"value2"}' --porcelain`
+	Then save STDOUT as {POST_ID}
+
+	When I run `wp post create --from-post={POST_ID} --porcelain`
+	Then save STDOUT as {DUPLICATE_POST_ID}
+
+	When I run `wp post meta list {DUPLICATE_POST_ID} --format=table`
+	Then STDOUT should be a table containing rows:
+	  | post_id             | meta_key | meta_value |
+	  | {DUPLICATE_POST_ID} | key1     | value1     |
+	  | {DUPLICATE_POST_ID} | key2     | value2     |
+
+
+  Scenario: Generate duplicate page.
+	When I run `wp post create --post_type="page" --post_title="Test Page" --post_content="Page Content" --porcelain`
+	Then save STDOUT as {POST_ID}
+
+	When I run `wp post create --from-post={POST_ID} --post_title="Duplicate Page" --porcelain`
+	Then save STDOUT as {DUPLICATE_POST_ID}
+
+	When I run `wp post list --post_type='page' --fields="title, content, type"`
+	Then STDOUT should be a table containing rows:
+	  | post_title     | post_content | post_type |
+	  | Test Page      | Page Content | page      |
+	  | Duplicate Page | Page Content | page      |
+
+  Scenario: Change type of duplicate post.
+	When I run `wp post create --post_title='Test Post' --porcelain`
+	Then save STDOUT as {POST_ID}
+
+	When I run `wp post create --from-post={POST_ID} --post_type=page --porcelain`
+	Then save STDOUT as {DUPLICATE_POST_ID}
+
+	When I run `wp post get {DUPLICATE_POST_ID} --fields=type`
+	Then STDOUT should be a table containing rows:
+	  | Field     | Value |
+	  | post_type | page  |

--- a/features/post.feature
+++ b/features/post.feature
@@ -223,7 +223,7 @@ Feature: Manage WordPress posts
     Then STDOUT should be:
       """
       http://example.com/?p=1
-      http://example.com/?p=3
+      http://example.com/?p={POST_ID}
       """
 
   Scenario: Update a post from file or STDIN
@@ -308,7 +308,7 @@ Feature: Manage WordPress posts
       """
 
     When I run `wp post list --post_type='page' --field=title`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       Sample Page
       """

--- a/features/site-empty.feature
+++ b/features/site-empty.feature
@@ -17,10 +17,10 @@ Feature: Empty a WordPress site of its data
       """
     And the return code should be 1
 
-    When I run `wp post create --post_title='Test post' --post_content='Test content.' --porcelain`
-    Then STDOUT should be:
+    When I run `wp post create --post_title='Test post' --post_content='Test content.'`
+    Then STDOUT should contain:
       """
-      4
+      Success: Created post
       """
 
     When I run `wp term create post_tag 'Test term' --slug=test --description='This is a test term'`

--- a/features/site-meta.feature
+++ b/features/site-meta.feature
@@ -1,19 +1,36 @@
-Feature: Manage site-wide custom fields.
+Feature: Manage site custom fields
 
   @require-wp-5.0
-  Scenario: Non-multisite
-    Given a WP install
+  Scenario: Site meta CRUD
+    Given a WP multisite installation
 
-    When I run `wp site-meta`
-    Then STDOUT should contain:
+    When I run `wp site meta add 1 foo 'bar'`
+    Then STDOUT should not be empty
+
+    When I run `wp site meta get 1 foo`
+    Then STDOUT should be:
       """
-      usage: wp site meta
+      bar
       """
 
-    When I try `wp site-meta get 1 test`
-    Then STDOUT should be empty
-    And STDERR should contain:
+    When I try `wp site meta get 999999 foo`
+    Then STDERR should be:
       """
-      This is not a multisite install.
+      Error: Could not find the site with ID 999999.
       """
     And the return code should be 1
+
+    When I run `wp site meta set 1 foo '[ "1", "2" ]' --format=json`
+    Then STDOUT should not be empty
+
+    When I run `wp site meta get 1 foo --format=json`
+    Then STDOUT should be:
+      """
+      ["1","2"]
+      """
+
+    When I run `wp site meta delete 1 foo`
+    Then STDOUT should not be empty
+
+    When I try `wp site meta get 1 foo`
+    Then the return code should be 1

--- a/features/site-meta.feature
+++ b/features/site-meta.feature
@@ -1,6 +1,6 @@
 Feature: Manage site custom fields
 
-  @require-wp-5.0.0
+  @require-wp-5.0
   Scenario: Site meta CRUD
     Given a WP multisite installation
 

--- a/features/site-meta.feature
+++ b/features/site-meta.feature
@@ -1,6 +1,6 @@
 Feature: Manage site custom fields
 
-  @require-wp-5.0
+  @require-wp-5.0.0
   Scenario: Site meta CRUD
     Given a WP multisite installation
 

--- a/features/site-meta.feature
+++ b/features/site-meta.feature
@@ -1,0 +1,19 @@
+Feature: Manage site-wide custom fields.
+
+  @require-wp-5.0
+  Scenario: Non-multisite
+    Given a WP install
+
+    When I run `wp site-meta`
+    Then STDOUT should contain:
+      """
+      usage: wp site meta
+      """
+
+    When I try `wp site-meta get 1 test`
+    Then STDOUT should be empty
+    And STDERR should contain:
+      """
+      This is not a multisite install.
+      """
+    And the return code should be 1

--- a/src/Comment_Meta_Command.php
+++ b/src/Comment_Meta_Command.php
@@ -25,6 +25,80 @@ class Comment_Meta_Command extends \WP_CLI\CommandWithMeta {
 	protected $meta_type = 'comment';
 
 	/**
+	 * Wrapper method for add_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object the metadata is for.
+	 * @param string $meta_key   Metadata key to use.
+	 * @param mixed  $meta_value Metadata value. Must be serializable if
+	 *                           non-scalar.
+	 * @param bool   $unique     Optional, default is false. Whether the
+	 *                           specified metadata key should be unique for the
+	 *                           object. If true, and the object already has a
+	 *                           value for the specified metadata key, no change
+	 *                           will be made.
+	 *
+	 * @return int|false The meta ID on success, false on failure.
+	 */
+	protected function add_metadata( $object_id, $meta_key, $meta_value, $unique = false ) {
+		return add_comment_meta( $object_id, $meta_key, $meta_value, $unique );
+	}
+
+	/**
+	 * Wrapper method for update_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object the metadata is for.
+	 * @param string $meta_key   Metadata key to use.
+	 * @param mixed  $meta_value Metadata value. Must be serializable if
+	 *                           non-scalar.
+	 * @param mixed  $prev_value Optional. If specified, only update existing
+	 *                           metadata entries with the specified value.
+	 *                           Otherwise, update all entries.
+	 *
+	 * @return int|bool Meta ID if the key didn't exist, true on successful
+	 *                  update, false on failure.
+	 */
+	protected function update_metadata( $object_id, $meta_key, $meta_value, $prev_value = '' ) {
+		return update_comment_meta( $object_id, $meta_key, $meta_value, $prev_value );
+	}
+
+	/**
+	 * Wrapper method for get_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id ID of the object the metadata is for.
+	 * @param string $meta_key  Optional. Metadata key. If not specified,
+	 *                          retrieve all metadata for the specified object.
+	 * @param bool   $single    Optional, default is false. If true, return only
+	 *                          the first value of the specified meta_key. This
+	 *                          parameter has no effect if meta_key is not
+	 *                          specified.
+	 *
+	 * @return mixed Single metadata value, or array of values.
+	 */
+	protected function get_metadata( $object_id, $meta_key = '', $single = false ) {
+		return get_comment_meta( $object_id, $meta_key, $single );
+	}
+
+	/**
+	 * Wrapper method for delete_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object metadata is for
+	 * @param string $meta_key   Metadata key
+	 * @param mixed $meta_value  Optional. Metadata value. Must be serializable
+	 *                           if non-scalar. If specified, only delete
+	 *                           metadata entries with this value. Otherwise,
+	 *                           delete all entries with the specified meta_key.
+	 *                           Pass `null, `false`, or an empty string to skip
+	 *                           this check. For backward compatibility, it is
+	 *                           not possible to pass an empty string to delete
+	 *                           those entries with an empty string for a value.
+	 *
+	 * @return bool True on successful delete, false on failure.
+	 */
+	protected function delete_metadata( $object_id, $meta_key, $meta_value = '' ) {
+		return delete_comment_meta( $object_id, $meta_key, $meta_value );
+	}
+
+	/**
 	 * Check that the comment ID exists
 	 *
 	 * @param int
@@ -35,4 +109,3 @@ class Comment_Meta_Command extends \WP_CLI\CommandWithMeta {
 		return $comment->comment_ID;
 	}
 }
-

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -78,6 +78,9 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 * [--post_name=<post_name>]
 	 * : The post name. Default is the sanitized post title when creating a new post.
 	 *
+	 * [--from-post=<post_id>]
+	 * : Post id of a post to be duplicated.
+	 *
 	 * [--to_ping=<to_ping>]
 	 * : Space or carriage return-separated list of URLs to ping. Default empty.
 	 *
@@ -147,6 +150,10 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 *     # Create a post with multiple meta values.
 	 *     $ wp post create --post_title='A post' --post_content='Just a small post.' --meta_input='{"key1":"value1","key2":"value2"}
 	 *     Success: Created post 1923.
+	 *
+	 *     # Create a duplicate post from existing posts.
+	 *     $ wp post create --from-post=123 --post_title='Different Title'
+	 *     Success: Created post 2350.
 	 */
 	public function create( $args, $assoc_args ) {
 		if ( ! empty( $args[0] ) ) {
@@ -172,6 +179,27 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 
 		$array_arguments = array( 'meta_input' );
 		$assoc_args      = \WP_CLI\Utils\parse_shell_arrays( $assoc_args, $array_arguments );
+
+		if ( isset( $assoc_args['from-post'] ) ) {
+			$post     = $this->fetcher->get_check( $assoc_args['from-post'] );
+			$post_arr = get_object_vars( $post );
+			$post_id  = $post_arr['ID'];
+			unset( $post_arr['post_date'] );
+			unset( $post_arr['post_date_gmt'] );
+			unset( $post_arr['guid'] );
+			unset( $post_arr['ID'] );
+
+			if ( empty( $assoc_args['meta_input'] ) ) {
+				$assoc_args['meta_input'] = $this->get_metadata( $post_id );
+			}
+			if ( empty( $assoc_args['post_category'] ) ) {
+				$post_arr['post_category'] = $this->get_category( $post_id );
+			}
+			if ( empty( $assoc_args['tags_input'] ) ) {
+				$post_arr['tags_input'] = $this->get_tags( $post_id );
+			}
+			$assoc_args = array_merge( $post_arr, $assoc_args );
+		}
 
 		$assoc_args = wp_slash( $assoc_args );
 		parent::_create( $args, $assoc_args, function ( $params ) {
@@ -796,5 +824,61 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 		}
 		// If no category ids found, return exploded array for compat with previous WP-CLI versions.
 		return $category_ids ? $category_ids : $categories;
+	}
+
+	/**
+	 * Get post metadata.
+	 *
+	 * @param $post_id ID of the post.
+	 *
+	 * @return array
+	 */
+	private function get_metadata( $post_id ) {
+		$metadata = get_metadata( 'post', $post_id );
+		$items    = array();
+		foreach ( $metadata as $key => $values ) {
+			foreach ( $values as $item_value ) {
+				$item_value  = maybe_unserialize( $item_value );
+				$items[$key] = $item_value;
+			}
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Get Categories of a post.
+	 *
+	 * @param $post_id ID of the post.
+	 *
+	 * @return array
+	 */
+	private function get_category( $post_id ) {
+		$category_data = get_the_category( $post_id );
+		$category_arr  = array();
+		foreach ( $category_data as $cat ) {
+			array_push( $category_arr, $cat->term_id );
+		}
+
+		return $category_arr;
+	}
+
+	/**
+	 * Get Tags of a post.
+	 *
+	 * @param $post_id ID of the post.
+	 *
+	 * @return array
+	 */
+	private function get_tags( $post_id ) {
+		$tag_data = get_the_tags( $post_id );
+		$tag_arr  = array();
+		if ( $tag_data ) {
+			foreach ( $tag_data as $tag ) {
+				array_push( $tag_arr, $tag->slug );
+			}
+		}
+
+		return $tag_arr;
 	}
 }

--- a/src/Post_Meta_Command.php
+++ b/src/Post_Meta_Command.php
@@ -34,4 +34,78 @@ class Post_Meta_Command extends \WP_CLI\CommandWithMeta {
 		$post = $fetcher->get_check( $object_id );
 		return $post->ID;
 	}
+
+	/**
+	 * Wrapper method for add_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object the metadata is for.
+	 * @param string $meta_key   Metadata key to use.
+	 * @param mixed  $meta_value Metadata value. Must be serializable if
+	 *                           non-scalar.
+	 * @param bool   $unique     Optional, default is false. Whether the
+	 *                           specified metadata key should be unique for the
+	 *                           object. If true, and the object already has a
+	 *                           value for the specified metadata key, no change
+	 *                           will be made.
+	 *
+	 * @return int|false The meta ID on success, false on failure.
+	 */
+	protected function add_metadata( $object_id, $meta_key, $meta_value, $unique = false ) {
+		return add_post_meta( $object_id, $meta_key, $meta_value, $unique );
+	}
+
+	/**
+	 * Wrapper method for update_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object the metadata is for.
+	 * @param string $meta_key   Metadata key to use.
+	 * @param mixed  $meta_value Metadata value. Must be serializable if
+	 *                           non-scalar.
+	 * @param mixed  $prev_value Optional. If specified, only update existing
+	 *                           metadata entries with the specified value.
+	 *                           Otherwise, update all entries.
+	 *
+	 * @return int|bool Meta ID if the key didn't exist, true on successful
+	 *                  update, false on failure.
+	 */
+	protected function update_metadata( $object_id, $meta_key, $meta_value, $prev_value = '' ) {
+		return update_post_meta( $object_id, $meta_key, $meta_value, $prev_value );
+	}
+
+	/**
+	 * Wrapper method for get_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id ID of the object the metadata is for.
+	 * @param string $meta_key  Optional. Metadata key. If not specified,
+	 *                          retrieve all metadata for the specified object.
+	 * @param bool   $single    Optional, default is false. If true, return only
+	 *                          the first value of the specified meta_key. This
+	 *                          parameter has no effect if meta_key is not
+	 *                          specified.
+	 *
+	 * @return mixed Single metadata value, or array of values.
+	 */
+	protected function get_metadata( $object_id, $meta_key = '', $single = false ) {
+		return get_post_meta( $object_id, $meta_key, $single );
+	}
+
+	/**
+	 * Wrapper method for delete_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object metadata is for
+	 * @param string $meta_key   Metadata key
+	 * @param mixed $meta_value  Optional. Metadata value. Must be serializable
+	 *                           if non-scalar. If specified, only delete
+	 *                           metadata entries with this value. Otherwise,
+	 *                           delete all entries with the specified meta_key.
+	 *                           Pass `null, `false`, or an empty string to skip
+	 *                           this check. For backward compatibility, it is
+	 *                           not possible to pass an empty string to delete
+	 *                           those entries with an empty string for a value.
+	 *
+	 * @return bool True on successful delete, false on failure.
+	 */
+	protected function delete_metadata( $object_id, $meta_key, $meta_value = '' ) {
+		return delete_post_meta( $object_id, $meta_key, $meta_value );
+	}
 }

--- a/src/Site_Meta_Command.php
+++ b/src/Site_Meta_Command.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Adds, updates, deletes, and lists site custom fields.
+ *
+ * ## EXAMPLES
+ *
+ *     # Set site meta
+ *     $ wp site meta set 123 bio "Mary is a WordPress developer."
+ *     Success: Updated custom field 'bio'.
+ *
+ *     # Get site meta
+ *     $ wp site meta get 123 bio
+ *     Mary is a WordPress developer.
+ *
+ *     # Update site meta
+ *     $ wp site meta update 123 bio "Mary is an awesome WordPress developer."
+ *     Success: Updated custom field 'bio'.
+ *
+ *     # Delete site meta
+ *     $ wp site meta delete 123 bio
+ *     Success: Deleted custom field.
+ */
+class Site_Meta_Command extends \WP_CLI\CommandWithMeta {
+	protected $meta_type = 'blog';
+
+	/**
+	 * Check that the site ID exists
+	 *
+	 * @param int
+	 */
+	protected function check_object_id( $object_id ) {
+		$fetcher = new \WP_CLI\Fetchers\Site;
+		$site = $fetcher->get_check( $object_id );
+		return $site->blog_id;
+	}
+
+}

--- a/src/Site_Meta_Command.php
+++ b/src/Site_Meta_Command.php
@@ -35,4 +35,78 @@ class Site_Meta_Command extends \WP_CLI\CommandWithMeta {
 		return $site->blog_id;
 	}
 
+	/**
+	 * Wrapper method for add_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object the metadata is for.
+	 * @param string $meta_key   Metadata key to use.
+	 * @param mixed  $meta_value Metadata value. Must be serializable if
+	 *                           non-scalar.
+	 * @param bool   $unique     Optional, default is false. Whether the
+	 *                           specified metadata key should be unique for the
+	 *                           object. If true, and the object already has a
+	 *                           value for the specified metadata key, no change
+	 *                           will be made.
+	 *
+	 * @return int|false The meta ID on success, false on failure.
+	 */
+	protected function add_metadata( $object_id, $meta_key, $meta_value, $unique = false ) {
+		return add_site_meta( $object_id, $meta_key, $meta_value, $unique );
+	}
+
+	/**
+	 * Wrapper method for update_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object the metadata is for.
+	 * @param string $meta_key   Metadata key to use.
+	 * @param mixed  $meta_value Metadata value. Must be serializable if
+	 *                           non-scalar.
+	 * @param mixed  $prev_value Optional. If specified, only update existing
+	 *                           metadata entries with the specified value.
+	 *                           Otherwise, update all entries.
+	 *
+	 * @return int|bool Meta ID if the key didn't exist, true on successful
+	 *                  update, false on failure.
+	 */
+	protected function update_metadata( $object_id, $meta_key, $meta_value, $prev_value = '' ) {
+		return update_site_meta( $object_id, $meta_key, $meta_value, $prev_value );
+	}
+
+	/**
+	 * Wrapper method for get_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id ID of the object the metadata is for.
+	 * @param string $meta_key  Optional. Metadata key. If not specified,
+	 *                          retrieve all metadata for the specified object.
+	 * @param bool   $single    Optional, default is false. If true, return only
+	 *                          the first value of the specified meta_key. This
+	 *                          parameter has no effect if meta_key is not
+	 *                          specified.
+	 *
+	 * @return mixed Single metadata value, or array of values.
+	 */
+	protected function get_metadata( $object_id, $meta_key = '', $single = false ) {
+		return get_site_meta( $object_id, $meta_key, $single );
+	}
+
+	/**
+	 * Wrapper method for delete_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object metadata is for
+	 * @param string $meta_key   Metadata key
+	 * @param mixed $meta_value  Optional. Metadata value. Must be serializable
+	 *                           if non-scalar. If specified, only delete
+	 *                           metadata entries with this value. Otherwise,
+	 *                           delete all entries with the specified meta_key.
+	 *                           Pass `null, `false`, or an empty string to skip
+	 *                           this check. For backward compatibility, it is
+	 *                           not possible to pass an empty string to delete
+	 *                           those entries with an empty string for a value.
+	 *
+	 * @return bool True on successful delete, false on failure.
+	 */
+	protected function delete_metadata( $object_id, $meta_key, $meta_value = '' ) {
+		return delete_site_meta( $object_id, $meta_key, $meta_value );
+	}
+
 }

--- a/src/Site_Meta_Command.php
+++ b/src/Site_Meta_Command.php
@@ -34,7 +34,7 @@ class Site_Meta_Command extends \WP_CLI\CommandWithMeta {
 		$site = $fetcher->get_check( $object_id );
 		return $site->blog_id;
 	}
-
+	
 	/**
 	 * Wrapper method for add_metadata that can be overridden in sub classes.
 	 *

--- a/src/Term_Meta_Command.php
+++ b/src/Term_Meta_Command.php
@@ -37,4 +37,77 @@ class Term_Meta_Command extends \WP_CLI\CommandWithMeta {
 		return $term->term_id;
 	}
 
+	/**
+	 * Wrapper method for add_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object the metadata is for.
+	 * @param string $meta_key   Metadata key to use.
+	 * @param mixed  $meta_value Metadata value. Must be serializable if
+	 *                           non-scalar.
+	 * @param bool   $unique     Optional, default is false. Whether the
+	 *                           specified metadata key should be unique for the
+	 *                           object. If true, and the object already has a
+	 *                           value for the specified metadata key, no change
+	 *                           will be made.
+	 *
+	 * @return int|false The meta ID on success, false on failure.
+	 */
+	protected function add_metadata( $object_id, $meta_key, $meta_value, $unique = false ) {
+		return add_term_meta( $object_id, $meta_key, $meta_value, $unique );
+	}
+
+	/**
+	 * Wrapper method for update_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object the metadata is for.
+	 * @param string $meta_key   Metadata key to use.
+	 * @param mixed  $meta_value Metadata value. Must be serializable if
+	 *                           non-scalar.
+	 * @param mixed  $prev_value Optional. If specified, only update existing
+	 *                           metadata entries with the specified value.
+	 *                           Otherwise, update all entries.
+	 *
+	 * @return int|bool Meta ID if the key didn't exist, true on successful
+	 *                  update, false on failure.
+	 */
+	protected function update_metadata( $object_id, $meta_key, $meta_value, $prev_value = '' ) {
+		return update_term_meta( $object_id, $meta_key, $meta_value, $prev_value );
+	}
+
+	/**
+	 * Wrapper method for get_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id ID of the object the metadata is for.
+	 * @param string $meta_key  Optional. Metadata key. If not specified,
+	 *                          retrieve all metadata for the specified object.
+	 * @param bool   $single    Optional, default is false. If true, return only
+	 *                          the first value of the specified meta_key. This
+	 *                          parameter has no effect if meta_key is not
+	 *                          specified.
+	 *
+	 * @return mixed Single metadata value, or array of values.
+	 */
+	protected function get_metadata( $object_id, $meta_key = '', $single = false ) {
+		return get_term_meta( $object_id, $meta_key, $single );
+	}
+
+	/**
+	 * Wrapper method for delete_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object metadata is for
+	 * @param string $meta_key   Metadata key
+	 * @param mixed $meta_value  Optional. Metadata value. Must be serializable
+	 *                           if non-scalar. If specified, only delete
+	 *                           metadata entries with this value. Otherwise,
+	 *                           delete all entries with the specified meta_key.
+	 *                           Pass `null, `false`, or an empty string to skip
+	 *                           this check. For backward compatibility, it is
+	 *                           not possible to pass an empty string to delete
+	 *                           those entries with an empty string for a value.
+	 *
+	 * @return bool True on successful delete, false on failure.
+	 */
+	protected function delete_metadata( $object_id, $meta_key, $meta_value = '' ) {
+		return delete_term_meta( $object_id, $meta_key, $meta_value );
+	}
 }

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -314,9 +314,6 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 	 * [--user_url=<url>]
 	 * : A string containing the user's URL for the user's web site.
 	 *
-	 * [--user_email=<email>]
-	 * : A string containing the user's email address.
-	 *
 	 * [--nickname=<nickname>]
 	 * : The user's nickname, defaults to the user's username.
 	 *

--- a/src/User_Meta_Command.php
+++ b/src/User_Meta_Command.php
@@ -227,6 +227,80 @@ class User_Meta_Command extends \WP_CLI\CommandWithMeta {
 	}
 
 	/**
+	 * Wrapper method for add_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object the metadata is for.
+	 * @param string $meta_key   Metadata key to use.
+	 * @param mixed  $meta_value Metadata value. Must be serializable if
+	 *                           non-scalar.
+	 * @param bool   $unique     Optional, default is false. Whether the
+	 *                           specified metadata key should be unique for the
+	 *                           object. If true, and the object already has a
+	 *                           value for the specified metadata key, no change
+	 *                           will be made.
+	 *
+	 * @return int|false The meta ID on success, false on failure.
+	 */
+	protected function add_metadata( $object_id, $meta_key, $meta_value, $unique = false ) {
+		return add_user_meta( $object_id, $meta_key, $meta_value, $unique );
+	}
+
+	/**
+	 * Wrapper method for update_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object the metadata is for.
+	 * @param string $meta_key   Metadata key to use.
+	 * @param mixed  $meta_value Metadata value. Must be serializable if
+	 *                           non-scalar.
+	 * @param mixed  $prev_value Optional. If specified, only update existing
+	 *                           metadata entries with the specified value.
+	 *                           Otherwise, update all entries.
+	 *
+	 * @return int|bool Meta ID if the key didn't exist, true on successful
+	 *                  update, false on failure.
+	 */
+	protected function update_metadata( $object_id, $meta_key, $meta_value, $prev_value = '' ) {
+		return update_user_meta( $object_id, $meta_key, $meta_value, $prev_value );
+	}
+
+	/**
+	 * Wrapper method for get_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id ID of the object the metadata is for.
+	 * @param string $meta_key  Optional. Metadata key. If not specified,
+	 *                          retrieve all metadata for the specified object.
+	 * @param bool   $single    Optional, default is false. If true, return only
+	 *                          the first value of the specified meta_key. This
+	 *                          parameter has no effect if meta_key is not
+	 *                          specified.
+	 *
+	 * @return mixed Single metadata value, or array of values.
+	 */
+	protected function get_metadata( $object_id, $meta_key = '', $single = false ) {
+		return get_user_meta( $object_id, $meta_key, $single );
+	}
+
+	/**
+	 * Wrapper method for delete_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object metadata is for
+	 * @param string $meta_key   Metadata key
+	 * @param mixed $meta_value  Optional. Metadata value. Must be serializable
+	 *                           if non-scalar. If specified, only delete
+	 *                           metadata entries with this value. Otherwise,
+	 *                           delete all entries with the specified meta_key.
+	 *                           Pass `null, `false`, or an empty string to skip
+	 *                           this check. For backward compatibility, it is
+	 *                           not possible to pass an empty string to delete
+	 *                           those entries with an empty string for a value.
+	 *
+	 * @return bool True on successful delete, false on failure.
+	 */
+	protected function delete_metadata( $object_id, $meta_key, $meta_value = '' ) {
+		return delete_user_meta( $object_id, $meta_key, $meta_value );
+	}
+
+	/**
 	 * Replaces user_login value with user ID
 	 * user meta is a special case that also supports user_login
 	 *

--- a/src/WP_CLI/CommandWithMeta.php
+++ b/src/WP_CLI/CommandWithMeta.php
@@ -68,7 +68,7 @@ abstract class CommandWithMeta extends \WP_CLI_Command {
 
 		$object_id = $this->check_object_id( $object_id );
 
-		$metadata = get_metadata( $this->meta_type, $object_id );
+		$metadata = $this->get_metadata( $object_id );
 		if ( ! $metadata ) {
 			$metadata = array();
 		}
@@ -147,7 +147,7 @@ abstract class CommandWithMeta extends \WP_CLI_Command {
 
 		$object_id = $this->check_object_id( $object_id );
 
-		$value = get_metadata( $this->meta_type, $object_id, $meta_key, true );
+		$value = $this->get_metadata( $object_id, $meta_key, true );
 
 		if ( '' === $value )
 			die(1);
@@ -186,8 +186,8 @@ abstract class CommandWithMeta extends \WP_CLI_Command {
 
 		if ( Utils\get_flag_value( $assoc_args, 'all' ) ) {
 			$errors = false;
-			foreach( get_metadata( $this->meta_type, $object_id ) as $meta_key => $values ) {
-				$success = delete_metadata( $this->meta_type, $object_id, $meta_key );
+			foreach( $this->get_metadata( $object_id ) as $meta_key => $values ) {
+				$success = $this->delete_metadata( $object_id, $meta_key );
 				if ( $success ) {
 					WP_CLI::log( "Deleted '{$meta_key}' custom field." );
 				} else {
@@ -201,7 +201,7 @@ abstract class CommandWithMeta extends \WP_CLI_Command {
 				WP_CLI::success( 'Deleted all custom fields.' );
 			}
 		} else {
-			$success = delete_metadata( $this->meta_type, $object_id, $meta_key, $meta_value );
+			$success = $this->delete_metadata( $object_id, $meta_key, $meta_value );
 			if ( $success ) {
 				WP_CLI::success( "Deleted custom field." );
 			} else {
@@ -242,7 +242,7 @@ abstract class CommandWithMeta extends \WP_CLI_Command {
 		$object_id = $this->check_object_id( $object_id );
 
 		$meta_value = wp_slash( $meta_value );
-		$success = add_metadata( $this->meta_type, $object_id, $meta_key, $meta_value );
+		$success = $this->add_metadata( $object_id, $meta_key, $meta_value );
 
 		if ( $success ) {
 			WP_CLI::success( "Added custom field." );
@@ -285,13 +285,13 @@ abstract class CommandWithMeta extends \WP_CLI_Command {
 		$object_id = $this->check_object_id( $object_id );
 
 		$meta_value = sanitize_meta( $meta_key, $meta_value, $this->meta_type );
-		$old_value = sanitize_meta( $meta_key, get_metadata( $this->meta_type, $object_id, $meta_key, true ), $this->meta_type );
+		$old_value = sanitize_meta( $meta_key, $this->get_metadata( $object_id, $meta_key, true ), $this->meta_type );
 
 		if ( $meta_value === $old_value ) {
 			WP_CLI::success( "Value passed for custom field '$meta_key' is unchanged." );
 		} else {
 			$meta_value = wp_slash( $meta_value );
-			$success = update_metadata( $this->meta_type, $object_id, $meta_key, $meta_value );
+			$success = $this->update_metadata( $object_id, $meta_key, $meta_value );
 
 			if ( $success ) {
 				WP_CLI::success( "Updated custom field '$meta_key'." );
@@ -336,7 +336,7 @@ abstract class CommandWithMeta extends \WP_CLI_Command {
 			return $key;
 		}, array_slice( $args, 2 ) );
 
-		$value = get_metadata( $this->meta_type, $object_id, $meta_key, true );
+		$value = $this->get_metadata( $object_id, $meta_key, true );
 
 		$traverser = new RecursiveDataStructureTraverser( $value );
 
@@ -405,7 +405,7 @@ abstract class CommandWithMeta extends \WP_CLI_Command {
 		}
 
 		/* Need to make a copy of $current_meta_value here as it is modified by reference */
-		$current_meta_value = $old_meta_value = sanitize_meta( $meta_key, get_metadata( $this->meta_type, $object_id, $meta_key, true ), $this->meta_type );
+		$current_meta_value = $old_meta_value = sanitize_meta( $meta_key, $this->get_metadata( $object_id, $meta_key, true ), $this->meta_type );
 		if ( is_object( $current_meta_value ) ) {
 			$old_meta_value = clone $current_meta_value;
 		}
@@ -424,7 +424,7 @@ abstract class CommandWithMeta extends \WP_CLI_Command {
 			WP_CLI::success( "Value passed for custom field '$meta_key' is unchanged." );
 		} else {
 			$slashed = wp_slash( $patched_meta_value );
-			$success = update_metadata( $this->meta_type, $object_id, $meta_key, $slashed );
+			$success = $this->update_metadata( $object_id, $meta_key, $slashed );
 
 			if ( $success ) {
 				WP_CLI::success( "Updated custom field '$meta_key'." );
@@ -432,6 +432,80 @@ abstract class CommandWithMeta extends \WP_CLI_Command {
 				WP_CLI::error( "Failed to update custom field '$meta_key'." );
 			}
 		}
+	}
+
+	/**
+	 * Wrapper method for add_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object the metadata is for.
+	 * @param string $meta_key   Metadata key to use.
+	 * @param mixed  $meta_value Metadata value. Must be serializable if
+	 *                           non-scalar.
+	 * @param bool   $unique     Optional, default is false. Whether the
+	 *                           specified metadata key should be unique for the
+	 *                           object. If true, and the object already has a
+	 *                           value for the specified metadata key, no change
+	 *                           will be made.
+	 *
+	 * @return int|false The meta ID on success, false on failure.
+	 */
+	protected function add_metadata( $object_id, $meta_key, $meta_value, $unique = false ) {
+		return add_metadata( $this->meta_type, $object_id, $meta_key, $meta_value, $unique );
+	}
+
+	/**
+	 * Wrapper method for update_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object the metadata is for.
+	 * @param string $meta_key   Metadata key to use.
+	 * @param mixed  $meta_value Metadata value. Must be serializable if
+	 *                           non-scalar.
+	 * @param mixed  $prev_value Optional. If specified, only update existing
+	 *                           metadata entries with the specified value.
+	 *                           Otherwise, update all entries.
+	 *
+	 * @return int|bool Meta ID if the key didn't exist, true on successful
+	 *                  update, false on failure.
+	 */
+	protected function update_metadata( $object_id, $meta_key, $meta_value, $prev_value = '' ) {
+		return update_metadata( $this->meta_type, $object_id, $meta_key, $meta_value, $prev_value );
+	}
+
+	/**
+	 * Wrapper method for get_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id ID of the object the metadata is for.
+	 * @param string $meta_key  Optional. Metadata key. If not specified,
+	 *                          retrieve all metadata for the specified object.
+	 * @param bool   $single    Optional, default is false. If true, return only
+	 *                          the first value of the specified meta_key. This
+	 *                          parameter has no effect if meta_key is not
+	 *                          specified.
+	 *
+	 * @return mixed Single metadata value, or array of values.
+	 */
+	protected function get_metadata( $object_id, $meta_key = '', $single = false ) {
+		return get_metadata( $this->meta_type, $object_id, $meta_key, $single );
+	}
+
+	/**
+	 * Wrapper method for delete_metadata that can be overridden in sub classes.
+	 *
+	 * @param int    $object_id  ID of the object metadata is for
+	 * @param string $meta_key   Metadata key
+	 * @param mixed $meta_value  Optional. Metadata value. Must be serializable
+	 *                           if non-scalar. If specified, only delete
+	 *                           metadata entries with this value. Otherwise,
+	 *                           delete all entries with the specified meta_key.
+	 *                           Pass `null, `false`, or an empty string to skip
+	 *                           this check. For backward compatibility, it is
+	 *                           not possible to pass an empty string to delete
+	 *                           those entries with an empty string for a value.
+	 *
+	 * @return bool True on successful delete, false on failure.
+	 */
+	protected function delete_metadata( $object_id, $meta_key, $meta_value = '' ) {
+		return delete_metadata( $this->meta_type, $object_id, $meta_key, $meta_value, false );
 	}
 
 	/**


### PR DESCRIPTION
Add the wp site meta sub-command, with tests. 

This one is going to be hard to test and might be merge after 5.0.0 is released. 

fixes #158 