### PR TITLE
Correct the home URL when listing sites

### DIFF
--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -614,7 +614,7 @@ class Site_Command extends CommandWithDBObject {
 		$iterator = Utils\iterator_map(
 			$iterator,
 			function( $blog ) {
-				$blog->url = trailingslashit( get_site_url( $blog->blog_id ) );
+				$blog->url = trailingslashit( get_home_url( $blog->blog_id ) );
 				return $blog;
 			}
 		);


### PR DESCRIPTION
Although not common on a Multisite installation, it is possible for the `home` and `siteurl` options to differ. In this situation the `wp site list` command returns the incorrect URL for the site. `get_home_url()` should be used as it returns the home URL.

All the existing tests pass. I wanted to add a functional test for this but I can't get the Behat tests to run locally, they're spitting out `Notice: Undefined index: DB_USER` errors. 