### PR TITLE
Turn `latest` into actual version number

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -8,6 +8,10 @@ then
 	phpunit
 fi
 
+if [ $WP_VERSION -eq "latest" ]; then
+	WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r ".offers[0].current")
+fi
+
 # Run the functional tests
 BEHAT_TAGS=$(php utils/behat-tags.php)
 behat --format progress $BEHAT_TAGS --strict

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -9,7 +9,7 @@ then
 fi
 
 if [ $WP_VERSION = "latest" ]; then
-	WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r ".offers[0].current")
+	export WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r ".offers[0].current")
 fi
 
 # Run the functional tests

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -8,7 +8,7 @@ then
 	phpunit
 fi
 
-if [ $WP_VERSION -eq "latest" ]; then
+if [ $WP_VERSION = "latest" ]; then
 	WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r ".offers[0].current")
 fi
 


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-cli/issues/3956