### PR TITLE
Allow `user_url` to be set with `wp user create`

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -497,3 +497,12 @@ Feature: Manage WordPress users
       Success: Updated user 1.
       """
     And an email should not be sent
+
+  Scenario: Set user url when creating a user
+    Given a WP install
+    And I run `wp user create testurl sample@email.com --user_url='http://www.testsite.com'`
+
+    When I run `wp user get testurl --fields=user_url`
+    Then STDOUT should be a table containing rows:
+      | Field        | Value                   |
+      | user_url     | http://www.testsite.com |

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -408,6 +408,8 @@ class User_Command extends CommandWithDBObject {
 
 		$user->description = Utils\get_flag_value( $assoc_args, 'description', false );
 
+		$user->user_url = Utils\get_flag_value( $assoc_args, 'user_url', false );
+
 		if ( isset( $assoc_args['user_pass'] ) ) {
 			$user->user_pass = $assoc_args['user_pass'];
 		} else {


### PR DESCRIPTION
Fixes #350 by setting `$user->user_url` from the `user_url` flag value.