### PR TITLE
Use `current_time()` for setting the default value for `user_registered` in `wp user create`

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -17,6 +17,12 @@ Feature: Manage WordPress users
       | ID           | {USER_ID}  |
       | roles        | author     |
 
+    When I run `wp user get {USER_ID} --field=user_registered`
+    Then STDOUT should not contain:
+      """
+      0000-00-00 00:00:00
+      """
+
     When I run `wp user meta get {USER_ID} first_name`
     Then STDOUT should be:
       """

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -397,7 +397,7 @@ class User_Command extends CommandWithDBObject {
 		$user->user_registered = Utils\get_flag_value(
 			$assoc_args,
 			'user_registered',
-			date_format( date_create(), '%F %T' )
+			current_time( 'mysql', true )
 		);
 
 		$user->display_name = Utils\get_flag_value( $assoc_args, 'display_name', false );
@@ -978,7 +978,7 @@ class User_Command extends CommandWithDBObject {
 			$defaults = [
 				'role'            => get_option( 'default_role' ),
 				'user_pass'       => wp_generate_password(),
-				'user_registered' => date_format( date_create(), '%F %T' ),
+				'user_registered' => current_time( 'mysql', true ),
 				'display_name'    => false,
 			];
 			$new_user = array_merge( $defaults, $new_user );


### PR DESCRIPTION
This PR fixes issue #377, by relying on `current_time()` instead of `date_format()` to properly produce a default value for `user_registered` when creating users via `wp user create`.

I've also included a behat test that should fail in `master` (but not on this branch).

**Note:** I did a quick search through the org and this seems to be the only place where we were using `date_format()` with an invalid format.

### Steps to test

1. Check out `master`.
1. Run `wp user create testuser testuser@example.com`.
1. Check that `wp user get testuser` shows `0000-00-00 00:00:00` as the value for the `user_registered` field.
1. Delete the user created in step 2. For example, with `wp user delete testuser`.
1. Check out this branch.
1. Repeat step 2 and confirm that this time the current date/time is the value of the `user_registered` field.

Closes #377.