### PR TITLE
Replace empty namespace autoloader with classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -189,10 +189,9 @@
         ]
     },
     "autoload": {
-        "psr-4": {
-            "": "src/",
-            "WP_CLI\\": "src/WP_CLI"
-        },
+        "classmap": [
+            "src/"
+        ],
         "files": [
             "entity-command.php"
         ]


### PR DESCRIPTION
This fixes the issue described here: https://github.com/wp-cli/wp-cli/issues/5731

This PR is slightly different compared to the PRs on the other commands, because part of the code is namespaced while another part is not. I still propose to replace the psr-4 autoloader with a classmap for now, until everything is namespaced.