### PR TITLE
Clarify url field in wp site list docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3429,7 +3429,7 @@ wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--field=
 
 	[--<field>=<value>]
 		Filter by one or more fields (see "Available Fields" section). However,
-		'url' isn't an available filter, because it's created from domain + path.
+		'url' isn't an available filter, as it comes from 'home' in wp_options.
 
 	[--site__in=<value>]
 		Only list the sites with these blog_id values (comma-separated).

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -513,7 +513,7 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * [--<field>=<value>]
 	 * : Filter by one or more fields (see "Available Fields" section). However,
-	 * 'url' isn't an available filter, because it's created from domain + path.
+	 * 'url' isn't an available filter, as it comes from 'home' in wp_options.
 	 *
 	 * [--site__in=<value>]
 	 * : Only list the sites with these blog_id values (comma-separated).


### PR DESCRIPTION
Docs update to clarify that the `url` field is pulled from wp_options, not wp_blogs.

Closes #400