### PR TITLE
Reset user password send error when no user is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -5216,7 +5216,7 @@ wp user reset-password <user>... [--skip-email]
     $ wp user reset-password admin editor
     Reset password for admin.
     Reset password for editor.
-    Success: Passwords reset.
+    Success: Passwords reset for 2 users.
 
 
 

--- a/features/user-reset-password.feature
+++ b/features/user-reset-password.feature
@@ -11,7 +11,7 @@ Feature: Reset passwords for one or more WordPress users.
     Then STDOUT should contain:
       """
       Reset password for admin.
-      Success: Password reset.
+      Success: Password reset for 1 user.
       """
     And an email should be sent
 
@@ -32,7 +32,7 @@ Feature: Reset passwords for one or more WordPress users.
     Then STDOUT should contain:
       """
       Reset password for admin.
-      Success: Password reset.
+      Success: Password reset for 1 user.
       """
     And an email should not be sent
 

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -702,7 +702,7 @@ class Post_Command extends CommandWithDBObject {
 	 *     Generating posts  100% [================================================] 0:01 / 0:04
 	 *
 	 *     # Generate posts with fetched content.
-	 *     $ curl http://loripsum.net/api/5 | wp post generate --post_content --count=10
+	 *     $ curl -N http://loripsum.net/api/5 | wp post generate --post_content --count=10
 	 *       % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
 	 *                                      Dload  Upload   Total   Spent    Left  Speed
 	 *     100  2509  100  2509    0     0    616      0  0:00:04  0:00:04 --:--:--   616

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -1104,12 +1104,12 @@ class User_Command extends CommandWithDBObject {
 		}
 
 		$reset_user_count = count( $users );
-		if( $reset_user_count === 1 ) {
-			WP_CLI::success( "Password reset for {$reset_user_count} user.");
+		if ( $reset_user_count === 1 ) {
+			WP_CLI::success( "Password reset for {$reset_user_count} user." );
 		} elseif ( $reset_user_count > 1 ) {
-			WP_CLI::success( "Passwords reset for {$reset_user_count} users.");
+			WP_CLI::success( "Passwords reset for {$reset_user_count} users." );
 		} else {
-			WP_CLI::error( "No user found to reset password." );
+			WP_CLI::error( 'No user found to reset password.' );
 		}
 	}
 

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -1079,7 +1079,7 @@ class User_Command extends CommandWithDBObject {
 	 *     $ wp user reset-password admin editor
 	 *     Reset password for admin.
 	 *     Reset password for editor.
-	 *     Success: Passwords reset.
+	 *     Success: Passwords reset for 2 users.
 	 *
 	 * @subcommand reset-password
 	 */
@@ -1102,7 +1102,15 @@ class User_Command extends CommandWithDBObject {
 		if ( $skip_email ) {
 			remove_filter( 'send_password_change_email', '__return_false' );
 		}
-		WP_CLI::success( count( $users ) > 1 ? 'Passwords reset.' : 'Password reset.' );
+
+		$reset_user_count = count( $users );
+		if( $reset_user_count === 1 ) {
+			WP_CLI::success( "Password reset for {$reset_user_count} user.");
+		} elseif ( $reset_user_count > 1 ) {
+			WP_CLI::success( "Passwords reset for {$reset_user_count} users.");
+		} else {
+			WP_CLI::error( "No user found to reset password." );
+		}
 	}
 
 	/**

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -1104,7 +1104,7 @@ class User_Command extends CommandWithDBObject {
 		}
 
 		$reset_user_count = count( $users );
-		if ( $reset_user_count === 1 ) {
+		if ( 1 === $reset_user_count ) {
 			WP_CLI::success( "Password reset for {$reset_user_count} user." );
 		} elseif ( $reset_user_count > 1 ) {
 			WP_CLI::success( "Passwords reset for {$reset_user_count} users." );

--- a/src/User_Session_Command.php
+++ b/src/User_Session_Command.php
@@ -176,7 +176,7 @@ class User_Session_Command extends WP_CLI_Command {
 
 		array_walk(
 			$sessions,
-			function( & $session, $token ) {
+			function( &$session, $token ) {
 				$session['token']           = $token;
 				$session['login_time']      = date( 'Y-m-d H:i:s', $session['login'] );
 				$session['expiration_time'] = date( 'Y-m-d H:i:s', $session['expiration'] );


### PR DESCRIPTION
This fixes issue #258
The success message was changed also to show the number of successful password reset. This was done to resolve the case when there are both valid and invalid users.

`
$ ./vendor/bin/wp user reset-password 0 invalid-user
Warning: Invalid user ID, email or login: '0'
Warning: Invalid user ID, email or login: 'invalid-user'
Error: No user found to reset password.

$ ./vendor/bin/wp user reset-password 0 invalid-user user1
Warning: Invalid user ID, email or login: '0'
Warning: Invalid user ID, email or login: 'invalid-user'
Reset password for user1.
Success: Password reset for 1 user.
`