### PR TITLE
Sync user-contributed example to `wp user delete`

### DIFF
--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -260,6 +260,9 @@ class User_Command extends CommandWithDBObject {
 	 *     $ wp user delete $(wp user list --role=contributor --field=ID) --reassign=2
 	 *     Success: Removed user 813 from http://example.com
 	 *     Success: Removed user 578 from http://example.com
+	 *
+	 *     # Delete all contributors in batches of 100 (avoid error: argument list too long: wp)
+	 *     $ wp user delete $(wp user list --role=contributor --field=ID | head -n 100)
 	 */
 	public function delete( $args, $assoc_args ) {
 		$network  = Utils\get_flag_value( $assoc_args, 'network' ) && is_multisite();


### PR DESCRIPTION
From https://github.com/wp-cli/handbook/pull/407