### PR TITLE
Post Generate: Add support for post_date_gmt

### DIFF
--- a/features/post-generate.feature
+++ b/features/post-generate.feature
@@ -112,3 +112,55 @@ Feature: Generate new WordPress posts
       """
       2018-07-04 00:00:00
       """
+
+  Scenario: Generating posts with post_date argument with hyphenated time
+    When I run `wp post generate --count=1 --post_date="2018-07-05-17:17:17"`
+    And I run `wp post list --field=post_date`
+    Then STDOUT should contain:
+      """
+      2018-07-05 17:17:17
+      """
+    And I run `wp post list --field=post_date_gmt`
+    Then STDOUT should contain:
+      """
+      2018-07-05 17:17:17
+      """
+
+  Scenario: Generating posts with post_date_gmt argument with hyphenated time
+    When I run `wp post generate --count=1 --post_date_gmt="2018-07-06-12:12:12"`
+    And I run `wp post list --field=post_date`
+    Then STDOUT should contain:
+      """
+      2018-07-06 12:12:12
+      """
+    And I run `wp post list --field=post_date_gmt`
+    Then STDOUT should contain:
+      """
+      2018-07-06 12:12:12
+      """
+
+  Scenario: Generating posts with different post_date & post_date_gmt argument without time
+    When I run `wp post generate --count=1 --post_date="1999-12-31" --post_date_gmt="2000-01-01"`
+    And I run `wp post list --field=post_date`
+    Then STDOUT should contain:
+      """
+      1999-12-31 00:00:00
+      """
+    And I run `wp post list --field=post_date_gmt`
+    Then STDOUT should contain:
+      """
+      2000-01-01 00:00:00
+      """
+
+	Scenario: Generating posts with different post_date & post_date_gmt argument with time
+    When I run `wp post generate --count=1 --post_date="1999-12-31 11:11:00" --post_date_gmt="2000-01-01 02:11:00"`
+    And I run `wp post list --field=post_date`
+    Then STDOUT should contain:
+      """
+      1999-12-31 11:11:00
+      """
+    And I run `wp post list --field=post_date_gmt`
+    Then STDOUT should contain:
+      """
+      2000-01-01 02:11:00
+      """

--- a/features/post-generate.feature
+++ b/features/post-generate.feature
@@ -60,3 +60,55 @@ Feature: Generate new WordPress posts
       howdy-3
       """
     And STDERR should be empty
+
+  Scenario: Generating posts with post_date argument without time
+    When I run `wp post generate --count=1 --post_date="2018-07-01"`
+    And I run `wp post list --field=post_date`
+    Then STDOUT should contain:
+      """
+      2018-07-01 00:00:00
+      """
+    And I run `wp post list --field=post_date_gmt`
+    Then STDOUT should contain:
+      """
+      2018-07-01 00:00:00
+      """
+
+  Scenario: Generating posts with post_date argument with time
+    When I run `wp post generate --count=1 --post_date="2018-07-02 00:00:00"`
+    And I run `wp post list --field=post_date`
+    Then STDOUT should contain:
+      """
+      2018-07-02 00:00:00
+      """
+    And I run `wp post list --field=post_date_gmt`
+    Then STDOUT should contain:
+      """
+      2018-07-02 00:00:00
+      """
+
+  Scenario: Generating posts with post_date_gmt argument without time
+    When I run `wp post generate --count=1 --post_date_gmt="2018-07-03"`
+    And I run `wp post list --field=post_date`
+    Then STDOUT should contain:
+      """
+      2018-07-03 00:00:00
+      """
+    And I run `wp post list --field=post_date_gmt`
+    Then STDOUT should contain:
+      """
+      2018-07-03 00:00:00
+      """
+
+  Scenario: Generating posts with post_date_gmt argument with time
+    When I run `wp post generate --count=1 --post_date_gmt="2018-07-04 00:00:00"`
+    And I run `wp post list --field=post_date`
+    Then STDOUT should contain:
+      """
+      2018-07-04 00:00:00
+      """
+    And I run `wp post list --field=post_date_gmt`
+    Then STDOUT should contain:
+      """
+      2018-07-04 00:00:00
+      """

--- a/features/post-generate.feature
+++ b/features/post-generate.feature
@@ -75,16 +75,16 @@ Feature: Generate new WordPress posts
       """
 
   Scenario: Generating posts with post_date argument with time
