### PR TITLE
Warn when an invalid role is provided for `wp user update`

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -426,14 +426,15 @@ Feature: Manage WordPress users
 
   Scenario: Invalid User Role
     Given a WP install
+    And I run `wp user create testuser4@example.com testemail4@example.com`
 
-    When I run `wp user update admin --role=banana`
+    When I run `wp user update testuser4@example.com --role=banana`
     Then STDOUT should contain:
       """
       Warning:
       """
 
-    When I run `wp user update admin --role=admin`
+    When I run `wp user update testuser4@example.com --role=admin`
     Then STDOUT should not contain:
       """
       Warning:

--- a/features/user.feature
+++ b/features/user.feature
@@ -239,6 +239,26 @@ Feature: Manage WordPress users
       | Field | Value |
       | roles |       |
 
+  Scenario: Invalid User Role
+    Given a WP install
+    When I run `wp user create testuser4 testemail4@example.com`
+    And I try `wp user update testuser4 --role=banana`
+    Then STDERR should be:
+      """
+      Warning: Role doesn't exist: banana
+      """
+    And STDOUT should contain:
+      """
+      Success:
+      """
+    And the return code should be 0
+
+    When I run `wp user get admin --field=roles`
+    Then STDOUT should be:
+      """
+      administrator
+      """
+
   Scenario: Managing user capabilities
     Given a WP install
 
@@ -422,22 +442,6 @@ Feature: Manage WordPress users
     Then STDOUT should be:
       """
       testuser4@example.com
-      """
-
-  Scenario: Invalid User Role
-    Given a WP install
-    And I run `wp user create testuser4@example.com testemail4@example.com`
-
-    When I run `wp user update testuser4@example.com --role=banana`
-    Then STDOUT should contain:
-      """
-      Warning:
-      """
-
-    When I run `wp user update testuser4@example.com --role=admin`
-    Then STDOUT should not contain:
-      """
-      Warning:
       """
 
   Scenario: Mark/remove a user from spam

--- a/features/user.feature
+++ b/features/user.feature
@@ -424,6 +424,17 @@ Feature: Manage WordPress users
       testuser4@example.com
       """
 
+  Scenario: Invalid User Role
+    Given a WP install
+
+    When I run `wp user update admin --role=banana`
+    Then STDOUT should contain:
+      """
+      Warning:
+      """
+
+
+
   Scenario: Mark/remove a user from spam
     Given a WP multisite install
     And I run `wp user create bumblebee bbee@example.com --role=author --porcelain`

--- a/features/user.feature
+++ b/features/user.feature
@@ -433,7 +433,11 @@ Feature: Manage WordPress users
       Warning:
       """
 
-
+    When I run `wp user update admin --role=admin`
+    Then STDOUT should not contain:
+      """
+      Warning:
+      """
 
   Scenario: Mark/remove a user from spam
     Given a WP multisite install

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -530,10 +530,7 @@ class User_Command extends CommandWithDBObject {
 		}
 
 		if ( isset( $assoc_args['role'] ) ) {
-			$role = $assoc_args['role'];
-			if ( ! in_array( $role, wp_roles()->role_names, true ) ) {
-				WP_CLI::warning( 'Invalid Role' );
-			}
+			self::validate_role( $assoc_args['role'], true );
 		}
 
 		$user_ids = [];
@@ -1163,12 +1160,17 @@ class User_Command extends CommandWithDBObject {
 	/**
 	 * Checks whether the role is valid
 	 *
-	 * @param string
+	 * @param $role string
+	 * @param $warn_user_only bool
 	 */
-	private static function validate_role( $role ) {
+	private static function validate_role( $role, $warn_user_only = false ) {
 
 		if ( ! empty( $role ) && null === get_role( $role ) ) {
-			WP_CLI::error( "Role doesn't exist: {$role}" );
+			if ( $warn_user_only ) {
+				WP_CLI::warning( "Role doesn't exist: {$role}" );
+			} else {
+				WP_CLI::error( "Role doesn't exist: {$role}" );
+			}
 		}
 
 	}

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -529,6 +529,13 @@ class User_Command extends CommandWithDBObject {
 			unset( $assoc_args['user_login'] );
 		}
 
+		if ( isset( $assoc_args['role'] ) ) {
+			$role = $assoc_args['role'];
+			if ( ! in_array( $role, wp_roles()->role_names, true ) ) {
+				WP_CLI::warning( 'Invalid Role' );
+			}
+		}
+
 		$user_ids = [];
 		foreach ( $this->fetcher->get_many( $args ) as $user ) {
 			$user_ids[] = $user->ID;


### PR DESCRIPTION
GitHub Issue: https://github.com/wp-cli/entity-command/issues/160

- Added the Check whether inputted role exist or not if not than warning is displayed.
