### PR TITLE
Fix command name in examples

### DIFF
--- a/src/User_Application_Password_Command.php
+++ b/src/User_Application_Password_Command.php
@@ -11,7 +11,7 @@ use WP_CLI\Utils;
  * ## EXAMPLES
  *
  *     # List user application passwords and only show app name and password hash
- *     $ wp user application-passwords list 123 --fields=name,password
+ *     $ wp user application-password list 123 --fields=name,password
  *     +--------+------------------------------------+
  *     | name   | password                           |
  *     +--------+------------------------------------+
@@ -19,7 +19,7 @@ use WP_CLI\Utils;
  *     +--------+------------------------------------+
  *
  *     # Get a specific application password and only show app name and created timestamp
- *     $ wp user application-passwords get 123 6633824d-c1d7-4f79-9dd5-4586f734d69e --fields=name,created
+ *     $ wp user application-password get 123 6633824d-c1d7-4f79-9dd5-4586f734d69e --fields=name,created
  *     +--------+------------+
  *     | name   | created    |
  *     +--------+------------+
@@ -27,20 +27,20 @@ use WP_CLI\Utils;
  *     +--------+------------+
  *
  *     # Create user application password
- *     $ wp user application-passwords create 123 myapp
+ *     $ wp user application-password create 123 myapp
  *     Success: Created application password.
  *     Password: ZG1bxdxdzjTwhsY8vK8l1C65
  *
  *     # Only print the password without any chrome
- *     $ wp user application-passwords create 123 myapp --porcelain
+ *     $ wp user application-password create 123 myapp --porcelain
  *     ZG1bxdxdzjTwhsY8vK8l1C65
  *
  *     # Update an existing application password
- *     $ wp user application-passwords update 123 6633824d-c1d7-4f79-9dd5-4586f734d69e --name=newappname
+ *     $ wp user application-password update 123 6633824d-c1d7-4f79-9dd5-4586f734d69e --name=newappname
  *     Success: Updated application password.
  *
  *     # Check if an application password for a given application exists
- *     $ wp user application-passwords exists 123 myapp
+ *     $ wp user application-password exists 123 myapp
  *     $ echo $?
  *     1
  *
@@ -121,7 +121,7 @@ final class User_Application_Password_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # List user application passwords and only show app name and password hash
-	 *     $ wp user application-passwords list 123 --fields=name,password
+	 *     $ wp user application-password list 123 --fields=name,password
 	 *     +--------+------------------------------------+
 	 *     | name   | password                           |
 	 *     +--------+------------------------------------+
@@ -228,7 +228,7 @@ final class User_Application_Password_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # Get a specific application password and only show app name and created timestamp
-	 *     $ wp user application-passwords get 123 6633824d-c1d7-4f79-9dd5-4586f734d69e --fields=name,created
+	 *     $ wp user application-password get 123 6633824d-c1d7-4f79-9dd5-4586f734d69e --fields=name,created
 	 *     +--------+------------+
 	 *     | name   | created    |
 	 *     +--------+------------+
@@ -284,16 +284,16 @@ final class User_Application_Password_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # Create user application password
-	 *     $ wp user application-passwords create 123 myapp
+	 *     $ wp user application-password create 123 myapp
 	 *     Success: Created application password.
 	 *     Password: ZG1bxdxdzjTwhsY8vK8l1C65
 	 *
 	 *     # Only print the password without any chrome
-	 *     $ wp user application-passwords create 123 myapp --porcelain
+	 *     $ wp user application-password create 123 myapp --porcelain
 	 *     ZG1bxdxdzjTwhsY8vK8l1C65
 	 *
 	 *     # Create user application with a custom application ID for internal tracking
-	 *     $ wp user application-passwords create 123 myapp --app-id=42 --porcelain
+	 *     $ wp user application-password create 123 myapp --app-id=42 --porcelain
 	 *     ZG1bxdxdzjTwhsY8vK8l1C65
 	 *
 	 * @param array $args       Indexed array of positional arguments.
@@ -344,7 +344,7 @@ final class User_Application_Password_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # Update an existing application password
-	 *     $ wp user application-passwords update 123 6633824d-c1d7-4f79-9dd5-4586f734d69e --name=newappname
+	 *     $ wp user application-password update 123 6633824d-c1d7-4f79-9dd5-4586f734d69e --name=newappname
 	 *     Success: Updated application password.
 	 *
 	 * @param array $args       Indexed array of positional arguments.
@@ -379,7 +379,7 @@ final class User_Application_Password_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # Record usage of an application password
-	 *     $ wp user application-passwords record-usage 123 6633824d-c1d7-4f79-9dd5-4586f734d69e
+	 *     $ wp user application-password record-usage 123 6633824d-c1d7-4f79-9dd5-4586f734d69e
 	 *     Success: Recorded application password usage.
 	 *
 	 * @subcommand record-usage
@@ -419,7 +419,7 @@ final class User_Application_Password_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # Record usage of an application password
-	 *     $ wp user application-passwords record-usage 123 6633824d-c1d7-4f79-9dd5-4586f734d69e
+	 *     $ wp user application-password record-usage 123 6633824d-c1d7-4f79-9dd5-4586f734d69e
 	 *     Success: Recorded application password usage.
 	 *
 	 * @param array $args       Indexed array of positional arguments.
@@ -484,7 +484,7 @@ final class User_Application_Password_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # Check if an application password for a given application exists
-	 *     $ wp user application-passwords exists 123 myapp
+	 *     $ wp user application-password exists 123 myapp
 	 *     $ echo $?
 	 *     1
 	 *


### PR DESCRIPTION
changes command from `application-passwords` to `application-password` in examples.

Closes #351 


