### PR TITLE
Add `wp option get-autoload` and `wp option set-autoload`

### DIFF
--- a/features/option-get-autoload.feature
+++ b/features/option-get-autoload.feature
@@ -1,0 +1,25 @@
+Feature: Get 'autoload' value for an option
+
+  Scenario: Option doesn't exist
+    Given a WP install
+
+    When I try `wp option get-autoload foo`
+    Then STDERR should be:
+      """
+      Error: Could not get 'foo' option. Does it exist?
+      """
+
+  Scenario: Displays 'autoload' value
+    Given a WP install
+
+    When I run `wp option add foo bar`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp option get-autoload foo`
+    Then STDOUT should be:
+      """
+      yes
+      """

--- a/features/option-set-autoload.feature
+++ b/features/option-set-autoload.feature
@@ -1,0 +1,52 @@
+Feature: Set 'autoload' value for an option
+
+  Scenario: Option doesn't exist
+    Given a WP install
+
+    When I try `wp option set-autoload foo yes`
+    Then STDERR should be:
+      """
+      Error: Could not get 'foo' option. Does it exist?
+      """
+
+  Scenario: Invalid 'autoload' value provided
+    Given a WP install
+
+    When I run `wp option add foo bar`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I try `wp option set-autoload foo invalid`
+    Then STDERR should be:
+      """
+      Error: Invalid value specified for positional arg.
+      """
+
+  Scenario: Successfully updates autoload value
+    Given a WP install
+
+    When I run `wp option add foo bar`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp option get-autoload foo`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp option set-autoload foo no`
+    Then STDOUT should be:
+      """
+      Success: Updated autoload value for 'foo' option.
+      """
+
+    When I run `wp option get-autoload foo`
+    Then STDOUT should be:
+      """
+      no
+      """

--- a/features/option-set-autoload.feature
+++ b/features/option-set-autoload.feature
@@ -45,6 +45,12 @@ Feature: Set 'autoload' value for an option
       Success: Updated autoload value for 'foo' option.
       """
 
+    When I run the previous command again
+    Then STDOUT should be:
+      """
+      Success: Autoload value passed for 'foo' option is unchanged.
+      """
+
     When I run `wp option get-autoload foo`
     Then STDOUT should be:
       """

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -473,7 +473,7 @@ class Option_Command extends WP_CLI_Command {
 	 * : The name of the option to set 'autoload' for.
 	 *
 	 * <autoload>
-	 * : Requires WP 4.2. Should this option be automatically loaded.
+	 * : Should this option be automatically loaded.
 	 * ---
 	 * options:
 	 *   - 'yes'

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -437,6 +437,98 @@ class Option_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Gets the 'autoload' value for an option.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <key>
+	 * : The name of the option to get 'autoload' of.
+	 *
+	 * @subcommand get-autoload
+	 */
+	public function get_autoload( $args ) {
+		global $wpdb;
+
+		list( $option ) = $args;
+
+		$existing = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT autoload FROM $wpdb->options WHERE option_name=%s",
+				$option
+			)
+		);
+		if ( ! $existing ) {
+			WP_CLI::error( "Could not get '{$option}' option. Does it exist?" );;
+		}
+		WP_CLI::log( $existing->autoload );
+	}
+
+	/**
+	 * Sets the 'autoload' value for an option.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <key>
+	 * : The name of the option to set 'autoload' for.
+	 *
+	 * <autoload>
+	 * : Requires WP 4.2. Should this option be automatically loaded.
+	 * ---
+	 * options:
+	 *   - 'yes'
+	 *   - 'no'
+	 * ---
+	 *
+	 * @subcommand set-autoload
+	 */
+	public function set_autoload( $args ) {
+		global $wpdb;
+
+		list( $option, $autoload ) = $args;
+
+		$previous = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT autoload, option_value FROM $wpdb->options WHERE option_name=%s",
+				$option
+			)
+		);
+		if ( ! $previous ) {
+			WP_CLI::error( "Could not get '{$option}' option. Does it exist?" );;
+		}
+
+		if ( $previous->autoload === $autoload ) {
+			WP_CLI::success( "Autoload value passed for '{$option}' option is unchanged." );
+			return;
+		}
+
+		$wpdb->update(
+			$wpdb->options,
+			array( 'autoload' => $autoload ),
+			array( 'option_name' => $option )
+		);
+
+		// Recreate cache refreshing from update_option().
+		$notoptions = wp_cache_get( 'notoptions', 'options' );
+
+		if ( is_array( $notoptions ) && isset( $notoptions[ $option ] ) ) {
+			unset( $notoptions[ $option ] );
+			wp_cache_set( 'notoptions', $notoptions, 'options' );
+		}
+
+		if ( ! wp_installing() ) {
+			$alloptions = wp_load_alloptions( true );
+			if ( isset( $alloptions[ $option ] ) ) {
+				$alloptions[ $option ] = $previous->option_value;
+				wp_cache_set( 'alloptions', $alloptions, 'options' );
+			} else {
+				wp_cache_set( $option, $previous->option_value, 'options' );
+			}
+		}
+
+		WP_CLI::success( "Updated autoload value for '{$option}' option." );
+	}
+
+	/**
 	 * Deletes an option.
 	 *
 	 * ## OPTIONS

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -458,7 +458,8 @@ class Option_Command extends WP_CLI_Command {
 			)
 		);
 		if ( ! $existing ) {
-			WP_CLI::error( "Could not get '{$option}' option. Does it exist?" );;
+			WP_CLI::error( "Could not get '{$option}' option. Does it exist?" );
+
 		}
 		WP_CLI::log( $existing->autoload );
 	}
@@ -493,7 +494,8 @@ class Option_Command extends WP_CLI_Command {
 			)
 		);
 		if ( ! $previous ) {
-			WP_CLI::error( "Could not get '{$option}' option. Does it exist?" );;
+			WP_CLI::error( "Could not get '{$option}' option. Does it exist?" );
+
 		}
 
 		if ( $previous->autoload === $autoload ) {

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -517,7 +517,7 @@ class Option_Command extends WP_CLI_Command {
 			wp_cache_set( 'notoptions', $notoptions, 'options' );
 		}
 
-		if ( ! wp_installing() ) {
+		if ( ! defined( 'WP_INSTALLING' ) ) {
 			$alloptions = wp_load_alloptions( true );
 			if ( isset( $alloptions[ $option ] ) ) {
 				$alloptions[ $option ] = $previous->option_value;


### PR DESCRIPTION
Adds `wp option get-autoload` and `wp option set-autoload` commands:

```
$ wp option add foo bar
Success: Added 'foo' option.
$ wp option get-autoload foo
yes
$ wp option set-autoload foo no
Success: Updated autoload value for 'foo' option.
$ wp option set-autoload foo no
Success: Autoload value passed for 'foo' option is unchanged.
```

These are useful for manipulating the `autoload` value. `wp option update` can't be used for this directly because `update_option()` won't change `autoload` if the `value` doesn't change.

Recreates the cache manipulation inside of `update_option()` too: https://github.com/WordPress/wordpress-develop/blob/04e8bb4bb5ed37dade1b1ddda634e45f7503820d/src/wp-includes/option.php#L525-L540

This feels brittle, but not sure there's a better way around it...