### PR TITLE
Add wp_slash() option to the check-password subcommand

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -85,6 +85,28 @@ Feature: Manage WordPress users
       """
     And the return code should be 1
 
+    When I run `wp user create testuser3b testuser3b@example.com --user_pass="test\"user3b's\pass\!"`
+    Then STDOUT should not contain:
+       """
+       Password:
+       """
+
+    # Check password without the `--escape-chars` option.
+    When I try `wp user check-password testuser3b "test\"user3b's\pass\!"`
+    Then STDERR should be:
+      """
+      Warning: Password contains characters that need to be escaped. Please escape them manually or use the `--escape-chars` option.
+      """
+    And the return code should be 1
+
+    # Check password with the `--escape-chars` option.
+    When I try `wp user check-password testuser3b "test\"user3b's\pass\!" --escape-chars`
+    Then the return code should be 0
+
+    # Check password with manually escaped characters.
+    When I try `wp user check-password testuser3b "test\\\"user3b\'s\\\pass\\\!"`
+    Then the return code should be 0
+
   Scenario: Reassigning user posts
     Given a WP multisite install
 

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -1268,6 +1268,9 @@ class User_Command extends CommandWithDBObject {
 	 * <user_pass>
 	 * : A string that contains the plain text password for the user.
 	 *
+	 * [--escape-chars]
+	 * : Escape password with `wp_slash()` to mimic the same behavior as `wp-login.php`.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Check whether given credentials are valid; exit status 0 if valid, otherwise 1
@@ -1282,10 +1285,16 @@ class User_Command extends CommandWithDBObject {
 	 *
 	 * @subcommand check-password
 	 */
-	public function check_password( $args ) {
+	public function check_password( $args, $assoc_args ) {
+
+		$escape_chars = Utils\get_flag_value( $assoc_args, 'escape-chars', false );
+
+		if ( ! $escape_chars && wp_slash( wp_unslash( $args[1] ) ) !== $args[1] ) {
+			WP_CLI::warning( 'Password contains characters that need to be escaped. Please escape them manually or use the `--escape-chars` option.' );
+		}
 
 		$user      = $this->fetcher->get_check( $args[0] );
-		$user_pass = $args[1];
+		$user_pass = $escape_chars ? wp_slash( $args[1] ) : $args[1];
 
 		if ( wp_check_password( $user_pass, $user->data->user_pass, $user->ID ) ) {
 			WP_CLI::halt( 0 );

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -1286,7 +1286,6 @@ class User_Command extends CommandWithDBObject {
 	 * @subcommand check-password
 	 */
 	public function check_password( $args, $assoc_args ) {
-
 		$escape_chars = Utils\get_flag_value( $assoc_args, 'escape-chars', false );
 
 		if ( ! $escape_chars && wp_slash( wp_unslash( $args[1] ) ) !== $args[1] ) {


### PR DESCRIPTION
Partially addresses https://github.com/wp-cli/wp-cli/issues/5278

Should this be saved for WP-CLI 3.0? Potentially, yes.

This PR is done in a way that is backward compatible, so that manual escaping is still the norm and you can use a new flag to have WP-CLI escape the characters for you.

But IMHO automatic escaping via `wp_slash()` should be the default behavior, after all, this is how the `wp-login.php` POST works, and as described in https://github.com/wp-cli/wp-cli/issues/5278, the `wp user create` command doesn't require you to escape the password characters, and it stands to reason that you should be able to check the password using the exact same input.

Perhaps in the next major release we could change the flag value be `true` by default so users can simply do `--no-escape-chars` to get back the current 2.x behavior and escape everything manually.

**CURRENT BEHAVIOR**
```bash
wp user create admin admin@local.test --user_pass="admin'spass"
wp user check-password admin "admin'spass"
echo $?
1

wp user create admin admin@local.test --user_pass="admin'spass"
wp user check-password admin "admin\'spass"
echo $?
0
```

**NEW BEHAVIOR**
```bash
wp user create admin admin@local.test --user_pass="admin'spass"
wp user check-password admin "admin'spass"
Warning: Password contains characters that need to be escaped. Please escape them manually or use the `--escape-chars` option.
echo $?
1

wp user create admin admin@local.test --user_pass="admin'spass"
wp user check-password admin "admin'spass" --escape-chars
echo $?
0
```