### PR TITLE
Update example input to reflect example output

### DIFF
--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -959,7 +959,7 @@ class Post_Command extends CommandWithDBObject {
 	 * ## EXAMPLES
 	 *
 	 *     # The post exists.
-	 *     $ wp post exists 1
+	 *     $ wp post exists 1337
 	 *     Success: Post with ID 1337 exists.
 	 *     $ echo $?
 	 *     0


### PR DESCRIPTION
This is (I know) a small documentation update that hardly matters *but* while looking at the command `wp post exists --help` I noticed the small inconsistency and figured I'd submit a quick patch instead of ignoring it.

Thanks <3