### PR TITLE
Add count to post-type and taxonomy commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -3037,7 +3037,7 @@ wp post-type get <post-type> [--field=<field>] [--fields=<fields>] [--format=<fo
 
 **AVAILABLE FIELDS**
 
-These fields will be displayed by default for each post type:
+These fields will be displayed by default for the specified post type:
 
 * name
 * label
@@ -3049,7 +3049,9 @@ These fields will be displayed by default for each post type:
 * cap
 * supports
 
-There are no optionally available fields.
+These fields are optionally available:
+
+* count
 
 **EXAMPLES**
 
@@ -3101,7 +3103,9 @@ These fields will be displayed by default for each post type:
 * public
 * capability_type
 
-There are no optionally available fields.
+These fields are optionally available:
+
+* count
 
 **EXAMPLES**
 
@@ -3618,6 +3622,24 @@ wp taxonomy get <taxonomy> [--field=<field>] [--fields=<fields>] [--format=<form
 		  - yaml
 		---
 
+**AVAILABLE FIELDS**
+
+These fields will be displayed by default for the specified taxonomy:
+
+* name
+* label
+* description
+* object_type
+* show_tagcloud
+* hierarchical
+* public
+* labels
+* cap
+
+These fields are optionally available:
+
+* count
+
 **EXAMPLES**
 
     # Get details of `category` taxonomy.
@@ -3674,10 +3696,14 @@ These fields will be displayed by default for each term:
 * name
 * label
 * description
-* public
+* object_type
+* show_tagcloud
 * hierarchical
+* public
 
-There are no optionally available fields.
+These fields are optionally available:
+
+* count
 
 **EXAMPLES**
 

--- a/features/post-type.feature
+++ b/features/post-type.feature
@@ -6,9 +6,17 @@ Feature: Manage WordPress post types
   Scenario: Listing post types
     When I run `wp post-type list --format=csv`
     Then STDOUT should be CSV containing:
-  | name | label | description | hierarchical | public | capability_type |
-  | post | Posts |             |              | 1      | post            |
-  | page | Pages |             | 1            | 1      | page            |
+      | name | label | description | hierarchical | public | capability_type |
+      | post | Posts |             |              | 1      | post            |
+      | page | Pages |             | 1            | 1      | page            |
+
+  @require-wp-5.0
+  Scenario: Listing post types with count
+    When I run `wp post-type list --fields=name,count --format=csv`
+    Then STDOUT should be CSV containing:
+      | name | count |
+      | post | 1     |
+      | page | 2     |
 
   Scenario: Get a post type
     When I try `wp post-type get invalid-post-type`
@@ -31,3 +39,11 @@ Feature: Manage WordPress post types
       """
       "title":true
       """
+
+  @require-wp-5.0
+  Scenario: Get a post type with count
+    When I try `wp post-type get page --fields=name,count`
+    Then STDOUT should be a table containing rows:
+      | Field       | Value     |
+      | name        | page      |
+      | count       | 2         |

--- a/features/taxonomy.feature
+++ b/features/taxonomy.feature
@@ -16,6 +16,14 @@ Feature: Manage WordPress taxonomies
       | name     | label            | description | object_type   | show_tagcloud | hierarchical | public |
       | nav_menu | Navigation Menus |             | nav_menu_item |               |              |        |
 
+  @require-wp-5.0
+  Scenario: Listing taxonomies with counts
+    When I run `wp taxonomy list --fields=name,count --format=csv`
+    Then STDOUT should be CSV containing:
+      | name     | count      |
+      | category | 1          |
+      | post_tag | 0          |
+
   Scenario: Get taxonomy
     When I try `wp taxonomy get invalid-taxonomy`
     Then STDERR should be:
@@ -30,3 +38,11 @@ Feature: Manage WordPress taxonomies
       | name        | category   |
       | object_type | ["post"]   |
       | label       | Categories |
+
+  @require-wp-5.0
+  Scenario: Get taxonomy with count
+    When I run `wp taxonomy get category --fields=name,count`
+    Then STDOUT should be a table containing rows:
+      | Field       | Value      |
+      | name        | category   |
+      | count       | 1          |


### PR DESCRIPTION
Fixes wp-cli/wp-cli#4573.

I took the liberty of implementing the term count for the `taxonomy` command as well even though it was not mentioned in the original issue as it is in a very similar situation.

Feedback is very much welcome.