-    When I run `wp post generate --count=1 --post_date="2018-07-02 00:00:00"`
+    When I run `wp post generate --count=1 --post_date="2018-07-02 02:21:05"`
     And I run `wp post list --field=post_date`
     Then STDOUT should contain:
       """
-      2018-07-02 00:00:00
+      2018-07-02 02:21:05
       """
     And I run `wp post list --field=post_date_gmt`
     Then STDOUT should contain:
       """
-      2018-07-02 00:00:00
+      2018-07-02 02:21:05
       """
 
   Scenario: Generating posts with post_date_gmt argument without time
@@ -101,16 +101,16 @@ Feature: Generate new WordPress posts
       """
 
   Scenario: Generating posts with post_date_gmt argument with time
-    When I run `wp post generate --count=1 --post_date_gmt="2018-07-04 00:00:00"`
+    When I run `wp post generate --count=1 --post_date_gmt="2018-07-04 12:34:56"`
     And I run `wp post list --field=post_date`
     Then STDOUT should contain:
       """
-      2018-07-04 00:00:00
+      2018-07-04 12:34:56
       """
     And I run `wp post list --field=post_date_gmt`
     Then STDOUT should contain:
       """
-      2018-07-04 00:00:00
+      2018-07-04 12:34:56
       """
 
   Scenario: Generating posts with post_date argument with hyphenated time

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -683,15 +683,21 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 			'post_type' => 'post',
 			'post_status' => 'publish',
 			'post_author' => false,
-			'post_date' => current_time( 'mysql' ),
+			'post_date' => false,
 			'post_date_gmt' => false,
 			'post_content' => '',
 			'post_title' => '',
 		);
 		extract( array_merge( $defaults, $assoc_args ), EXTR_SKIP );
 
+		$call_time = current_time( 'mysql' );
+
 		if ( $post_date_gmt === false ) {
-			$post_date_gmt = $post_date;
+			$post_date_gmt = $post_date ? $post_date : $call_time;
+		}
+
+		if ( $post_date === false ) {
+			$post_date = $post_date_gmt ? $post_date_gmt : $call_time;
 		}
 
 		// @codingStandardsIgnoreStart

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -634,6 +634,9 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 * [--post_date=<yyyy-mm-dd-hh-ii-ss>]
 	 * : The date of the generated posts. Default: current date
 	 *
+	 * [--post_date_gmt=<yyyy-mm-dd-hh-ii-ss>]
+	 * : The GMT date of the generated posts. Default: value of post_date (or current date if it's not set)
+	 *
 	 * [--post_content]
 	 * : If set, the command reads the post_content from STDIN.
 	 *
@@ -681,10 +684,15 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 			'post_status' => 'publish',
 			'post_author' => false,
 			'post_date' => current_time( 'mysql' ),
+			'post_date_gmt' => false,
 			'post_content' => '',
 			'post_title' => '',
 		);
 		extract( array_merge( $defaults, $assoc_args ), EXTR_SKIP );
+
+		if ( $post_date_gmt === false ) {
+			$post_date_gmt = $post_date;
+		}
 
 		// @codingStandardsIgnoreStart
 		if ( !post_type_exists( $post_type ) ) {
@@ -745,6 +753,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 				'post_parent' => $current_parent,
 				'post_name' => ! empty( $post_title  ) ? sanitize_title( $post_title . ( $i === $total ) ? '' : '-$i' ) : "post-$i",
 				'post_date' => $post_date,
+				'post_date_gmt' => $post_date_gmt,
 				'post_content' => $post_content,
 			);
 


### PR DESCRIPTION
Sets the GMT / UTC date of the generated posts. 

If the `--post_date_gmt` flag is provided, use that.
If not, default to the value of post_date (which defaults to the current date if _it's_ not set).

Fixes #183