### PR TITLE
WIP: Issue #87 : Show primary site of the user

### DIFF
--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -574,6 +574,16 @@ class Site_Command extends CommandWithDBObject {
 
 		global $wpdb;
 
+		if ( isset( $assoc_args['primary'] ) ) {
+			$user_id = get_current_user_id();
+
+			if ( empty( $user_id ) ) {
+				WP_CLI::error( 'Please set --user for Primary site.' );
+			}
+
+			$assoc_args['site__in'] = get_user_option( 'primary_blog', $user_id );
+		}
+
 		if ( isset( $assoc_args['fields'] ) ) {
 			$assoc_args['fields'] = preg_split( '/,[ \t]*/', $assoc_args['fields'] );
 		}


### PR DESCRIPTION
Fixes #87 

@Sidsector9 If there are multiple administrators on the site, they can set different primary sites for them.

![image](https://user-images.githubusercontent.com/19459637/185781665-b8ec55c7-713d-48c0-a9f0-db1a65430932.png)

In that case, we have to pass `--user` in this command.

Let me know if this approach works. Then I'll add behat tests.