### PR TITLE
Add `wp post meta clean-duplicates <id> <key>` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2518,6 +2518,30 @@ wp post meta add <id> <key> [<value>] [--format=<format>]
 
 
 
+### wp post meta clean-duplicates
+
+Cleans up duplicate post meta values on a post.
+
+~~~
+wp post meta clean-duplicates <id> <key>
+~~~
+
+**OPTIONS**
+
+	<id>
+		ID of the post to clean.
+
+	<key>
+		Meta key to clean up.
+
+**EXAMPLES**
+
+    # Delete duplicate post meta.
+    wp post meta clean-duplicates 1234 enclosure
+    Success: Cleaned up duplicate 'enclosure' meta values.
+
+
+
 ### wp post meta delete
 
 Delete a meta field.

--- a/composer.json
+++ b/composer.json
@@ -101,6 +101,7 @@
             "post list",
             "post meta",
             "post meta add",
+            "post meta clean-duplicates",
             "post meta delete",
             "post meta get",
             "post meta list",

--- a/features/post-meta-clean-duplicates.feature
+++ b/features/post-meta-clean-duplicates.feature
@@ -1,0 +1,63 @@
+Feature: Clean up duplicate post meta values
+
+  Scenario: Clean up duplicate post meta values.
+    Given a WP install
+    And a session_no file:
+      """
+      n
+      """
+    And a session_yes file:
+      """
+      y
+      """
+
+    When I run `wp post meta add 1 foo bar`
+    Then STDOUT should be:
+      """
+      Success: Added custom field.
+      """
+
+    When I run the previous command again
+    Then the return code should be 0
+
+    When I run the previous command again
+    Then the return code should be 0
+
+    When I run `wp post meta list 1 --keys=foo`
+    Then STDOUT should be a table containing rows:
+      | post_id | meta_key | meta_value |
+      | 1       | foo      | bar        |
+      | 1       | foo      | bar        |
+      | 1       | foo      | bar        |
+
+    When I run `wp post meta clean-duplicates 1 foo < session_no`
+    # Check for contains only, as the string contains a trailing space.
+    Then STDOUT should contain:
+      """
+      Are you sure you want to delete 2 duplicate meta values and keep 1 valid meta value? [y/n]
+      """
+
+    When I run `wp post meta list 1 --keys=foo --format=count`
+    Then STDOUT should be:
+      """
+      3
+      """
+
+    When I run `wp post meta clean-duplicates 1 foo < session_yes`
+    Then STDOUT should contain:
+      """
+      Cleaned up duplicate 'foo' meta values.
+      """
+
+    When I try the previous command again
+    Then STDOUT should contain:
+      """
+      Success: Nothing to clean up: found 1 valid meta value and 0 duplicates.
+      """
+
+    When I try `wp post meta clean-duplicates 1 food`
+    Then STDERR should be:
+      """
+      Error: No meta data found.
+      """
+    And the return code should be 1

--- a/features/post-meta-clean-duplicates.feature
+++ b/features/post-meta-clean-duplicates.feature
@@ -58,6 +58,6 @@ Feature: Clean up duplicate post meta values
     When I try `wp post meta clean-duplicates 1 food`
     Then STDERR should be:
       """
-      Error: No meta data found.
+      Error: No meta values found for 'food'.
       """
     And the return code should be 1

--- a/features/post-meta.feature
+++ b/features/post-meta.feature
@@ -506,11 +506,18 @@ Feature: Manage post custom fields
       Success: Added custom field.
       """
 
-    When I try the previous command again
+    When I run the previous command again
     Then the return code should be 0
 
-    When I try the previous command again
+    When I run the previous command again
     Then the return code should be 0
+
+    When I run `wp post meta list 1 --keys=foo`
+    Then STDOUT should be a table containing rows:
+      | post_id | meta_key | meta_value |
+      | 1       | foo      | bar        |
+      | 1       | foo      | bar        |
+      | 1       | foo      | bar        |
 
     When I run `wp post meta clean-duplicates 1 foo < session_no`
     # Check for contains only, as the string contains a trailing space.
@@ -523,6 +530,12 @@ Feature: Manage post custom fields
     Then STDOUT should contain:
       """
       Success: Cleaned up duplicate enclosures.
