### PR TITLE
PHP 8.2 Deprecation: Fix creation of dynamic property.

### DIFF
--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -41,6 +41,8 @@ class Comment_Command extends CommandWithDBObject {
 		'comment_author_email',
 	];
 
+	private $fetcher;
+
 	public function __construct() {
 		$this->fetcher = new CommentFetcher();
 	}

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -36,6 +36,8 @@ class Post_Command extends CommandWithDBObject {
 		'post_status',
 	];
 
+	private $fetcher;
+
 	public function __construct() {
 		$this->fetcher = new PostFetcher();
 	}

--- a/src/Post_Term_Command.php
+++ b/src/Post_Term_Command.php
@@ -33,6 +33,8 @@ use WP_CLI\Fetchers\Post as PostFetcher;
 class Post_Term_Command extends CommandWithTerms {
 	protected $obj_type = 'post';
 
+	private $fetcher;
+
 	public function __construct() {
 		$this->fetcher = new PostFetcher();
 	}

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -33,6 +33,8 @@ class Site_Command extends CommandWithDBObject {
 	protected $obj_type   = 'site';
 	protected $obj_id_key = 'blog_id';
 
+	private $fetcher;
+
 	public function __construct() {
 		$this->fetcher = new SiteFetcher();
 	}

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -48,6 +48,7 @@ class User_Command extends CommandWithDBObject {
 	private $cap_fields = [
 		'name',
 	];
+	private $fetcher;
 
 	public function __construct() {
 		$this->fetcher = new UserFetcher();

--- a/src/User_Meta_Command.php
+++ b/src/User_Meta_Command.php
@@ -33,6 +33,8 @@ use WP_CLI\Fetchers\User as UserFetcher;
 class User_Meta_Command extends CommandWithMeta {
 	protected $meta_type = 'user';
 
+	private $fetcher;
+
 	public function __construct() {
 		$this->fetcher = new UserFetcher();
 	}


### PR DESCRIPTION
If I use WP CLI 2.8.1 with PHP 8.2.7 and call `wp site list`, I get a PHP deprecation message:

`Deprecated: Creation of dynamic property Site_Command::$fetcher is deprecated in phar:///usr/local/bin/wp/vendor/wp-cli/entity-command/src/Site_Command.php on line 37`


This PR adds properties to all classes with a fetcher.
