### PR TITLE
User: Add more examples for scoped password reset

### DIFF
--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -1114,6 +1114,18 @@ class User_Command extends CommandWithDBObject {
 	 *     $ wp user reset-password admin --skip-email --porcelain
 	 *     yV6BP*!d70wg
 	 *
+	 *     # Reset password for all users.
+	 *     $ wp user reset-password $(wp user list --format=ids)
+	 *     Reset password for admin
+	 *     Reset password for editor
+	 *     Reset password for subscriber
+	 *     Success: Passwords reset for 3 users.
+	 *
+	 *     # Reset password for all users with a particular role.
+	 *     $ wp user reset-password $(wp user list --format=ids --role=administrator)
+	 *     Reset password for admin
+	 *     Success: Password reset for 1 user.
+	 *
 	 * @subcommand reset-password
 	 */
 	public function reset_password( $args, $assoc_args ) {


### PR DESCRIPTION
When an account has been compromised, then resetting the passwords of users with a particular role or all users can be helpful.

Rather than add new flags to the `user reset-password` command, we can document how to combine with the existing `user list` command instead ("[composability is a good idea](https://make.wordpress.org/cli/handbook/contributions/philosophy/#composability-is-always-a-good-idea)"). This will then appear when `wp user reset-password --help` is run.

Fixes #282.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