+      """
+
+    When I try the previous command again
+    Then STDOUT should contain:
+      """
+      Success: Nothing to clean up: found 1 valid enclosures and 0 duplicate enclosures.
       """
 
     When I try `wp post meta clean-duplicates 1 food`

--- a/features/post-meta.feature
+++ b/features/post-meta.feature
@@ -526,6 +526,12 @@ Feature: Manage post custom fields
       Are you sure you want to delete 2 duplicate enclosures and keep 1 valid enclosures? [y/n]
       """
 
+    When I run `wp post meta list 1 --keys=foo --format=count`
+    Then STDOUT should be:
+      """
+      3
+      """
+
     When I run `wp post meta clean-duplicates 1 foo < session_yes`
     Then STDOUT should contain:
       """

--- a/features/post-meta.feature
+++ b/features/post-meta.feature
@@ -59,87 +59,87 @@ Feature: Manage post custom fields
 
     When I run `wp post meta list 1`
     Then STDOUT should be a table containing rows:
-      | post_id | meta_key | meta_value                              |
-      | 1       | apple    | banana                                  |
-      | 1       | apple    | banana                                  |
-      | 1       | banana   | a:2:{i:0;s:5:"apple";i:1;s:5:"apple";}  |
+      | post_id | meta_key | meta_value                             |
+      | 1       | apple    | banana                                 |
+      | 1       | apple    | banana                                 |
+      | 1       | banana   | a:2:{i:0;s:5:"apple";i:1;s:5:"apple";} |
 
     When I run `wp post meta list 1 --unserialize`
     Then STDOUT should be a table containing rows:
-      | post_id | meta_key | meta_value         |
-      | 1       | apple    | banana             |
-      | 1       | apple    | banana             |
-      | 1       | banana   | ["apple","apple"]  |
+      | post_id | meta_key | meta_value        |
+      | 1       | apple    | banana            |
+      | 1       | apple    | banana            |
+      | 1       | banana   | ["apple","apple"] |
 
     When I run `wp post meta list 1 --orderby=id --order=desc`
     Then STDOUT should be a table containing rows:
-      | post_id | meta_key | meta_value                              |
-      | 1       | banana   | a:2:{i:0;s:5:"apple";i:1;s:5:"apple";}  |
-      | 1       | apple    | banana                                  |
-      | 1       | apple    | banana                                  |
+      | post_id | meta_key | meta_value                             |
+      | 1       | banana   | a:2:{i:0;s:5:"apple";i:1;s:5:"apple";} |
+      | 1       | apple    | banana                                 |
+      | 1       | apple    | banana                                 |
 
     When I run `wp post meta list 1 --orderby=id --order=desc --unserialize`
     Then STDOUT should be a table containing rows:
-      | post_id | meta_key | meta_value         |
-      | 1       | banana   | ["apple","apple"]  |
-      | 1       | apple    | banana             |
-      | 1       | apple    | banana             |
+      | post_id | meta_key | meta_value        |
+      | 1       | banana   | ["apple","apple"] |
+      | 1       | apple    | banana            |
+      | 1       | apple    | banana            |
 
     When I run `wp post meta list 1 --orderby=meta_key --order=asc`
     Then STDOUT should be a table containing rows:
-      | post_id | meta_key | meta_value                              |
-      | 1       | apple    | banana                                  |
-      | 1       | apple    | banana                                  |
-      | 1       | banana   | a:2:{i:0;s:5:"apple";i:1;s:5:"apple";}  |
+      | post_id | meta_key | meta_value                             |
+      | 1       | apple    | banana                                 |
+      | 1       | apple    | banana                                 |
+      | 1       | banana   | a:2:{i:0;s:5:"apple";i:1;s:5:"apple";} |
 
     When I run `wp post meta list 1 --orderby=meta_key --order=asc --unserialize`
     Then STDOUT should be a table containing rows:
-      | post_id | meta_key | meta_value         |
-      | 1       | apple    | banana             |
-      | 1       | apple    | banana             |
-      | 1       | banana   | ["apple","apple"]  |
+      | post_id | meta_key | meta_value        |
+      | 1       | apple    | banana            |
+      | 1       | apple    | banana            |
+      | 1       | banana   | ["apple","apple"] |
 
     When I run `wp post meta list 1 --orderby=meta_key --order=desc`
     Then STDOUT should be a table containing rows:
-      | post_id | meta_key | meta_value                              |
-      | 1       | banana   | a:2:{i:0;s:5:"apple";i:1;s:5:"apple";}  |
-      | 1       | apple    | banana                                  |
-      | 1       | apple    | banana                                  |
+      | post_id | meta_key | meta_value                             |
+      | 1       | banana   | a:2:{i:0;s:5:"apple";i:1;s:5:"apple";} |
+      | 1       | apple    | banana                                 |
+      | 1       | apple    | banana                                 |
 
     When I run `wp post meta list 1 --orderby=meta_key --order=desc --unserialize`
     Then STDOUT should be a table containing rows:
-      | post_id | meta_key | meta_value         |
-      | 1       | banana   | ["apple","apple"]  |
-      | 1       | apple    | banana             |
-      | 1       | apple    | banana             |
+      | post_id | meta_key | meta_value        |
+      | 1       | banana   | ["apple","apple"] |
+      | 1       | apple    | banana            |
+      | 1       | apple    | banana            |
 
     When I run `wp post meta list 1 --orderby=meta_value --order=asc`
     Then STDOUT should be a table containing rows:
-      | post_id | meta_key | meta_value                              |
-      | 1       | apple    | banana                                  |
-      | 1       | apple    | banana                                  |
-      | 1       | banana   | a:2:{i:0;s:5:"apple";i:1;s:5:"apple";}  |
+      | post_id | meta_key | meta_value                             |
+      | 1       | apple    | banana                                 |
+      | 1       | apple    | banana                                 |
+      | 1       | banana   | a:2:{i:0;s:5:"apple";i:1;s:5:"apple";} |
 
     When I run `wp post meta list 1 --orderby=meta_value --order=asc --unserialize`
     Then STDOUT should be a table containing rows:
-      | post_id | meta_key | meta_value         |
-      | 1       | apple    | banana             |
-      | 1       | apple    | banana             |
-      | 1       | banana   | ["apple","apple"]  |
+      | post_id | meta_key | meta_value        |
+      | 1       | apple    | banana            |
+      | 1       | apple    | banana            |
+      | 1       | banana   | ["apple","apple"] |
 
     When I run `wp post meta list 1 --orderby=meta_value --order=desc`
     Then STDOUT should be a table containing rows:
-      | post_id | meta_key | meta_value                              |
-      | 1       | banana   | a:2:{i:0;s:5:"apple";i:1;s:5:"apple";}  |
-      | 1       | apple    | banana                                  |
-      | 1       | apple    | banana                                  |
+      | post_id | meta_key | meta_value                             |
+      | 1       | banana   | a:2:{i:0;s:5:"apple";i:1;s:5:"apple";} |
+      | 1       | apple    | banana                                 |
+      | 1       | apple    | banana                                 |
 
     When I run `wp post meta list 1 --orderby=meta_value --order=desc --unserialize`
     Then STDOUT should be a table containing rows:
-      | post_id | meta_key | meta_value         |
-      | 1       | banana   | ["apple","apple"]  |
-      | 1       | apple    | banana             |
-      | 1       | apple    | banana             |
+      | post_id | meta_key | meta_value        |
+      | 1       | banana   | ["apple","apple"] |
+      | 1       | apple    | banana            |
+      | 1       | apple    | banana            |
 
   Scenario: Delete all post meta
     Given a WP install
@@ -186,8 +186,8 @@ Feature: Manage post custom fields
 
     When I run `wp post meta list 1`
     Then STDOUT should be a table containing rows:
-      | post_id | meta_key | meta_value         |
-      | 1       | foo      |                    |
+      | post_id | meta_key | meta_value |
+      | 1       | foo      |            |
 
   Scenario: Make sure WordPress receives the slashed data it expects in meta fields
     Given a WP install
@@ -225,7 +225,7 @@ Feature: Manage post custom fields
     And an input.json file:
       """
       {
-        "foo": "bar"
+      "foo": "bar"
       }
       """
     And I run `wp post meta set 1 meta-key --format=json < input.json`
@@ -242,14 +242,14 @@ Feature: Manage post custom fields
     And an input.json file:
       """
       {
-        "foo": {
-          "bar": {
-            "baz": "some value"
-          }
-        },
-        "foo.com": {
-          "visitors": 999
-        }
+      "foo": {
+      "bar": {
+      "baz": "some value"
+      }
+      },
+      "foo.com": {
+      "visitors": 999
+      }
       }
       """
     And I run `wp post meta set 1 meta-key --format=json < input.json`
@@ -307,7 +307,7 @@ Feature: Manage post custom fields
     And an input.json file:
       """
       {
-        "foo": "bar"
+      "foo": "bar"
       }
       """
     And I run `wp post meta set 1 meta-key --format=json < input.json`
@@ -322,7 +322,7 @@ Feature: Manage post custom fields
     Then STDOUT should be JSON containing:
       """
       {
-        "foo": "baz"
+      "foo": "baz"
       }
       """
 
@@ -332,10 +332,10 @@ Feature: Manage post custom fields
     And an input.json file:
       """
       {
-        "foo": {
-          "bar": "baz"
-        },
-        "bar": "bad"
+      "foo": {
+      "bar": "baz"
+      },
+      "bar": "bad"
       }
       """
     And a patch file:
@@ -354,10 +354,10 @@ Feature: Manage post custom fields
     Then STDOUT should be JSON containing:
       """
       {
-        "foo": {
-          "bar": "new value"
-        },
-        "bar": "bad"
+      "foo": {
+      "bar": "new value"
+      },
+      "bar": "bad"
       }
       """
 
@@ -367,10 +367,10 @@ Feature: Manage post custom fields
     And an input.json file:
       """
       {
-        "foo": {
-          "bar": "baz"
-        },
-        "bar": "bad"
+      "foo": {
+      "bar": "baz"
+      },
+      "bar": "bad"
       }
       """
     And I run `wp post meta set 1 meta-key --format=json < input.json`
@@ -389,10 +389,10 @@ Feature: Manage post custom fields
     And an input.json file:
       """
       {
-        "foo": {
-          "bar": "baz",
-          "abe": "lincoln"
-        }
+      "foo": {
+      "bar": "baz",
+      "abe": "lincoln"
+      }
       }
       """
     And I run `wp post meta set 1 meta-key --format=json < input.json`
@@ -407,9 +407,9 @@ Feature: Manage post custom fields
     Then STDOUT should be JSON containing:
       """
       {
-        "foo": {
-          "abe": "lincoln"
-        }
+      "foo": {
+      "abe": "lincoln"
+      }
       }
       """
 
@@ -419,9 +419,9 @@ Feature: Manage post custom fields
     And an input.json file:
       """
       {
-        "foo": {
-          "bar": "baz"
-        }
+      "foo": {
+      "bar": "baz"
+      }
       }
       """
     And I run `wp post meta set 1 meta-key --format=json < input.json`
@@ -449,7 +449,7 @@ Feature: Manage post custom fields
     Then STDOUT should be JSON containing:
       """
       {
-        "foo": "bar"
+      "foo": "bar"
       }
       """
 
@@ -488,65 +488,3 @@ Feature: Manage post custom fields
       """
       [ "new", "bar" ]
       """
-
-  Scenario: Clean up duplicate post meta values.
-    Given a WP install
-    And a session_no file:
-      """
-      n
-      """
-    And a session_yes file:
-      """
-      y
-      """
-
-    When I run `wp post meta add 1 foo bar`
-    Then STDOUT should be:
-      """
-      Success: Added custom field.
-      """
-
-    When I run the previous command again
-    Then the return code should be 0
-
-    When I run the previous command again
-    Then the return code should be 0
-
-    When I run `wp post meta list 1 --keys=foo`
-    Then STDOUT should be a table containing rows:
-      | post_id | meta_key | meta_value |
-      | 1       | foo      | bar        |
-      | 1       | foo      | bar        |
-      | 1       | foo      | bar        |
-
-    When I run `wp post meta clean-duplicates 1 foo < session_no`
-    # Check for contains only, as the string contains a trailing space.
-    Then STDOUT should contain:
-      """
-      Are you sure you want to delete 2 duplicate meta values and keep 1 valid meta value? [y/n]
-      """
-
-    When I run `wp post meta list 1 --keys=foo --format=count`
-    Then STDOUT should be:
-      """
-      3
-      """
-
-    When I run `wp post meta clean-duplicates 1 foo < session_yes`
-    Then STDOUT should contain:
-      """
-      Cleaned up duplicate 'foo' meta values.
-      """
-
-    When I try the previous command again
-    Then STDOUT should contain:
-      """
-      Success: Nothing to clean up: found 1 valid meta value and 0 duplicates.
-      """
-
-    When I try `wp post meta clean-duplicates 1 food`
-    Then STDERR should be:
-      """
-      Error: No meta data found.
-      """
-    And the return code should be 1

--- a/features/post-meta.feature
+++ b/features/post-meta.feature
@@ -525,8 +525,8 @@ Feature: Manage post custom fields
       Success: Cleaned up duplicate enclosures.
       """
 
