### PR TITLE
Add application password commands

### DIFF
--- a/entity-command.php
+++ b/entity-command.php
@@ -1,5 +1,7 @@
 <?php
 
+use WP_CLI\Utils;
+
 if ( ! class_exists( 'WP_CLI' ) ) {
 	return;
 }
@@ -63,26 +65,36 @@ WP_CLI::add_command(
 	'Term_Meta_Command',
 	array(
 		'before_invoke' => function() {
-			if ( \WP_CLI\Utils\wp_version_compare( '4.4', '<' ) ) {
+			if ( Utils\wp_version_compare( '4.4', '<' ) ) {
 				WP_CLI::error( 'Requires WordPress 4.4 or greater.' );
 			}
 		},
 	)
 );
 WP_CLI::add_command( 'user', 'User_Command' );
+WP_CLI::add_command(
+	'user application-password',
+	'User_Application_Password_Command',
+	array(
+		'before_invoke' => function() {
+			if ( Utils\wp_version_compare( '5.6', '<' ) ) {
+				WP_CLI::error( 'Requires WordPress 5.6 or greater.' );
+			}
+		},
+	)
+);
 WP_CLI::add_command( 'user meta', 'User_Meta_Command' );
 WP_CLI::add_command(
 	'user session',
 	'User_Session_Command',
 	array(
 		'before_invoke' => function() {
-			if ( \WP_CLI\Utils\wp_version_compare( '4.0', '<' ) ) {
+			if ( Utils\wp_version_compare( '4.0', '<' ) ) {
 				WP_CLI::error( 'Requires WordPress 4.0 or greater.' );
 			}
 		},
 	)
 );
-
 WP_CLI::add_command( 'user term', 'User_Term_Command' );
 
 if ( class_exists( 'WP_CLI\Dispatcher\CommandNamespace' ) ) {

--- a/features/user-application-password.feature
+++ b/features/user-application-password.feature
@@ -1,0 +1,219 @@
+Feature: Manage user custom fields
+
+  Scenario: User application password CRUD
+    Given a WP install
+
+    When I run `wp user application-password create 1 myapp`
+    Then STDOUT should not be empty
+
+    When I run `wp user application-password list 1`
+    Then STDOUT should contain:
+      """
+      myapp
+      """
+
+    When I run `wp user application-password list 1 --name=myapp --field=uuid`
+    And save STDOUT as {UUID}
+    And I run `wp user application-password get 1 {UUID}`
+    Then STDOUT should contain:
+      """
+      myapp
+      """
+
+    When I try `wp user application-password get 2 {UUID}`
+    Then STDERR should be:
+      """
+      Error: Invalid user ID, email or login: '2'
+      """
+    And the return code should be 1
+
+    When I try `wp user application-password get 1 123`
+    Then STDERR should be:
+      """
+      Error: No application password found for this user ID and UUID.
+      """
+    And the return code should be 1
+
+    When I run `wp user application-password update 1 {UUID} --name=anotherapp`
+    Then STDOUT should not be empty
+
+    When I run `wp user application-password get 1 {UUID}`
+    Then STDOUT should contain:
+      """
+      anotherapp
+      """
+    Then STDOUT should not contain:
+      """
+      myapp
+      """
+
+    When I run `wp user application-password delete 1 {UUID}`
+    Then STDOUT should contain:
+      """
+      Success: Deleted 1 of 1 application password.
+      """
+
+    When I try `wp user application-password get 1 {UUID}`
+    Then the return code should be 1
+
+    When I run `wp user application-password create 1 myapp1`
+    And I run `wp user application-password create 1 myapp2`
+    And I run `wp user application-password create 1 myapp3`
+    And I run `wp user application-password create 1 myapp4`
+    And I run `wp user application-password create 1 myapp5`
+    Then STDOUT should not be empty
+
+    When I run `wp user application-password list 1 --format=count`
+    Then STDOUT should be:
+      """
+      5
+      """
+
+    When I run `wp user application-password list 1 --name=myapp1 --field=uuid`
+    And save STDOUT as {UUID1}
+    And I run `wp user application-password list 1 --name=myapp2 --field=uuid`
+    And save STDOUT as {UUID2}
+    When I try `wp user application-password delete 1 {UUID1} {UUID2} nonsense`
+    Then STDERR should contain:
+      """
+      Warning: Failed to delete UUID nonsense
+      """
+    Then STDOUT should contain:
+      """
+      Success: Deleted 2 of 3 application passwords.
+      """
+
+    When I run `wp user application-password list 1 --format=count`
+    Then STDOUT should be:
+      """
+      3
+      """
+
+    When I run `wp user application-password delete 1 --all`
+    And I run `wp user application-password list 1 --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+  Scenario: List user application passwords
+    Given a WP install
+
+    When I run `wp user application-password create 1 myapp1`
+    Then STDOUT should not be empty
+
+    When I run `wp user application-password create 1 myapp2`
+    Then STDOUT should not be empty
+
+    When I run `wp user application-password list 1 --name=myapp1 --field=uuid`
+    Then save STDOUT as {UUID1}
+
+    When I run `wp user application-password list 1 --name=myapp2 --field=uuid`
+    Then save STDOUT as {UUID2}
+
+    When I run `wp user application-password list 1 --name=myapp1 --field=password`
+    Then save STDOUT as {HASH1}
+
+    When I run `wp user application-password list 1 --name=myapp1 --field=password | sed 's#/#\\\/#g'`
+    Then save STDOUT as {JSONHASH1}
+
+    When I run `wp user application-password list 1 --name=myapp2 --field=password`
+    Then save STDOUT as {HASH2}
+
+    When I run `wp user application-password list 1 --name=myapp2 --field=password | sed 's#/#\\\/#g'`
+    Then save STDOUT as {JSONHASH2}
+
+    When I run `wp user application-password list 1 --name=myapp1 --field=created`
+    Then save STDOUT as {CREATED1}
+
+    When I run `wp user application-password list 1 --name=myapp2 --field=created`
+    Then save STDOUT as {CREATED2}
+
+    When I run `wp user application-password list 1 --format=json`
+    Then STDOUT should be JSON containing:
+      """
+      [{"uuid":"{UUID1}","app_id":"","name":"myapp1","password":"{JSONHASH1}","created":{CREATED1},"last_used":null,"last_ip":null},{"uuid":"{UUID2}","app_id":"","name":"myapp2","password":"{JSONHASH2}","created":{CREATED2},"last_used":null,"last_ip":null}]
+      """
+
+    When I run `wp user application-password list 1 --format=json --fields=uuid,name`
+    Then STDOUT should be JSON containing:
+      """
+      [{"uuid":"{UUID1}","name":"myapp1"},{"uuid":"{UUID2}","name":"myapp2"}]
+      """
+
+    When I run `wp user application-password list 1`
+    Then STDOUT should be a table containing rows:
+      | uuid    | app_id | name   | password | created    | last_used | last_ip |
+      | {UUID2} |        | myapp2 | {HASH2}  | {CREATED2} |           |         |
+      | {UUID1} |        | myapp1 | {HASH1}  | {CREATED1} |           |         |
+
+    When I run `wp user application-password list 1 --fields=uuid,app_id,name`
+    Then STDOUT should be a table containing rows:
+      | uuid    | app_id | name   |
+      | {UUID2} |        | myapp2 |
+      | {UUID1} |        | myapp1 |
+
+    When I run `wp user application-password list admin`
+    Then STDOUT should be a table containing rows:
+      | uuid    | app_id | name   | password | created    | last_used | last_ip |
+      | {UUID2} |        | myapp2 | {HASH2}  | {CREATED2} |           |         |
+      | {UUID1} |        | myapp1 | {HASH1}  | {CREATED1} |           |         |
+
+    When I run `wp user application-password list admin --orderby=created --order=asc`
+    Then STDOUT should be a table containing rows:
+      | uuid    | app_id | name   | password | created    | last_used | last_ip |
+      | {UUID1} |        | myapp1 | {HASH1}  | {CREATED1} |           |         |
+      | {UUID2} |        | myapp2 | {HASH2}  | {CREATED2} |           |         |
+
+    When I run `wp user application-password list admin --orderby=name --order=asc`
+    Then STDOUT should be a table containing rows:
+      | uuid    | app_id | name   | password | created    | last_used | last_ip |
+      | {UUID1} |        | myapp1 | {HASH1}  | {CREATED1} |           |         |
+      | {UUID2} |        | myapp2 | {HASH2}  | {CREATED2} |           |         |
+
+    When I run `wp user application-password list admin --orderby=name --order=desc`
+    Then STDOUT should be a table containing rows:
+      | uuid    | app_id | name   | password | created    | last_used | last_ip |
+      | {UUID2} |        | myapp2 | {HASH2}  | {CREATED2} |           |         |
+      | {UUID1} |        | myapp1 | {HASH1}  | {CREATED1} |           |         |
+
+    When I run `wp user application-password list admin --name=myapp2 --format=json`
+    Then STDOUT should contain:
+      """
+      myapp2
+      """
+    And STDOUT should not contain:
+      """
+      myapp1
+      """
+
+    When I run `wp user application-password list admin --field=name`
+    Then STDOUT should be:
+      """
+      myapp1
+      myapp2
+      """
+
+  Scenario: Get particular user application password hash
+    Given a WP install
+
+    When I run `wp user create testuser testuser@example.com --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {USER_ID}
+
+    When I try the previous command again
+    Then the return code should be 1
+
+    Given I run `wp user application-password create {USER_ID} someapp --porcelain`
+    And save STDOUT as {PASSWORD}
+    And I run `wp user application-password list {USER_ID} --name=someapp --field=uuid`
+    And save STDOUT as {UUID}
+
+    Given I run `wp user application-password get {USER_ID} {UUID} --field=password | sed 's/\$/\\\$/g'`
+    And save STDOUT as {HASH}
+
+    When I run `wp eval "var_export( wp_check_password( '{PASSWORD}', '{HASH}', {USER_ID} ) );"`
+    Then STDOUT should contain:
+      """
+      true
+      """

--- a/features/user-application-password.feature
+++ b/features/user-application-password.feature
@@ -1,5 +1,6 @@
 Feature: Manage user custom fields
 
+  @less-than-php-8.0
   Scenario: User application passwords are disabled for WordPress lower than 5.6
     Given a WP install
     And I try `wp theme install twentytwenty --activate`

--- a/features/user-application-password.feature
+++ b/features/user-application-password.feature
@@ -1,5 +1,35 @@
 Feature: Manage user custom fields
 
+  Scenario: User application passwords are disabled for WordPress lower than 5.6
+    Given a WP install
+    And I try `wp theme install twentytwenty --activate`
+    And I run `wp core download --version=5.5 --force`
+
+    When I try `wp user application-password create 1 myapp`
+    Then STDERR should contain:
+      """
+      Error: Requires WordPress 5.6 or greater.
+      """
+
+    When I try `wp user application-password list 1`
+    Then STDERR should contain:
+      """
+      Error: Requires WordPress 5.6 or greater.
+      """
+
+    When I try `wp user application-password get 1 123`
+    Then STDERR should contain:
+      """
+      Error: Requires WordPress 5.6 or greater.
+      """
+
+    When I try `wp user application-password delete 1 123`
+    Then STDERR should contain:
+      """
+      Error: Requires WordPress 5.6 or greater.
+      """
+
+  @require-wp-5.6
   Scenario: User application password CRUD
     Given a WP install
 
@@ -96,6 +126,7 @@ Feature: Manage user custom fields
       0
       """
 
+  @require-wp-5.6
   Scenario: List user application passwords
     Given a WP install
 
@@ -205,6 +236,7 @@ Feature: Manage user custom fields
       myapp2
       """
 
+  @require-wp-5.6
   Scenario: Get particular user application password hash
     Given a WP install
 

--- a/features/user-application-password.feature
+++ b/features/user-application-password.feature
@@ -130,15 +130,23 @@ Feature: Manage user custom fields
     Then save STDOUT as {CREATED2}
 
     When I run `wp user application-password list 1 --format=json`
-    Then STDOUT should be JSON containing:
+    Then STDOUT should contain:
       """
-      [{"uuid":"{UUID1}","app_id":"","name":"myapp1","password":"{JSONHASH1}","created":{CREATED1},"last_used":null,"last_ip":null},{"uuid":"{UUID2}","app_id":"","name":"myapp2","password":"{JSONHASH2}","created":{CREATED2},"last_used":null,"last_ip":null}]
+      {"uuid":"{UUID1}","app_id":"","name":"myapp1","password":"{JSONHASH1}","created":{CREATED1},"last_used":null,"last_ip":null}
+      """
+    And STDOUT should contain:
+      """
+      {"uuid":"{UUID2}","app_id":"","name":"myapp2","password":"{JSONHASH2}","created":{CREATED2},"last_used":null,"last_ip":null}
       """
 
     When I run `wp user application-password list 1 --format=json --fields=uuid,name`
-    Then STDOUT should be JSON containing:
+    Then STDOUT should contain:
       """
-      [{"uuid":"{UUID1}","name":"myapp1"},{"uuid":"{UUID2}","name":"myapp2"}]
+      {"uuid":"{UUID1}","name":"myapp1"}
+      """
+    And STDOUT should contain:
+      """
+      {"uuid":"{UUID2}","name":"myapp2"}
       """
 
     When I run `wp user application-password list 1`
@@ -188,9 +196,12 @@ Feature: Manage user custom fields
       """
 
     When I run `wp user application-password list admin --field=name`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       myapp1
+      """
+    And STDOUT should contain:
+      """
       myapp2
       """
 

--- a/features/user-application-password.feature
+++ b/features/user-application-password.feature
@@ -134,7 +134,7 @@ Feature: Manage user custom fields
     When I run `wp user application-password create 1 myapp1`
     Then STDOUT should not be empty
 
-    When I run `wp user application-password create 1 myapp2`
+    When I run `wp user application-password create 1 myapp2 --app-id=42`
     Then STDOUT should not be empty
 
     When I run `wp user application-password list 1 --name=myapp1 --field=uuid`
@@ -168,7 +168,7 @@ Feature: Manage user custom fields
       """
     And STDOUT should contain:
       """
-      {"uuid":"{UUID2}","app_id":"","name":"myapp2","password":"{JSONHASH2}","created":{CREATED2},"last_used":null,"last_ip":null}
+      {"uuid":"{UUID2}","app_id":"42","name":"myapp2","password":"{JSONHASH2}","created":{CREATED2},"last_used":null,"last_ip":null}
       """
 
     When I run `wp user application-password list 1 --format=json --fields=uuid,name`
@@ -184,37 +184,37 @@ Feature: Manage user custom fields
     When I run `wp user application-password list 1`
     Then STDOUT should be a table containing rows:
       | uuid    | app_id | name   | password | created    | last_used | last_ip |
-      | {UUID2} |        | myapp2 | {HASH2}  | {CREATED2} |           |         |
+      | {UUID2} | 42     | myapp2 | {HASH2}  | {CREATED2} |           |         |
       | {UUID1} |        | myapp1 | {HASH1}  | {CREATED1} |           |         |
 
     When I run `wp user application-password list 1 --fields=uuid,app_id,name`
     Then STDOUT should be a table containing rows:
       | uuid    | app_id | name   |
-      | {UUID2} |        | myapp2 |
+      | {UUID2} | 42     | myapp2 |
       | {UUID1} |        | myapp1 |
 
     When I run `wp user application-password list admin`
     Then STDOUT should be a table containing rows:
       | uuid    | app_id | name   | password | created    | last_used | last_ip |
-      | {UUID2} |        | myapp2 | {HASH2}  | {CREATED2} |           |         |
+      | {UUID2} | 42     | myapp2 | {HASH2}  | {CREATED2} |           |         |
       | {UUID1} |        | myapp1 | {HASH1}  | {CREATED1} |           |         |
 
     When I run `wp user application-password list admin --orderby=created --order=asc`
     Then STDOUT should be a table containing rows:
       | uuid    | app_id | name   | password | created    | last_used | last_ip |
       | {UUID1} |        | myapp1 | {HASH1}  | {CREATED1} |           |         |
-      | {UUID2} |        | myapp2 | {HASH2}  | {CREATED2} |           |         |
+      | {UUID2} | 42     | myapp2 | {HASH2}  | {CREATED2} |           |         |
 
     When I run `wp user application-password list admin --orderby=name --order=asc`
     Then STDOUT should be a table containing rows:
       | uuid    | app_id | name   | password | created    | last_used | last_ip |
       | {UUID1} |        | myapp1 | {HASH1}  | {CREATED1} |           |         |
-      | {UUID2} |        | myapp2 | {HASH2}  | {CREATED2} |           |         |
+      | {UUID2} | 42     | myapp2 | {HASH2}  | {CREATED2} |           |         |
 
     When I run `wp user application-password list admin --orderby=name --order=desc`
     Then STDOUT should be a table containing rows:
       | uuid    | app_id | name   | password | created    | last_used | last_ip |
-      | {UUID2} |        | myapp2 | {HASH2}  | {CREATED2} |           |         |
+      | {UUID2} | 42     | myapp2 | {HASH2}  | {CREATED2} |           |         |
       | {UUID1} |        | myapp1 | {HASH1}  | {CREATED1} |           |         |
 
     When I run `wp user application-password list admin --name=myapp2 --format=json`
@@ -233,6 +233,12 @@ Feature: Manage user custom fields
       myapp1
       """
     And STDOUT should contain:
+      """
+      myapp2
+      """
+
+    When I run `wp user application-password list 1 --field=name --app-id=42`
+    Then STDOUT should be:
       """
       myapp2
       """

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -67,7 +67,7 @@
 		<exclude-pattern>*/src/Post(_Meta|_Term|_Type)?_Command\.php$</exclude-pattern>
 		<exclude-pattern>*/src/Site(_Meta|_Option)?_Command\.php$</exclude-pattern>
 		<exclude-pattern>*/src/Term(_Meta)?_Command\.php$</exclude-pattern>
-		<exclude-pattern>*/src/User(_Meta|_Session|_Term)?_Command\.php$</exclude-pattern>
+		<exclude-pattern>*/src/User(_Application_Password|_Meta|_Session|_Term)?_Command\.php$</exclude-pattern>
 	</rule>
 
 	<!-- Whitelisting to provide backward compatibility to classes possibly extending this class. -->

--- a/src/User_Application_Password_Command.php
+++ b/src/User_Application_Password_Command.php
@@ -241,6 +241,10 @@ final class User_Application_Password_Command {
 			WP_CLI::error( $application_password );
 		}
 
+		if ( null === $application_password ) {
+			WP_CLI::error( 'No application password found for this user ID and UUID.' );
+		}
+
 		$fields = self::APPLICATION_PASSWORD_FIELDS;
 
 		if ( ! empty( $assoc_args['fields'] ) ) {
@@ -433,9 +437,10 @@ final class User_Application_Password_Command {
 
 		WP_CLI::success(
 			sprintf(
-				'Deleted %d of %d application passwords.',
+				'Deleted %d of %d application %s.',
 				$count - $errors,
-				$count
+				$count,
+				Utils\pluralize( 'password', $count )
 			)
 		);
 

--- a/src/User_Application_Password_Command.php
+++ b/src/User_Application_Password_Command.php
@@ -404,9 +404,9 @@ final class User_Application_Password_Command {
 
 		$user_id = array_shift( $args );
 		$all     = Utils\get_flag_value( $assoc_args, 'all', false );
-		$count   = count($args);
+		$count   = count( $args );
 
-		if ( ( $count > 0 && true === $all ) || ( $count === 0 && true !== $all ) ) {
+		if ( ( 0 < $count && true === $all ) || ( 0 === $count && true !== $all ) ) {
 			WP_CLI::error( 'You need to specify either one or more UUIDS or provide the --all flag' );
 		}
 
@@ -439,7 +439,7 @@ final class User_Application_Password_Command {
 			)
 		);
 
-		WP_CLI::halt( $errors === 0 ? 0 : 1 );
+		WP_CLI::halt( 0 === $errors ? 0 : 1 );
 	}
 
 	/**
@@ -507,8 +507,7 @@ final class User_Application_Password_Command {
 	 * @param string $app_name Application name to look for.
 	 * @return bool
 	 */
-	private function application_name_exists_for_user( $user_id, $app_name )
-	{
+	private function application_name_exists_for_user( $user_id, $app_name ) {
 		if ( Utils\wp_version_compare( '5.7', '<' ) ) {
 			$passwords = WP_Application_Passwords::get_user_application_passwords( $user_id );
 

--- a/src/User_Application_Password_Command.php
+++ b/src/User_Application_Password_Command.php
@@ -1,0 +1,526 @@
+<?php
+
+use WP_CLI\ExitException;
+use WP_CLI\Fetchers\User as UserFetcher;
+use WP_CLI\Formatter;
+use WP_CLI\Utils;
+
+/**
+ * Creates, updates, deletes, lists and retrieves application passwords.
+ *
+ * ## EXAMPLES
+ *
+ *     # List user application passwords and only show app name and password hash
+ *     $ wp user application-passwords list 123 --fields=name,password
+ *     +--------+------------------------------------+
+ *     | name   | password                           |
+ *     +--------+------------------------------------+
+ *     | myapp  | $P$BVGeou1CUot114YohIemgpwxQCzb8O/ |
+ *     +--------+------------------------------------+
+ *
+ *     # Get a specific application password and only show app name and created timestamp
+ *     $ wp user application-passwords get 123 6633824d-c1d7-4f79-9dd5-4586f734d69e --fields=name,created
+ *     +--------+------------+
+ *     | name   | created    |
+ *     +--------+------------+
+ *     | myapp  | 1638395611 |
+ *     +--------+------------+
+ *
+ *     # Create user application password
+ *     $ wp user application-passwords create 123 myapp
+ *     Success: Created application password.
+ *     Password: ZG1bxdxdzjTwhsY8vK8l1C65
+ *
+ *     # Only print the password without any chrome
+ *     $ wp user application-passwords create 123 myapp --porcelain
+ *     ZG1bxdxdzjTwhsY8vK8l1C65
+ *
+ *     # Update an existing application password
+ *     $ wp user application-passwords update 123 6633824d-c1d7-4f79-9dd5-4586f734d69e --name=newappname
+ *     Success: Updated application password.
+ *
+ *     # Check if an application password for a given application exists
+ *     $ wp user application-passwords exists 123 myapp
+ *     $ echo $?
+ *     1
+ *
+ *     # Bash script for checking whether an application password exists and creating one if not
+ *     if ! wp user application-password exists 123 myapp; then
+ *         PASSWORD=$(wp user application-password create 123 myapp --porcelain)
+ *     fi
+ */
+final class User_Application_Password_Command {
+
+	/**
+	 * List of application password fields.
+	 *
+	 * @var array<string>
+	 */
+	const APPLICATION_PASSWORD_FIELDS = [
+		'uuid',
+		'app_id',
+		'name',
+		'password',
+		'created',
+		'last_used',
+		'last_ip',
+	];
+
+	/**
+	 * Lists all application passwords associated with a user.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user>
+	 * : The user login, user email, or user ID of the user to get application passwords for.
+	 *
+	 * [--<field>=<value>]
+	 * : Filter the list by a specific field.
+	 *
+	 * [--field=<field>]
+	 * : Prints the value of a single field for each application password.
+	 *
+	 * [--fields=<fields>]
+	 * : Limit the output to specific fields.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - count
+	 *   - yaml
+	 * ---
+	 *
+	 * [--orderby=<fields>]
+	 * : Set orderby which field.
+	 * ---
+	 * default: created
+	 * options:
+	 *  - uuid
+	 *  - app_id
+	 *  - name
+	 *  - password
+	 *  - created
+	 *  - last_used
+	 *  - last_ip
+	 * ---
+	 *
+	 * [--order=<order>]
+	 * : Set ascending or descending order.
+	 * ---
+	 * default: desc
+	 * options:
+	 *  - asc
+	 *  - desc
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # List user application passwords and only show app name and password hash
+	 *     $ wp user application-passwords list 123 --fields=name,password
+	 *     +--------+------------------------------------+
+	 *     | name   | password                           |
+	 *     +--------+------------------------------------+
+	 *     | myapp  | $P$BVGeou1CUot114YohIemgpwxQCzb8O/ |
+	 *     +--------+------------------------------------+
+	 *
+	 * @subcommand list
+	 *
+	 * @param array $args       Indexed array of positional arguments.
+	 * @param array $assoc_args Associative array of associative arguments.
+	 * @throws ExitException If the user could not be found/parsed.
+	 * @throws ExitException If the application passwords could not be retrieved.
+	 */
+	public function list_( $args, $assoc_args ) {
+		$args = $this->replace_login_with_user_id( $args );
+
+		list( $user_id ) = $args;
+
+		$application_passwords = WP_Application_Passwords::get_user_application_passwords( $user_id );
+
+		if ( $application_passwords instanceof WP_Error ) {
+			WP_CLI::error( $application_passwords );
+		}
+
+		if ( empty( $application_passwords ) ) {
+			$application_passwords = [];
+		}
+
+		$order   = Utils\get_flag_value( $assoc_args, 'order' );
+		$orderby = Utils\get_flag_value( $assoc_args, 'orderby' );
+
+		usort(
+			$application_passwords,
+			static function ( $a, $b ) use ( $orderby, $order ) {
+				// Sort array.
+				return 'asc' === $order
+					? $a[ $orderby ] > $b[ $orderby ]
+					: $a[ $orderby ] < $b[ $orderby ];
+			}
+		);
+
+		$fields = self::APPLICATION_PASSWORD_FIELDS;
+
+		foreach ( $fields as $field ) {
+			if ( ! array_key_exists( $field, $assoc_args ) ) {
+				continue;
+			}
+
+			$value = Utils\get_flag_value( $assoc_args, $field );
+
+			$application_passwords = array_filter(
+				$application_passwords,
+				static function ( $application_password ) use ( $field, $value ) {
+					return $application_password[ $field ] === $value;
+				}
+			);
+		}
+
+		if ( ! empty( $assoc_args['fields'] ) ) {
+			$fields = explode( ',', $assoc_args['fields'] );
+		}
+
+		$formatter = new Formatter( $assoc_args, $fields );
+		$formatter->display_items( $application_passwords );
+	}
+
+	/**
+	 * Gets a specific application password.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user>
+	 * : The user login, user email, or user ID of the user to get the application password for.
+	 *
+	 * <uuid>
+	 * : The universally unique ID of the application password.
+	 *
+	 * [--field=<field>]
+	 * : Prints the value of a single field for the application password.
+	 *
+	 * [--fields=<fields>]
+	 * : Limit the output to specific fields.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Get a specific application password and only show app name and created timestamp
+	 *     $ wp user application-passwords get 123 6633824d-c1d7-4f79-9dd5-4586f734d69e --fields=name,created
+	 *     +--------+------------+
+	 *     | name   | created    |
+	 *     +--------+------------+
+	 *     | myapp  | 1638395611 |
+	 *     +--------+------------+
+	 *
+	 * @param array $args       Indexed array of positional arguments.
+	 * @param array $assoc_args Associative array of associative arguments.
+	 * @throws ExitException If the application passwords could not be retrieved.
+	 */
+	public function get( $args, $assoc_args ) {
+		$args = $this->replace_login_with_user_id( $args );
+
+		list( $user_id, $uuid ) = $args;
+
+		$application_password = WP_Application_Passwords::get_user_application_password( $user_id, $uuid );
+
+		if ( $application_password instanceof WP_Error ) {
+			WP_CLI::error( $application_password );
+		}
+
+		$fields = self::APPLICATION_PASSWORD_FIELDS;
+
+		if ( ! empty( $assoc_args['fields'] ) ) {
+			$fields = explode( ',', $assoc_args['fields'] );
+		}
+
+		$formatter = new Formatter( $assoc_args, $fields );
+		$formatter->display_items( [ $application_password ] );
+	}
+
+	/**
+	 * Creates a new application password.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user>
+	 * : The user login, user email, or user ID of the user to create a new application password for.
+	 *
+	 * <app-name>
+	 * : Unique name of the application to create an application password for.
+	 *
+	 * [--porcelain]
+	 * : Output just the new password.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Create user application password
+	 *     $ wp user application-passwords create 123 myapp
+	 *     Success: Created application password.
+	 *     Password: ZG1bxdxdzjTwhsY8vK8l1C65
+	 *
+	 *     # Only print the password without any chrome
+	 *     $ wp user application-passwords create 123 myapp --porcelain
+	 *     ZG1bxdxdzjTwhsY8vK8l1C65
+	 *
+	 * @param array $args       Indexed array of positional arguments.
+	 * @param array $assoc_args Associative array of associative arguments.
+	 * @throws ExitException If the application password could not be created.
+	 */
+	public function create( $args, $assoc_args ) {
+		$args = $this->replace_login_with_user_id( $args );
+
+		list( $user_id, $app_name ) = $args;
+
+		$result = WP_Application_Passwords::create_new_application_password( $user_id, [ 'name' => $app_name ] );
+
+		if ( $result instanceof WP_Error ) {
+			WP_CLI::error( $result );
+		}
+
+		if ( Utils\get_flag_value( $assoc_args, 'porcelain', false ) ) {
+			WP_CLI::line( $result[0] );
+			WP_CLI::halt( 0 );
+		}
+
+		WP_CLI::success( 'Created application password.' );
+		WP_CLI::line( "Password: {$result[0]}" );
+	}
+
+	/**
+	 * Updates an existing application password.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user>
+	 * : The user login, user email, or user ID of the user to update the application password for.
+	 *
+	 * <uuid>
+	 * : The universally unique ID of the application password.
+	 *
+	 * [--<field>=<value>]
+	 * : Update the <field> with a new <value>. Currently supported fields: name.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Update an existing application password
+	 *     $ wp user application-passwords update 123 6633824d-c1d7-4f79-9dd5-4586f734d69e --name=newappname
+	 *     Success: Updated application password.
+	 *
+	 * @param array $args       Indexed array of positional arguments.
+	 * @param array $assoc_args Associative array of associative arguments.
+	 * @throws ExitException If the application password could not be created.
+	 */
+	public function update( $args, $assoc_args ) {
+		$args = $this->replace_login_with_user_id( $args );
+
+		list( $user_id, $uuid ) = $args;
+
+		$result = WP_Application_Passwords::update_application_password( $user_id, $uuid, $assoc_args );
+
+		if ( $result instanceof WP_Error ) {
+			WP_CLI::error( $result );
+		}
+
+		WP_CLI::success( 'Updated application password.' );
+	}
+
+	/**
+	 * Record usage of an application password.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user>
+	 * : The user login, user email, or user ID of the user to update the application password for.
+	 *
+	 * <uuid>
+	 * : The universally unique ID of the application password.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Record usage of an application password
+	 *     $ wp user application-passwords record-usage 123 6633824d-c1d7-4f79-9dd5-4586f734d69e
+	 *     Success: Recorded application password usage.
+	 *
+	 * @subcommand record-usage
+	 *
+	 * @param array $args       Indexed array of positional arguments.
+	 * @param array $assoc_args Associative array of associative arguments.
+	 * @throws ExitException If the application password could not be created.
+	 */
+	public function record_usage( $args, $assoc_args ) {
+		$args = $this->replace_login_with_user_id( $args );
+
+		list( $user_id, $uuid ) = $args;
+
+		$result = WP_Application_Passwords::record_application_password_usage( $user_id, $uuid );
+
+		if ( $result instanceof WP_Error ) {
+			WP_CLI::error( $result );
+		}
+
+		WP_CLI::success( 'Recorded application password usage.' );
+	}
+
+	/**
+	 * Delete an existing application password.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user>
+	 * : The user login, user email, or user ID of the user to delete the application password for.
+	 *
+	 * [<uuid>...]
+	 * : Comma-separated list of UUIDs of the application passwords to delete.
+	 *
+	 * [--all]
+	 * : Delete all of the user's application password.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Record usage of an application password
+	 *     $ wp user application-passwords record-usage 123 6633824d-c1d7-4f79-9dd5-4586f734d69e
+	 *     Success: Recorded application password usage.
+	 *
+	 * @param array $args       Indexed array of positional arguments.
+	 * @param array $assoc_args Associative array of associative arguments.
+	 * @throws ExitException If the application password could not be created.
+	 */
+	public function delete( $args, $assoc_args ) {
+		$args = $this->replace_login_with_user_id( $args );
+
+		$user_id = array_shift( $args );
+		$all     = Utils\get_flag_value( $assoc_args, 'all', false );
+		$count   = count($args);
+
+		if ( ( $count > 0 && true === $all ) || ( $count === 0 && true !== $all ) ) {
+			WP_CLI::error( 'You need to specify either one or more UUIDS or provide the --all flag' );
+		}
+
+		if ( true === $all ) {
+			$result = WP_Application_Passwords::delete_all_application_passwords( $user_id );
+
+			if ( $result instanceof WP_Error ) {
+				WP_CLI::error( $result );
+			}
+
+			WP_CLI::success( 'Deleted all application passwords.' );
+			WP_CLI::halt( 0 );
+		}
+
+		$errors = 0;
+		foreach ( $args as $uuid ) {
+			$result = WP_Application_Passwords::delete_application_password( $user_id, $uuid );
+
+			if ( $result instanceof WP_Error ) {
+				WP_CLI::warning( "Failed to delete UUID {$uuid}: " . $result->get_error_message() );
+				$errors++;
+			}
+		}
+
+		WP_CLI::success(
+			sprintf(
+				'Deleted %d of %d application passwords.',
+				$count - $errors,
+				$count
+			)
+		);
+
+		WP_CLI::halt( $errors === 0 ? 0 : 1 );
+	}
+
+	/**
+	 * Checks whether an application password for a given application exists.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user>
+	 * : The user login, user email, or user ID of the user to check the existence of an application password for.
+	 *
+	 * <app-name>
+	 * : Name of the application to check the existence of an application password for.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Check if an application password for a given application exists
+	 *     $ wp user application-passwords exists 123 myapp
+	 *     $ echo $?
+	 *     1
+	 *
+	 *     # Bash script for checking whether an application password exists and creating one if not
+	 *     if ! wp user application-password exists 123 myapp; then
+	 *         PASSWORD=$(wp user application-password create 123 myapp --porcelain)
+	 *     fi
+	 *
+	 * @param array $args       Indexed array of positional arguments.
+	 * @param array $assoc_args Associative array of associative arguments.
+	 * @throws ExitException If the application password could not be created.
+	 */
+	public function exists( $args, $assoc_args ) {
+		$args = $this->replace_login_with_user_id( $args );
+
+		list( $user_id, $app_name ) = $args;
+
+		$result = $this->application_name_exists_for_user( $user_id, $app_name );
+
+		if ( $result instanceof WP_Error ) {
+			WP_CLI::error( $result );
+		}
+
+		WP_CLI::halt( $result ? 0 : 1 );
+	}
+
+	/**
+	 * Replaces user_login value with user ID.
+	 *
+	 * @param array $args Associative array of arguments.
+	 * @return array Associative array of arguments with the user login replaced with an ID.
+	 * @throws ExitException If the user is not found.
+	 */
+	private function replace_login_with_user_id( $args ) {
+		$user    = ( new UserFetcher() )->get_check( $args[0] );
+		$args[0] = $user->ID;
+
+		return $args;
+	}
+
+	/**
+	 * Checks if application name exists for the given user.
+	 *
+	 * This is a polyfill for WP_Application_Passwords::get_user_application_passwords(), which was only added for
+	 * WordPress 5.7+, but we're already supporting application passwords for WordPress 5.6+.
+	 *
+	 * @param int    $user_id  User ID to check the application passwords for.
+	 * @param string $app_name Application name to look for.
+	 * @return bool
+	 */
+	private function application_name_exists_for_user( $user_id, $app_name )
+	{
+		if ( Utils\wp_version_compare( '5.7', '<' ) ) {
+			$passwords = WP_Application_Passwords::get_user_application_passwords( $user_id );
+
+			foreach ( $passwords as $password ) {
+				if ( strtolower( $password['name'] ) === strtolower( $name ) ) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		return WP_Application_Passwords::application_name_exists_for_user( $user_id, $app_name );
+	}
+}

--- a/src/User_Application_Password_Command.php
+++ b/src/User_Application_Password_Command.php
@@ -165,22 +165,21 @@ final class User_Application_Password_Command {
 
 		$fields = self::APPLICATION_PASSWORD_FIELDS;
 
+		// Avoid confusion regarding the dash/underscore usage.
+		foreach ( [ 'app-id', 'last-used', 'last-ip' ] as $flag ) {
+			if ( array_key_exists( $flag, $assoc_args ) ) {
+				$underscored_flag                = str_replace( '-', '_', $flag );
+				$assoc_args[ $underscored_flag ] = $assoc_args[ $flag ];
+				unset( $assoc_args[ $flag ] );
+			}
+		}
+
 		foreach ( $fields as $field ) {
-			if (
-				! array_key_exists( $field, $assoc_args )
-				&&
-				! ( 'app_id' === $field && array_key_exists( 'app-id', $assoc_args ) )
-			) {
+			if ( ! array_key_exists( $field, $assoc_args ) ) {
 				continue;
 			}
 
 			$value = Utils\get_flag_value( $assoc_args, $field );
-
-			// Avoid confusion regarding the dash/underscore between creation flag
-			// and querying field name.
-			if ( 'app_id' === $field && array_key_exists( 'app-id', $assoc_args ) ) {
-				$value = Utils\get_flag_value( $assoc_args, 'app-id' );
-			}
 
 			$application_passwords = array_filter(
 				$application_passwords,

--- a/src/User_Application_Password_Command.php
+++ b/src/User_Application_Password_Command.php
@@ -166,11 +166,21 @@ final class User_Application_Password_Command {
 		$fields = self::APPLICATION_PASSWORD_FIELDS;
 
 		foreach ( $fields as $field ) {
-			if ( ! array_key_exists( $field, $assoc_args ) ) {
+			if (
+				! array_key_exists( $field, $assoc_args )
+				&&
+				! ( 'app_id' === $field && array_key_exists( 'app-id', $assoc_args ) )
+			) {
 				continue;
 			}
 
 			$value = Utils\get_flag_value( $assoc_args, $field );
+
+			// Avoid confusion regarding the dash/underscore between creation flag
+			// and querying field name.
+			if ( 'app_id' === $field && array_key_exists( 'app-id', $assoc_args ) ) {
+				$value = Utils\get_flag_value( $assoc_args, 'app-id' );
+			}
 
 			$application_passwords = array_filter(
 				$application_passwords,
@@ -266,6 +276,9 @@ final class User_Application_Password_Command {
 	 * <app-name>
 	 * : Unique name of the application to create an application password for.
 	 *
+	 * [--app-id=<app-id>]
+	 * : Application ID to attribute to the application password.
+	 *
 	 * [--porcelain]
 	 * : Output just the new password.
 	 *
@@ -280,6 +293,10 @@ final class User_Application_Password_Command {
 	 *     $ wp user application-passwords create 123 myapp --porcelain
 	 *     ZG1bxdxdzjTwhsY8vK8l1C65
 	 *
+	 *     # Create user application with a custom application ID for internal tracking
+	 *     $ wp user application-passwords create 123 myapp --app-id=42 --porcelain
+	 *     ZG1bxdxdzjTwhsY8vK8l1C65
+	 *
 	 * @param array $args       Indexed array of positional arguments.
 	 * @param array $assoc_args Associative array of associative arguments.
 	 * @throws ExitException If the application password could not be created.
@@ -289,7 +306,14 @@ final class User_Application_Password_Command {
 
 		list( $user_id, $app_name ) = $args;
 
-		$result = WP_Application_Passwords::create_new_application_password( $user_id, [ 'name' => $app_name ] );
+		$app_id = Utils\get_flag_value( $assoc_args, 'app-id', '' );
+
+		$arguments = [
+			'name'   => $app_name,
+			'app_id' => $app_id,
+		];
+
+		$result = WP_Application_Passwords::create_new_application_password( $user_id, $arguments );
 
 		if ( $result instanceof WP_Error ) {
 			WP_CLI::error( $result );

--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,2 +1,4 @@
 require:
   - entity-command.php
+path: /home/alain/dev/sites/testsite
+

--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,4 +1,2 @@
 require:
   - entity-command.php
-path: /home/alain/dev/sites/testsite
-


### PR DESCRIPTION
This PR adds new commands for managing application passwords.

* `wp user application-password list <user> [--<field>=<value>] [--field=<field>] [--fields=<fields>] [--orderby=<field>] [--order=<order>]`
* `wp user application-password get <user> <uuid> [--field=<field>] [--fields=<fields>] [--format=<format>]`
* `wp user application-password exists <user> <name>`
* `wp user application-password update <user> <uuid> [--<field>=<value>]`
* `wp user application-password record-usage <user> <uuid>`
* `wp user application-password create <user> <name> [--app-id=<app-id>]`
* `wp user application-password delete <user> [<uuid>...] [--all]`

TODO:
- [x] Look into APP ID requirements
- [x] Add Behat tests

Fixes #329