### PR TITLE
Improve grammar on a successful comment spam.

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,7 +650,7 @@ wp comment spam <id>...
 
     # Spam comment.
     $ wp comment spam 1337
-    Success: Marked as spam comment 1337.
+    Success: Marked comment 1337 as spam.
 
 
 

--- a/features/comment.feature
+++ b/features/comment.feature
@@ -276,7 +276,7 @@ Feature: Manage WordPress comments
     When I run `wp comment spam {COMMENT_ID}`
     Then STDOUT should be:
       """
-      Success: Marked as spam comment {COMMENT_ID}.
+      Success: Marked comment {COMMENT_ID} as spam.
       """
 
     When I run `wp comment list --format=count --status=spam`
@@ -301,7 +301,7 @@ Feature: Manage WordPress comments
     When I run `wp comment spam {COMMENT_ID}`
     Then STDOUT should be:
       """
-      Success: Marked as spam comment {COMMENT_ID}.
+      Success: Marked comment {COMMENT_ID} as spam.
       """
 
     When I try `wp comment unspam {COMMENT_ID}`

--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -432,11 +432,11 @@ class Comment_Command extends CommandWithDBObject {
 			WP_CLI::error( "{$failure} comment {$comment_id}." );
 		}
 
-        if ( 'spam' === $status ) {
-            WP_CLI::success( "{$success} comment {$comment_id} as spam." );
-        } else {
-            WP_CLI::success( "{$success} comment {$comment_id}." );
-        }
+		if ( 'spam' === $status ) {
+			WP_CLI::success( "{$success} comment {$comment_id} as spam." );
+		} else {
+			WP_CLI::success( "{$success} comment {$comment_id}." );
+		}
 	}
 
 	private function set_status( $args, $status, $success ) {
@@ -518,7 +518,7 @@ class Comment_Command extends CommandWithDBObject {
 	 */
 	public function spam( $args, $assoc_args ) {
 		foreach ( $args as $id ) {
-            $this->call( $id, __FUNCTION__, 'Marked', 'Failed marking as spam' );
+			$this->call( $id, __FUNCTION__, 'Marked', 'Failed marking as spam' );
 		}
 	}
 

--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -431,8 +431,12 @@ class Comment_Command extends CommandWithDBObject {
 		if ( ! $func( $comment_id ) ) {
 			WP_CLI::error( "{$failure} comment {$comment_id}." );
 		}
-
-		WP_CLI::success( "{$success} comment {$comment_id}." );
+		
+		if ( 'spam' === $status ) {
+			WP_CLI::success( "{$success} comment {$comment_id} as spam." );	
+		} else {
+			WP_CLI::success( "{$success} comment {$comment_id}." );
+		}
 	}
 
 	private function set_status( $args, $status, $success ) {
@@ -510,11 +514,11 @@ class Comment_Command extends CommandWithDBObject {
 	 *
 	 *     # Spam comment.
 	 *     $ wp comment spam 1337
-	 *     Success: Marked as spam comment 1337.
+	 *     Success: Marked comment 1337 as spam.
 	 */
 	public function spam( $args, $assoc_args ) {
 		foreach ( $args as $id ) {
-			$this->call( $id, __FUNCTION__, 'Marked as spam', 'Failed marking as spam' );
+			$this->call( $id, __FUNCTION__, 'Marked', 'Failed marking as spam' );
 		}
 	}
 

--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -431,12 +431,12 @@ class Comment_Command extends CommandWithDBObject {
 		if ( ! $func( $comment_id ) ) {
 			WP_CLI::error( "{$failure} comment {$comment_id}." );
 		}
-		
-		if ( 'spam' === $status ) {
-			WP_CLI::success( "{$success} comment {$comment_id} as spam." );	
-		} else {
-			WP_CLI::success( "{$success} comment {$comment_id}." );
-		}
+
+        if ( 'spam' === $status ) {
+            WP_CLI::success( "{$success} comment {$comment_id} as spam." );
+        } else {
+            WP_CLI::success( "{$success} comment {$comment_id}." );
+        }
 	}
 
 	private function set_status( $args, $status, $success ) {
@@ -518,7 +518,7 @@ class Comment_Command extends CommandWithDBObject {
 	 */
 	public function spam( $args, $assoc_args ) {
 		foreach ( $args as $id ) {
-			$this->call( $id, __FUNCTION__, 'Marked', 'Failed marking as spam' );
+            $this->call( $id, __FUNCTION__, 'Marked', 'Failed marking as spam' );
 		}
 	}
 

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -702,7 +702,7 @@ class Post_Command extends CommandWithDBObject {
 	 *     Generating posts  100% [================================================] 0:01 / 0:04
 	 *
 	 *     # Generate posts with fetched content.
-	 *     $ curl http://loripsum.net/api/5 | wp post generate --post_content --count=10
+	 *     $ curl -N http://loripsum.net/api/5 | wp post generate --post_content --count=10
 	 *       % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
 	 *                                      Dload  Upload   Total   Spent    Left  Speed
 	 *     100  2509  100  2509    0     0    616      0  0:00:04  0:00:04 --:--:--   616

--- a/src/User_Session_Command.php
+++ b/src/User_Session_Command.php
@@ -176,7 +176,7 @@ class User_Session_Command extends WP_CLI_Command {
 
 		array_walk(
 			$sessions,
-			function( & $session, $token ) {
+			function( &$session, $token ) {
 				$session['token']           = $token;
 				$session['login_time']      = date( 'Y-m-d H:i:s', $session['login'] );
 				$session['expiration_time'] = date( 'Y-m-d H:i:s', $session['expiration'] );


### PR DESCRIPTION
This PR fixes issue #259

Command Tests:
`$ ./vendor/bin/wp comment spam 1
Success: Marked comment 1 as spam.

$ ./vendor/bin/wp comment unspam 1
Success: Unspammed comment 1.

$ ./vendor/bin/wp comment spam 0
Error: Failed marking as spam comment 0.
`