-    When I run `wp post meta clean-duplicates 1 food`
-    Then STDERR should contain:
+    When I try `wp post meta clean-duplicates 1 food`
+    Then STDERR should be:
       """
       Error: No enclosures found.
       """

--- a/features/post-meta.feature
+++ b/features/post-meta.feature
@@ -523,7 +523,7 @@ Feature: Manage post custom fields
     # Check for contains only, as the string contains a trailing space.
     Then STDOUT should contain:
       """
-      Are you sure you want to delete 2 duplicate enclosures and keep 1 valid enclosures? [y/n]
+      Are you sure you want to delete 2 duplicate meta values and keep 1 valid meta value? [y/n]
       """
 
     When I run `wp post meta list 1 --keys=foo --format=count`
@@ -535,18 +535,18 @@ Feature: Manage post custom fields
     When I run `wp post meta clean-duplicates 1 foo < session_yes`
     Then STDOUT should contain:
       """
-      Success: Cleaned up duplicate enclosures.
+      Cleaned up duplicate 'foo' meta values.
       """
 
     When I try the previous command again
     Then STDOUT should contain:
       """
-      Success: Nothing to clean up: found 1 valid enclosures and 0 duplicate enclosures.
+      Success: Nothing to clean up: found 1 valid meta value and 0 duplicates.
       """
 
     When I try `wp post meta clean-duplicates 1 food`
     Then STDERR should be:
       """
-      Error: No enclosures found.
+      Error: No meta data found.
       """
     And the return code should be 1

