### PR TITLE
Support filtering for users without a role with `--role=none`

### DIFF
--- a/features/user-list.feature
+++ b/features/user-list.feature
@@ -27,6 +27,7 @@ Feature: List WordPress users
       bobjones
       """
 
+  @require-wp-4.9
   Scenario: List users without roles
     Given a WP install
     When I run `wp user create bili bili@example.com --porcelain`

--- a/features/user-list.feature
+++ b/features/user-list.feature
@@ -26,3 +26,16 @@ Feature: List WordPress users
       """
       bobjones
       """
+
+  Scenario: List users without roles
+    Given a WP install
+    When I run `wp user generate --count=1 --format=ids`
+    Then save STDOUT as {USER_ID}
+
+    And I run `wp user remove-role {USER_ID} subscriber`
+
+    When I run `wp user list --role=none --field=id`
+    Then STDOUT should be:
+      """
+      {USER_ID}
+      """

--- a/features/user-list.feature
+++ b/features/user-list.feature
@@ -29,13 +29,14 @@ Feature: List WordPress users
 
   Scenario: List users without roles
     Given a WP install
-    When I run `wp user generate --count=1 --format=ids`
+    When I run `wp user create bili bili@example.com --porcelain`
     Then save STDOUT as {USER_ID}
 
+    And I run `wp user create sally sally@example.com --role=editor`
     And I run `wp user remove-role {USER_ID} subscriber`
 
-    When I run `wp user list --role=none --field=id`
+    When I run `wp user list --role=none --field=user_login`
     Then STDOUT should be:
       """
-      {USER_ID}
+      bili
       """

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -162,7 +162,17 @@ class User_Command extends CommandWithDBObject {
 
 		$assoc_args['count_total'] = false;
 		$assoc_args                = self::process_csv_arguments_to_arrays( $assoc_args );
-		$users                     = get_users( $assoc_args );
+
+		if ( ! empty( $assoc_args['role'] ) && 'none' === $assoc_args['role'] ) {
+			$norole_user_ids = wp_get_users_with_no_role();
+
+			if ( ! empty( $norole_user_ids ) ) {
+				$assoc_args['include'] = $norole_user_ids;
+				unset($assoc_args['role']);
+			}
+		}
+
+		$users = get_users( $assoc_args );
 
 		if ( 'ids' === $formatter->format ) {
 			echo implode( ' ', $users );

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -168,7 +168,7 @@ class User_Command extends CommandWithDBObject {
 
 			if ( ! empty( $norole_user_ids ) ) {
 				$assoc_args['include'] = $norole_user_ids;
-				unset($assoc_args['role']);
+				unset( $assoc_args['role'] );
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/wp-cli/entity-command/issues/34

Allow getting users with no role by using the following command

`wp user list --role=none`

Waiting for clarification https://github.com/wp-cli/entity-command/issues/34#issuecomment-1214336137