### PR TITLE
Add examples and update the documentation to the `wp post term`

### DIFF
--- a/src/Post_Term_Command.php
+++ b/src/Post_Term_Command.php
@@ -8,9 +8,27 @@ use WP_CLI\Fetchers\Post as PostFetcher;
  *
  * ## EXAMPLES
  *
- *     # Set post terms
+ *     # Set category post term `test` to the post ID 123
  *     $ wp post term set 123 test category
+ *     Success: Set term.
+ *
+ *     # Set category post terms `test` and `apple` to the post ID 123
+ *     $ wp post term set 123 test apple category
  *     Success: Set terms.
+ *
+ *     # List category post terms for the post ID 123
+ *     $ wp post term list 123 category --fields=term_id,slug
+ *     +---------+-------+
+ *     | term_id | slug  |
+ *     +---------+-------+
+ *     | 2       | apple |
+ *     | 3       | test  |
+ *     +----------+------+
+ *
+ *     # Remove category post terms `test` and `apple` for the post ID 123
+ *     $ wp post term remove 123 category test apple
+ *     Success: Removed terms.
+ *
  */
 class Post_Term_Command extends CommandWithTerms {
 	protected $obj_type = 'post';

--- a/src/WP_CLI/CommandWithTerms.php
+++ b/src/WP_CLI/CommandWithTerms.php
@@ -121,7 +121,7 @@ abstract class CommandWithTerms extends WP_CLI_Command {
 	 * : The name of the term's taxonomy.
 	 *
 	 * [<term>...]
-	 * : The slug of the term or terms (space-separated) to be removed from the object.
+	 * : The slug of the term or terms to be removed from the object.
 	 *
 	 * [--by=<field>]
 	 * : Explicitly handle the term value as a slug or id.
@@ -212,7 +212,7 @@ abstract class CommandWithTerms extends WP_CLI_Command {
 	 * : The name of the taxonomy type to be added.
 	 *
 	 * <term>...
-	 * : The slug of the term or terms (space-separated) to be added.
+	 * : The slug of the term or terms to be added.
 	 *
 	 * [--by=<field>]
 	 * : Explicitly handle the term value as a slug or id.
@@ -258,7 +258,7 @@ abstract class CommandWithTerms extends WP_CLI_Command {
 	 * : The name of the taxonomy type to be updated.
 	 *
 	 * <term>...
-	 * : The slug of the term or terms (space-separated) to be updated.
+	 * : The slug of the term or terms to be updated.
 	 *
 	 * [--by=<field>]
 	 * : Explicitly handle the term value as a slug or id.

--- a/src/WP_CLI/CommandWithTerms.php
+++ b/src/WP_CLI/CommandWithTerms.php
@@ -121,11 +121,12 @@ abstract class CommandWithTerms extends WP_CLI_Command {
 	 * : The name of the term's taxonomy.
 	 *
 	 * [<term>...]
-	 * : The name of the term or terms to be removed from the object.
+	 * : The slug of the term or terms (separated by space) to be removed from the object.
 	 *
 	 * [--by=<field>]
 	 * : Explicitly handle the term value as a slug or id.
 	 * ---
+	 * default: slug
 	 * options:
 	 *   - slug
 	 *   - id
@@ -211,11 +212,12 @@ abstract class CommandWithTerms extends WP_CLI_Command {
 	 * : The name of the taxonomy type to be added.
 	 *
 	 * <term>...
-	 * : The slug of the term or terms to be added.
+	 * : The slug of the term or terms (separated by space) to be added.
 	 *
 	 * [--by=<field>]
 	 * : Explicitly handle the term value as a slug or id.
 	 * ---
+	 * default: slug
 	 * options:
 	 *   - slug
 	 *   - id
@@ -253,14 +255,15 @@ abstract class CommandWithTerms extends WP_CLI_Command {
 	 * : The ID of the object.
 	 *
 	 * <taxonomy>
-	 * : The name of the taxonomy type to be updated.
+	 * : The slug of the taxonomy type to be updated.
 	 *
 	 * <term>...
-	 * : The slug of the term or terms to be updated.
+	 * : The slug of the term or terms (separated by space) to be updated.
 	 *
 	 * [--by=<field>]
 	 * : Explicitly handle the term value as a slug or id.
 	 * ---
+	 * default: slug
 	 * options:
 	 *   - slug
 	 *   - id

--- a/src/WP_CLI/CommandWithTerms.php
+++ b/src/WP_CLI/CommandWithTerms.php
@@ -255,7 +255,7 @@ abstract class CommandWithTerms extends WP_CLI_Command {
 	 * : The ID of the object.
 	 *
 	 * <taxonomy>
-	 * : The slug of the taxonomy type to be updated.
+	 * : The name of the taxonomy type to be updated.
 	 *
 	 * <term>...
 	 * : The slug of the term or terms (space-separated) to be updated.

--- a/src/WP_CLI/CommandWithTerms.php
+++ b/src/WP_CLI/CommandWithTerms.php
@@ -121,7 +121,7 @@ abstract class CommandWithTerms extends WP_CLI_Command {
 	 * : The name of the term's taxonomy.
 	 *
 	 * [<term>...]
-	 * : The slug of the term or terms (separated by space) to be removed from the object.
+	 * : The slug of the term or terms (space-separated) to be removed from the object.
 	 *
 	 * [--by=<field>]
 	 * : Explicitly handle the term value as a slug or id.
@@ -212,7 +212,7 @@ abstract class CommandWithTerms extends WP_CLI_Command {
 	 * : The name of the taxonomy type to be added.
 	 *
 	 * <term>...
-	 * : The slug of the term or terms (separated by space) to be added.
+	 * : The slug of the term or terms (space-separated) to be added.
 	 *
 	 * [--by=<field>]
 	 * : Explicitly handle the term value as a slug or id.
@@ -258,7 +258,7 @@ abstract class CommandWithTerms extends WP_CLI_Command {
 	 * : The slug of the taxonomy type to be updated.
 	 *
 	 * <term>...
-	 * : The slug of the term or terms (separated by space) to be updated.
+	 * : The slug of the term or terms (space-separated) to be updated.
 	 *
 	 * [--by=<field>]
 	 * : Explicitly handle the term value as a slug or id.


### PR DESCRIPTION
This PR tries to make more clear the usage of the command `wp post term` by adding more examples and updating the documentation.