--- a/features/post-meta.feature
+++ b/features/post-meta.feature
@@ -488,3 +488,46 @@ Feature: Manage post custom fields
       """
       [ "new", "bar" ]
       """
+
+  Scenario: Clean up duplicate post meta values.
+    Given a WP install
+    And a session_no file:
+      """
+      n
+      """
+    And a session_yes file:
+      """
+      y
+      """
+
+    When I run `wp post meta add 1 foo bar`
+    Then STDOUT should be:
+      """
+      Success: Added custom field.
+      """
+
+    When I try the previous command again
+    Then the return code should be 0
+
+    When I try the previous command again
+    Then the return code should be 0
+
+    When I run `wp post meta clean-duplicates 1 foo < session_no`
+    # Check for contains only, as the string contains a trailing space.
+    Then STDOUT should contain:
+      """
+      Are you sure you want to delete 2 duplicate enclosures and keep 1 valid enclosures? [y/n]
+      """
+
+    When I run `wp post meta clean-duplicates 1 foo < session_yes`
+    Then STDOUT should contain:
+      """
+      Success: Cleaned up duplicate enclosures.
+      """
+
+    When I run `wp post meta clean-duplicates 1 food`
+    Then STDERR should contain:
+      """
+      Error: No enclosures found.
+      """
+    And the return code should be 1

