### PR TITLE
Abstract meta CRUD into methods

### DIFF
--- a/src/Comment_Meta_Command.php
+++ b/src/Comment_Meta_Command.php
@@ -24,6 +24,23 @@
 class Comment_Meta_Command extends \WP_CLI\CommandWithMeta {
 	protected $meta_type = 'comment';
 
+
+	protected function add_metadata( $object_id, $meta_key, $meta_value, $unique = false ) {
+		return add_comment_meta( $object_id, $meta_key, $meta_value, $unique );
+	}
+
+	protected function update_metadata( $object_id, $meta_key, $meta_value, $prev_value = '' ) {
+		return update_comment_meta( $object_id, $meta_key, $meta_value, $prev_value );
+	}
+
+	protected function get_metadata( $object_id, $meta_key = '', $single = false ) {
+		return get_comment_meta( $object_id, $meta_key, $single );
+	}
+
+	protected function delete_metadata( $meta_type, $object_id, $meta_key, $meta_value = '', $delete_all = false ) {
+		return delete_comment_meta( $object_id, $meta_key, $meta_value, $delete_all );
+	}
+
 	/**
 	 * Check that the comment ID exists
 	 *
@@ -35,4 +52,3 @@ class Comment_Meta_Command extends \WP_CLI\CommandWithMeta {
 		return $comment->comment_ID;
 	}
 }
-

--- a/src/Post_Meta_Command.php
+++ b/src/Post_Meta_Command.php
@@ -34,4 +34,20 @@ class Post_Meta_Command extends \WP_CLI\CommandWithMeta {
 		$post = $fetcher->get_check( $object_id );
 		return $post->ID;
 	}
+
+	protected function add_metadata( $object_id, $meta_key, $meta_value, $unique = false ) {
+		return add_post_meta( $object_id, $meta_key, $meta_value, $unique );
+	}
+
+	protected function update_metadata( $object_id, $meta_key, $meta_value, $prev_value = '' ) {
+		return update_post_meta( $object_id, $meta_key, $meta_value, $prev_value );
+	}
+
+	protected function get_metadata( $object_id, $meta_key = '', $single = false ) {
+		return get_post_meta( $object_id, $meta_key, $single );
+	}
+
+	protected function delete_metadata( $meta_type, $object_id, $meta_key, $meta_value = '', $delete_all = false ) {
+		return delete_post_meta( $object_id, $meta_key, $meta_value, $delete_all );
+	}
 }

--- a/src/Term_Meta_Command.php
+++ b/src/Term_Meta_Command.php
@@ -37,4 +37,20 @@ class Term_Meta_Command extends \WP_CLI\CommandWithMeta {
 		return $term->term_id;
 	}
 
+	protected function add_metadata( $object_id, $meta_key, $meta_value, $unique = false ) {
+		return add_term_meta( $object_id, $meta_key, $meta_value, $unique );
+	}
+
+	protected function update_metadata( $object_id, $meta_key, $meta_value, $prev_value = '' ) {
+		return update_term_meta( $object_id, $meta_key, $meta_value, $prev_value );
+	}
+
+	protected function get_metadata( $object_id, $meta_key = '', $single = false ) {
+		return get_term_meta( $object_id, $meta_key, $single );
+	}
+
+	protected function delete_metadata( $meta_type, $object_id, $meta_key, $meta_value = '', $delete_all = false ) {
+		return delete_term_meta( $object_id, $meta_key, $meta_value, $delete_all );
+	}
+
 }

--- a/src/User_Meta_Command.php
+++ b/src/User_Meta_Command.php
@@ -226,6 +226,22 @@ class User_Meta_Command extends \WP_CLI\CommandWithMeta {
 		parent::update( $args, $assoc_args );
 	}
 
+	protected function add_metadata( $object_id, $meta_key, $meta_value, $unique = false ) {
+		return add_user_meta( $object_id, $meta_key, $meta_value, $unique );
+	}
+
+	protected function update_metadata( $object_id, $meta_key, $meta_value, $prev_value = '' ) {
+		return update_user_meta( $object_id, $meta_key, $meta_value, $prev_value );
+	}
+
+	protected function get_metadata( $object_id, $meta_key = '', $single = false ) {
+		return get_user_meta( $object_id, $meta_key, $single );
+	}
+
+	protected function delete_metadata( $meta_type, $object_id, $meta_key, $meta_value = '', $delete_all = false ) {
+		return delete_user_meta( $object_id, $meta_key, $meta_value, $delete_all );
+	}
+
 	/**
 	 * Replaces user_login value with user ID
 	 * user meta is a special case that also supports user_login


### PR DESCRIPTION
In this PR, I abstract off the meta crud into there own method. This means that can overridden from the parent class. 

fixes #172 
related: #158