### PR TITLE
Reset option value to default for privacy policy on site empty

### DIFF
--- a/features/site-empty.feature
+++ b/features/site-empty.feature
@@ -29,6 +29,21 @@ Feature: Empty a WordPress site of its data
       Success: Created post_tag 2.
       """
 
+    When I run `wp post create --post_type=page --post_title='Sample Privacy Page' --post_content='Sample Privacy Terms' --porcelain`
+    Then save STDOUT as {PAGE_ID}
+
+    When I run `wp option set wp_page_for_privacy_policy {PAGE_ID}`
+    Then STDOUT should be:
+      """
+      Success: Updated 'wp_page_for_privacy_policy' option.
+      """
+
+    When I run `wp option get wp_page_for_privacy_policy`
+    Then STDOUT should be:
+      """
+      {PAGE_ID}
+      """
+
     When I run `wp site empty --yes`
     Then STDOUT should be:
       """

--- a/features/site-empty.feature
+++ b/features/site-empty.feature
@@ -42,6 +42,12 @@ Feature: Empty a WordPress site of its data
     When I run `wp term list post_tag --format=ids`
     Then STDOUT should be empty
 
+    When I run `wp option get wp_page_for_privacy_policy`
+    Then STDOUT should be:
+      """
+      0
+      """
+
   Scenario: Empty a site and its uploads directory
     Given a WP multisite installation
     And I run `wp site create --slug=foo`

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -136,6 +136,14 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 	}
 
 	/**
+	 * Reset option values to default.
+	 */
+	private function _reset_options() {
+		// Reset Privacy Policy value to prevent error.
+		update_option( 'wp_page_for_privacy_policy', 0 );
+	}
+
+	/**
 	 * Empties a site of its content (posts, comments, terms, and meta).
 	 *
 	 * Truncates posts, comments, and terms tables to empty a site of its
@@ -186,6 +194,7 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 		$this->_empty_comments();
 		$this->_empty_taxonomies();
 		$this->_insert_default_terms();
+		$this->_reset_options();
 
 		if ( ! empty( $upload_message ) ) {
 			$upload_dir = wp_upload_dir();


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-cli/issues/5086