--- a/src/Post_Meta_Command.php
+++ b/src/Post_Meta_Command.php
@@ -148,8 +148,8 @@ class Post_Meta_Command extends CommandWithMeta {
 			WP_CLI::error( 'No meta data found.' );
 		}
 
-		$uniq_metas = [];
-		$dupe_metas = [];
+		$uniq_metas = array();
+		$dupe_metas = array();
 		foreach ( $metas as $meta ) {
 			if ( ! isset( $uniq_metas[ $meta->meta_value ] ) ) {
 				$uniq_metas[ $meta->meta_value ] = (int) $meta->meta_id;
@@ -166,7 +166,7 @@ class Post_Meta_Command extends CommandWithMeta {
 					count( $uniq_metas )
 				)
 			);
-			foreach( $dupe_metas as $meta_id ) {
+			foreach ( $dupe_metas as $meta_id ) {
 				delete_metadata_by_mid( 'post', $meta_id );
 				WP_CLI::log( sprintf( 'Deleted meta id %d.', $meta_id ) );
 			}

--- a/src/Post_Meta_Command.php
+++ b/src/Post_Meta_Command.php
@@ -125,7 +125,7 @@ class Post_Meta_Command extends CommandWithMeta {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Delete dulpicate post meta.
+	 *     # Delete duplicate post meta.
 	 *     wp post meta clean-duplicates 1234 enclosure
 	 *     Success: Cleaned up duplicate 'enclosure' meta values.
 	 *

--- a/src/Post_Meta_Command.php
+++ b/src/Post_Meta_Command.php
@@ -125,7 +125,9 @@ class Post_Meta_Command extends CommandWithMeta {
 	 *
 	 * ## EXAMPLES
 	 *
+	 *     # Delete dulpicate post meta.
 	 *     wp post meta clean-duplicates 1234 enclosure
+	 *     Success: Cleaned up duplicate enclosures.
 	 *
 	 * @subcommand clean-duplicates
 	 */

--- a/src/Post_Meta_Command.php
+++ b/src/Post_Meta_Command.php
@@ -127,7 +127,7 @@ class Post_Meta_Command extends CommandWithMeta {
 	 *
 	 *     # Delete dulpicate post meta.
 	 *     wp post meta clean-duplicates 1234 enclosure
-	 *     Success: Cleaned up duplicate enclosures.
+	 *     Success: Cleaned up duplicate 'enclosure' meta values.
 	 *
 	 * @subcommand clean-duplicates
 	 */
@@ -145,38 +145,38 @@ class Post_Meta_Command extends CommandWithMeta {
 		);
 
 		if ( empty( $metas ) ) {
-			WP_CLI::error( 'No enclosures found.' );
+			WP_CLI::error( 'No meta data found.' );
 		}
 
-		$uniq_enclosures = array();
-		$dupe_enclosures = array();
+		$uniq_metas = [];
+		$dupe_metas = [];
 		foreach ( $metas as $meta ) {
-			if ( ! isset( $uniq_enclosures[ $meta->meta_value ] ) ) {
-				$uniq_enclosures[ $meta->meta_value ] = (int) $meta->meta_id;
+			if ( ! isset( $uniq_metas[ $meta->meta_value ] ) ) {
+				$uniq_metas[ $meta->meta_value ] = (int) $meta->meta_id;
 			} else {
-				$dupe_enclosures[] = (int) $meta->meta_id;
+				$dupe_metas[] = (int) $meta->meta_id;
 			}
 		}
 
-		if ( count( $dupe_enclosures ) ) {
+		if ( count( $dupe_metas ) ) {
 			WP_CLI::confirm(
 				sprintf(
-					'Are you sure you want to delete %d duplicate enclosures and keep %d valid enclosures?',
-					count( $dupe_enclosures ),
-					count( $uniq_enclosures )
+					'Are you sure you want to delete %d duplicate meta values and keep %d valid meta value?',
+					count( $dupe_metas ),
+					count( $uniq_metas )
 				)
 			);
-			foreach ( $dupe_enclosures as $meta_id ) {
+			foreach( $dupe_metas as $meta_id ) {
 				delete_metadata_by_mid( 'post', $meta_id );
 				WP_CLI::log( sprintf( 'Deleted meta id %d.', $meta_id ) );
 			}
-			WP_CLI::success( 'Cleaned up duplicate enclosures.' );
+			WP_CLI::success( sprintf( 'Cleaned up duplicate \'%s\' meta values.', $key ) );
 		} else {
 			WP_CLI::success(
 				sprintf(
-					'Nothing to clean up: found %d valid enclosures and %d duplicate enclosures.',
-					count( $uniq_enclosures ),
-					count( $dupe_enclosures )
+					'Nothing to clean up: found %d valid meta value and %d duplicates.',
+					count( $uniq_metas ),
+					count( $dupe_metas )
 				)
 			);
 		}

--- a/src/Post_Meta_Command.php
+++ b/src/Post_Meta_Command.php
@@ -97,14 +97,14 @@ class Post_Meta_Command extends CommandWithMeta {
 	 *
 	 * @param int    $object_id  ID of the object metadata is for
 	 * @param string $meta_key   Metadata key
-	 * @param mixed $meta_value  Optional. Metadata value. Must be serializable
-	 *                           if non-scalar. If specified, only delete
-	 *                           metadata entries with this value. Otherwise,
-	 *                           delete all entries with the specified meta_key.
-	 *                           Pass `null, `false`, or an empty string to skip
-	 *                           this check. For backward compatibility, it is
-	 *                           not possible to pass an empty string to delete
-	 *                           those entries with an empty string for a value.
+	 * @param mixed  $meta_value  Optional. Metadata value. Must be serializable
+	 *                            if non-scalar. If specified, only delete
+	 *                            metadata entries with this value. Otherwise,
+	 *                            delete all entries with the specified meta_key.
+	 *                            Pass `null, `false`, or an empty string to skip
+	 *                            this check. For backward compatibility, it is
+	 *                            not possible to pass an empty string to delete
+	 *                            those entries with an empty string for a value.
 	 *
 	 * @return bool True on successful delete, false on failure.
 	 */
@@ -146,8 +146,8 @@ class Post_Meta_Command extends CommandWithMeta {
 			WP_CLI::error( 'No enclosures found.' );
 		}
 
-		$uniq_enclosures = [];
-		$dupe_enclosures = [];
+		$uniq_enclosures = array();
+		$dupe_enclosures = array();
 		foreach ( $metas as $meta ) {
 			if ( ! isset( $uniq_enclosures[ $meta->meta_value ] ) ) {
 				$uniq_enclosures[ $meta->meta_value ] = (int) $meta->meta_id;
@@ -164,7 +164,7 @@ class Post_Meta_Command extends CommandWithMeta {
 					count( $uniq_enclosures )
 				)
 			);
-			foreach( $dupe_enclosures as $meta_id ) {
+			foreach ( $dupe_enclosures as $meta_id ) {
 				delete_metadata_by_mid( 'post', $meta_id );
 				WP_CLI::log( sprintf( 'Deleted meta id %d.', $meta_id ) );
 			}

--- a/src/Post_Meta_Command.php
+++ b/src/Post_Meta_Command.php
@@ -145,7 +145,7 @@ class Post_Meta_Command extends CommandWithMeta {
 		);
 
 		if ( empty( $metas ) ) {
-			WP_CLI::error( 'No meta data found.' );
+			WP_CLI::error( sprintf( 'No meta values found for \'%s\'.', $key ) );
 		}
 
 		$uniq_metas = array();


### PR DESCRIPTION
Fixes: #356 

Need suggestions/corrections for labelling. 

QUESTION: Should we do the same for the user and term meta commands.?