### PR TITLE
Show error when parameter is missing in wp option patch

### DIFF
--- a/features/option-pluck-patch.feature
+++ b/features/option-pluck-patch.feature
@@ -317,3 +317,10 @@ Feature: Option commands have pluck and patch.
       Please provide value to update.
       """
     And the return code should be 1
+
+    When I try `wp option patch update option_name foo 0`
+    And STDERR should contain:
+      """
+      Please provide value to update.
+      """
+    And the return code should be 1

--- a/features/option-pluck-patch.feature
+++ b/features/option-pluck-patch.feature
@@ -299,3 +299,21 @@ Feature: Option commands have pluck and patch.
       """
       1
       """
+
+  @patch
+  Scenario: When we don't pass all necessary argumants.
+    Given a WP install
+    And an input.json file:
+      """
+      {
+        "foo": "bar"
+      }
+      """
+    And I run `wp option update option_name --format=json < input.json`
+
+    When I try `wp option patch update option_name foo`
+    And STDERR should contain:
+      """
+      Please provide value to update.
+      """
+    And the return code should be 1

--- a/features/option-pluck-patch.feature
+++ b/features/option-pluck-patch.feature
@@ -318,9 +318,8 @@ Feature: Option commands have pluck and patch.
       """
     And the return code should be 1
 
-    When I try `wp option patch update option_name foo 0`
-    And STDERR should contain:
+    When I run `wp option patch update option_name foo 0`
+    And STDOUT should be:
       """
-      Please provide value to update.
+      Success: Updated 'option_name' option.
       """
-    And the return code should be 1

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -574,7 +574,7 @@ class Option_Command extends WP_CLI_Command {
 					: null );
 
 			if ( empty( $patch_value ) ) {
-				WP_CLI::error( "Please provide value to update." );
+				WP_CLI::error( 'Please provide value to update.' );
 			}
 		}
 

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -569,7 +569,13 @@ class Option_Command extends WP_CLI_Command {
 				: null;
 			$patch_value = ! empty( $stdin_value )
 				? WP_CLI::read_value( $stdin_value, $assoc_args )
-				: WP_CLI::read_value( array_pop( $key_path ), $assoc_args );
+				: ( count( $key_path ) > 1
+					? WP_CLI::read_value( array_pop( $key_path ), $assoc_args )
+					: null );
+
+			if ( empty( $patch_value ) ) {
+				WP_CLI::error( "Please provide value to update." );
+			}
 		}
 
 		/* Need to make a copy of $current_value here as it is modified by reference */

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -578,7 +578,7 @@ class Option_Command extends WP_CLI_Command {
 				}
 			}
 
-			if ( empty( $patch_value ) ) {
+			if ( null === $patch_value ) {
 				WP_CLI::error( 'Please provide value to update.' );
 			}
 		}

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -567,11 +567,16 @@ class Option_Command extends WP_CLI_Command {
 			$stdin_value = EntityUtils::has_stdin()
 				? trim( WP_CLI::get_value_from_arg_or_stdin( $args, -1 ) )
 				: null;
-			$patch_value = ! empty( $stdin_value )
-				? WP_CLI::read_value( $stdin_value, $assoc_args )
-				: ( count( $key_path ) > 1
-					? WP_CLI::read_value( array_pop( $key_path ), $assoc_args )
-					: null );
+
+			if ( ! empty( $stdin_value ) ) {
+				$patch_value = WP_CLI::read_value( $stdin_value, $assoc_args );
+			} else {
+				if ( count( $key_path ) > 1 ) {
+					$patch_value = WP_CLI::read_value( array_pop( $key_path ), $assoc_args );
+				} else {
+					$patch_value = null;
+				}
+			}
 
 			if ( empty( $patch_value ) ) {
 				WP_CLI::error( 'Please provide value to update.' );


### PR DESCRIPTION
Fixes #353 

- Currently, I've displayed an error message when an argument is missing.