### PR TITLE
Add '--field=url' support for posts, comments, and terms

### DIFF
--- a/features/comment.feature
+++ b/features/comment.feature
@@ -105,6 +105,12 @@ Feature: Manage WordPress comments
       #comment-1
       """
 
+    When I run `wp comment get 1 --field=url`
+    Then STDOUT should contain:
+      """
+      #comment-1
+      """
+
   Scenario: List the URLs of comments
     When I run `wp comment create --comment_post_ID=1 --porcelain`
     Then save STDOUT as {COMMENT_ID}

--- a/features/post.feature
+++ b/features/post.feature
@@ -432,3 +432,25 @@ Feature: Manage WordPress posts
       """
       0
       """
+
+  Scenario: Get Post URL
+
+    When I try `composer require --dev "wp-cli/rewrite-command":"^2"`
+    Then the return code should be 0
+
+    When I run `wp post create --post_title='Test post' --post_type="test" --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {CUSTOM_POST_ID}
+
+    When I run `wp post exists {CUSTOM_POST_ID}`
+    Then STDOUT should be:
+      """
+      Success: Post with ID {CUSTOM_POST_ID} exists.
+      """
+    And the return code should be 0
+
+    When I run `wp post get {CUSTOM_POST_ID} --field=url`
+    Then STDOUT should be:
+      """
+      https://example.com/?p={CUSTOM_POST_ID}
+      """

--- a/features/post.feature
+++ b/features/post.feature
@@ -435,9 +435,6 @@ Feature: Manage WordPress posts
 
   Scenario: Get Post URL
 
-    When I try `composer require --dev "wp-cli/rewrite-command":"^2"`
-    Then the return code should be 0
-
     When I run `wp post create --post_title='Test post' --post_type="test" --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {CUSTOM_POST_ID}

--- a/features/post.feature
+++ b/features/post.feature
@@ -254,6 +254,12 @@ Feature: Manage WordPress posts
       https://example.com/?p={POST_ID}
       """
 
+    When I run `wp post get 1 --field=url`
+    Then STDOUT should be:
+      """
+      https://example.com/?p=1
+      """
+
   Scenario: Update a post from file or STDIN
     Given a content.html file:
       """
@@ -431,23 +437,4 @@ Feature: Manage WordPress posts
     Then STDOUT should be:
       """
       0
-      """
-
-  Scenario: Get the URL of a post
-
-    When I run `wp post create --post_title='Test post' --post_type="test" --porcelain`
-    Then STDOUT should be a number
-    And save STDOUT as {CUSTOM_POST_ID}
-
-    When I run `wp post exists {CUSTOM_POST_ID}`
-    Then STDOUT should be:
-      """
-      Success: Post with ID {CUSTOM_POST_ID} exists.
-      """
-    And the return code should be 0
-
-    When I run `wp post get {CUSTOM_POST_ID} --field=url`
-    Then STDOUT should be:
-      """
-      https://example.com/?p={CUSTOM_POST_ID}
       """

--- a/features/post.feature
+++ b/features/post.feature
@@ -433,7 +433,7 @@ Feature: Manage WordPress posts
       0
       """
 
-  Scenario: Get Post URL
+  Scenario: Get the URL of a post
 
     When I run `wp post create --post_title='Test post' --post_type="test" --porcelain`
     Then STDOUT should be a number

--- a/features/term.feature
+++ b/features/term.feature
@@ -148,6 +148,12 @@ Feature: Manage WordPress terms
       https://example.com/?cat=2
       """
 
+    When I run `wp term get category 1 --field=url`
+    Then STDOUT should be:
+      """
+      https://example.com/?cat=1
+      """
+
   Scenario: Make sure WordPress receives the slashed data it expects
     When I run `wp term create category 'My\Term' --description='My\Term\Description' --porcelain`
     Then save STDOUT as {TERM_ID}

--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -241,6 +241,10 @@ class Comment_Command extends CommandWithDBObject {
 			WP_CLI::error( 'Invalid comment ID.' );
 		}
 
+		if ( ! isset( $comment->url ) ) {
+			$comment->url = get_comment_link( $comment );
+		}
+
 		if ( empty( $assoc_args['fields'] ) ) {
 			$comment_array        = get_object_vars( $comment );
 			$assoc_args['fields'] = array_keys( $comment_array );

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -437,6 +437,10 @@ class Post_Command extends CommandWithDBObject {
 		$post_arr = get_object_vars( $post );
 		unset( $post_arr['filter'] );
 
+		if ( ! isset( $post_arr['url'] ) ) {
+			$post_arr['url'] = get_permalink( $post->ID );
+		}
+
 		if ( empty( $assoc_args['fields'] ) ) {
 			$assoc_args['fields'] = array_keys( $post_arr );
 		}

--- a/src/Term_Command.php
+++ b/src/Term_Command.php
@@ -291,6 +291,10 @@ class Term_Command extends WP_CLI_Command {
 			WP_CLI::error( "Term doesn't exist." );
 		}
 
+		if ( ! isset( $term->url ) ) {
+			$term->url = get_term_link( $term );
+		}
+
 		if ( empty( $assoc_args['fields'] ) ) {
 			$term_array           = get_object_vars( $term );
 			$assoc_args['fields'] = array_keys( $term_array );


### PR DESCRIPTION
Fixes: #120 

Adding `url` in the `wp get post $ID` command