### PR TITLE
add example for deleting multiple post IDs

### DIFF
--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -469,6 +469,12 @@ class Post_Command extends CommandWithDBObject {
 	 *     $ wp post delete 123 --force
 	 *     Success: Deleted post 123.
 	 *
+	 *     # Delete multiple posts
+	 *     $ wp post delete 123 456 789
+	 *     Success: Trashed post 123.
+	 *     Success: Trashed post 456.
+	 *     Success: Trashed post 789.
+	 *
 	 *     # Delete all pages
 	 *     $ wp post delete $(wp post list --post_type='page' --format=ids)
 	 *     Success: Trashed post 1164.


### PR DESCRIPTION
The documentation isn't clear that to delete multiple posts the IDs must be space separated, not comma separated

Fixes #386