### PR TITLE
Add preliminary PHP 7.4 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 dist: trusty
 
 language: php
-php: 7.2
+php: 7.3
 
 notifications:
   email:
@@ -51,6 +51,9 @@ jobs:
         - composer phpcs
       env: BUILD=sniff
     - stage: test
+      php: 7.4snapshot
+      env: WP_VERSION=latest
+    - stage: test
       php: 7.3
       env: WP_VERSION=latest
     - stage: test
@@ -75,3 +78,7 @@ jobs:
       php: 5.4
       dist: precise
       env: WP_VERSION=5.1
+  allow_failures:
+    - stage: test
+      php: 7.4snapshot
+      env: WP_VERSION=latest

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -378,7 +378,7 @@ class User_Command extends CommandWithDBObject {
 		$user->user_registered = Utils\get_flag_value(
 			$assoc_args,
 			'user_registered',
-			strftime( '%F %T', current_time( 'timestamp' ) )
+			strftime( '%F %T', current_time( 'timestamp' ) ) // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp
 		);
 
 		$user->display_name = Utils\get_flag_value( $assoc_args, 'display_name', false );
@@ -1185,7 +1185,7 @@ class User_Command extends CommandWithDBObject {
 			WP_CLI::error( 'This is not a multisite installation.' );
 		}
 
-		if ( 'spam' === $pref && '1' === $value ) {
+		if ( 'spam' === $pref ) {
 			$action = (int) $value ? 'marked as spam' : 'removed from spam';
 			$verb   = (int) $value ? 'spam' : 'unspam';
 		}
@@ -1231,7 +1231,12 @@ class User_Command extends CommandWithDBObject {
 			}
 
 			// Set status and show message.
-			update_user_status( $user_id, $pref, $value );
+			wp_update_user(
+				[
+					'ID'  => $user_id,
+					$pref => $value,
+				]
+			);
 			WP_CLI::log( "User {$user_id} {$action}." );
 			$successes++;
 		}

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -50,6 +50,9 @@ class User_Command extends CommandWithDBObject {
 		'name',
 	];
 
+	/** Intermediate storage for a BC filter */
+	private $value_for_spam;
+
 	public function __construct() {
 		$this->fetcher     = new UserFetcher();
 		$this->sitefetcher = new SiteFetcher();
@@ -1220,8 +1223,8 @@ class User_Command extends CommandWithDBObject {
 			}
 
 			// Make that user's blog as spam too.
-			$blogs = get_blogs_of_user( $user_id, true );
-			foreach ( (array) $blogs as $details ) {
+			$blogs = (array) get_blogs_of_user( $user_id, true );
+			foreach ( $blogs as $details ) {
 				$site = $this->sitefetcher->get_check( $details->site_id );
 
 				// Main blog shouldn't a spam !
@@ -1230,18 +1233,57 @@ class User_Command extends CommandWithDBObject {
 				}
 			}
 
-			// Set status and show message.
-			wp_update_user(
-				[
-					'ID'  => $user_id,
-					$pref => $value,
-				]
-			);
+			if ( Utils\wp_version_compare( '5.3', '<' ) ) {
+				/*
+				 * Provide fallback for WP < 5.3 so as to use the preferred
+				 * method wp_update_user().
+				 * See https://core.trac.wordpress.org/ticket/45747
+				 */
+				$this->value_for_spam = $value;
+				add_filter( 'wp_pre_insert_user_data', [ $this, 'set_spam_value' ], 10, 3 );
+				wp_update_user(
+					[
+						'ID'  => $user_id,
+						$pref => $value,
+					]
+				);
+				remove_filter( 'wp_pre_insert_user_data', [ $this, 'set_spam_value' ], 10 );
+				if ( 1 === (int) $value ) {
+					do_action( 'make_spam_user', $user_id );
+				} else {
+					do_action( 'make_ham_user', $user_id );
+				}
+			} else {
+				wp_update_user(
+					[
+						'ID'  => $user_id,
+						$pref => $value,
+					]
+				);
+			}
+
 			WP_CLI::log( "User {$user_id} {$action}." );
 			$successes++;
 		}
 
 		Utils\report_batch_operation_results( 'user', $verb, count( $user_ids ), $successes, $errors );
+	}
+
+	/**
+	 * Filter the user data to provide support spam user data value.
+	 *
+	 * This is only needed on WP < 5.3.
+	 *
+	 * See https://core.trac.wordpress.org/ticket/45747
+	 *
+	 * @param array    $data   Associative array of user data.
+	 * @param bool     $update Whether this is an update or a new user.
+	 * @param int|null $id     ID of the user in case of an update, null if not.
+	 * @return array Modified associative array of user data.
+	 */
+	public function set_spam_value( $data, $update, $id ) {
+		$data['spam'] = $this->value_for_spam;
+		return $data;
 	}
 
 	/**

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -1248,11 +1248,13 @@ class User_Command extends CommandWithDBObject {
 					]
 				);
 				remove_filter( 'wp_pre_insert_user_data', [ $this, 'set_spam_value' ], 10 );
+				// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- We want to fake Core actions.
 				if ( 1 === (int) $value ) {
 					do_action( 'make_spam_user', $user_id );
 				} else {
 					do_action( 'make_ham_user', $user_id );
 				}
+				// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			} else {
 				wp_update_user(
 					[

--- a/src/User_Session_Command.php
+++ b/src/User_Session_Command.php
@@ -178,8 +178,8 @@ class User_Session_Command extends WP_CLI_Command {
 			$sessions,
 			function( &$session, $token ) {
 				$session['token']           = $token;
-				$session['login_time']      = date( 'Y-m-d H:i:s', $session['login'] );
-				$session['expiration_time'] = date( 'Y-m-d H:i:s', $session['expiration'] );
+				$session['login_time']      = date( 'Y-m-d H:i:s', $session['login'] ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+				$session['expiration_time'] = date( 'Y-m-d H:i:s', $session['expiration'] ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 			}
 		);
 


### PR DESCRIPTION
The testing step for PHP 7.4 is still allowed to fail for now while we prepare the code base for the upcoming release.