### PR TITLE
Update `site empty` command to include removal of `wp_links` table data

### DIFF
--- a/features/site-empty.feature
+++ b/features/site-empty.feature
@@ -6,6 +6,21 @@ Feature: Empty a WordPress site of its data
     And download:
       | path                        | url                                              |
       | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
+    And a insert_link_data.sql file:
+      """
+      INSERT INTO `wp_links` (`link_url`, `link_name`, `link_image`, `link_target`, `link_description`, `link_visible`, `link_owner`, `link_rating`, `link_rel`, `link_notes`, `link_rss`)
+      VALUES ('http://wordpress.org/', 'test', '', '', 'test', 'Y', 1, 0, '', '', '')
+      """
+
+    When I run `wp db query "SOURCE insert_link_data.sql;"`
+    Then STDERR should be empty
+
+    When I run `wp db query "SELECT COUNT(link_id) FROM wp_links;"`
+    Then STDOUT should be:
+      """
+      COUNT(link_id)
+      1
+      """
 
     When I run `wp media import {CACHE_DIR}/large-image.jpg --post_id=1`
     Then the wp-content/uploads/large-image.jpg file should exist
@@ -60,6 +75,13 @@ Feature: Empty a WordPress site of its data
     When I run `wp option get wp_page_for_privacy_policy`
     Then STDOUT should be:
       """
+      0
+      """
+
+    When I run `wp db query "SELECT COUNT(link_id) FROM wp_links;"`
+    Then STDOUT should be:
+      """
+      COUNT(link_id)
       0
       """
 

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -116,6 +116,34 @@ class Site_Command extends CommandWithDBObject {
 	}
 
 	/**
+	 * Delete all links, link_category terms, and related cache.
+	 */
+	private function empty_links() {
+		global $wpdb;
+
+		// Remove links and related cached data.
+		$links_query = "SELECT link_id FROM $wpdb->links";
+		$links       = new QueryIterator( $links_query, 10000 );
+
+		// Remove bookmarks cache group.
+		wp_cache_delete( 'get_bookmarks', 'bookmark' );
+
+		while ( $links->valid() ) {
+			$link_id = $links->current()->link_id;
+
+			// Remove cache for the link.
+			wp_delete_object_term_relationships( $link_id, 'link_category' );
+			wp_cache_delete( $link_id, 'bookmark' );
+			clean_object_term_cache( $link_id, 'link' );
+
+			$links->next();
+		}
+
+		// Empty the table once link related cache and term is removed.
+		$wpdb->query( "TRUNCATE $wpdb->links" );
+	}
+
+	/**
 	 * Insert default terms.
 	 */
 	private function insert_default_terms() {
@@ -211,7 +239,7 @@ class Site_Command extends CommandWithDBObject {
 	 * ## EXAMPLES
 	 *
 	 *     $ wp site empty
-	 *     Are you sure you want to empty the site at http://www.example.com of all posts, comments, and terms? [y/n] y
+	 *     Are you sure you want to empty the site at http://www.example.com of all posts, links, comments, and terms? [y/n] y
 	 *     Success: The site at 'http://www.example.com' was emptied.
 	 *
 	 * @subcommand empty
@@ -223,9 +251,10 @@ class Site_Command extends CommandWithDBObject {
 			$upload_message = ', and delete its uploads directory';
 		}
 
-		WP_CLI::confirm( "Are you sure you want to empty the site at '" . site_url() . "' of all posts, comments, and terms" . $upload_message . '?', $assoc_args );
+		WP_CLI::confirm( "Are you sure you want to empty the site at '" . site_url() . "' of all posts, links, comments, and terms" . $upload_message . '?', $assoc_args );
 
 		$this->empty_posts();
+		$this->empty_links();
 		$this->empty_comments();
 		$this->empty_taxonomies();
 		$this->insert_default_terms();

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -122,7 +122,7 @@ class Site_Command extends CommandWithDBObject {
 		global $wpdb;
 
 		// Remove links and related cached data.
-		$links_query = "SELECT link_id FROM $wpdb->links";
+		$links_query = "SELECT link_id FROM {$wpdb->links}";
 		$links       = new QueryIterator( $links_query, 10000 );
 
 		// Remove bookmarks cache group.
@@ -140,7 +140,7 @@ class Site_Command extends CommandWithDBObject {
 		}
 
 		// Empty the table once link related cache and term is removed.
-		$wpdb->query( "TRUNCATE $wpdb->links" );
+		$wpdb->query( "TRUNCATE {$wpdb->links}" );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #261