### PR TITLE
Fix the 'Raise PHP memory limit' comment in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
       echo "xdebug.ini does not exist"
     fi
   - |
-    # Raise PHP memory limit to 256MB
+    # Raise PHP memory limit to 2048MB.
     echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 install:


### PR DESCRIPTION
As @schlessera pointed out in wp-cli/scaffold-command#136, there's a disagreement between the comment (256MB) and the actual value (2048MB) being set.