### PR TITLE
Add `--slug=<site>` as an available parameter to `wp site` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -3271,18 +3271,24 @@ wp site
 Activates one or more sites.
 
 ~~~
-wp site activate <id>...
+wp site activate [<id>...] [--slug=<slug>]
 ~~~
 
 **OPTIONS**
 
-	<id>...
-		One or more IDs of sites to activate.
+	[<id>...]
+		One or more IDs of sites to activate. If not provided, you must set the --slug parameter.
+
+	[--slug=<slug>]
+		Path of the site to be activated. Subdomain on subdomain installs, directory on subdirectory installs.
 
 **EXAMPLES**
 
     $ wp site activate 123
     Success: Site 123 activated.
+
+     $ wp site activate --slug=demo
+     Success: Site 123 marked as activated.
 
 
 
@@ -3291,17 +3297,23 @@ wp site activate <id>...
 Archives one or more sites.
 
 ~~~
-wp site archive <id>...
+wp site archive [<id>...] [--slug=<slug>]
 ~~~
 
 **OPTIONS**
 
-	<id>...
-		One or more IDs of sites to archive.
+	[<id>...]
+		One or more IDs of sites to archive. If not provided, you must set the --slug parameter.
+
+	[--slug=<slug>]
+		Path of the site to archive. Subdomain on subdomain installs, directory on subdirectory installs.
 
 **EXAMPLES**
 
     $ wp site archive 123
+    Success: Site 123 archived.
+
+    $ wp site archive --slug=demo
     Success: Site 123 archived.
 
 
@@ -3346,18 +3358,24 @@ wp site create --slug=<slug> [--title=<title>] [--email=<email>] [--network_id=<
 Deactivates one or more sites.
 
 ~~~
-wp site deactivate <id>...
+wp site deactivate [<id>...] [--slug=<slug>]
 ~~~
 
 **OPTIONS**
 
-	<id>...
-		One or more IDs of sites to deactivate.
+	[<id>...]
+		One or more IDs of sites to deactivate. If not provided, you must set the --slug parameter.
+
+	[--slug=<slug>]
+		Path of the site to be deactivated. Subdomain on subdomain installs, directory on subdirectory installs.
 
 **EXAMPLES**
 
     $ wp site deactivate 123
     Success: Site 123 deactivated.
+
+     $ wp site deactivate --slug=demo
+     Success: Site 123 marked as deactivated.
 
 
 
@@ -3375,7 +3393,7 @@ wp site delete [<site-id>] [--slug=<slug>] [--yes] [--keep-tables]
 		The id of the site to delete. If not provided, you must set the --slug parameter.
 
 	[--slug=<slug>]
-		Path of the blog to be deleted. Subdomain on subdomain installs, directory on subdirectory installs.
+		Path of the site to be deleted. Subdomain on subdomain installs, directory on subdirectory installs.
 
 	[--yes]
 		Answer yes to the confirmation message.
@@ -3508,17 +3526,23 @@ These fields are optionally available:
 Sets one or more sites as mature.
 
 ~~~
-wp site mature <id>...
+wp site mature [<id>...] [--slug=<slug>]
 ~~~
 
 **OPTIONS**
 
-	<id>...
-		One or more IDs of sites to set as mature.
+	[<id>...]
+		One or more IDs of sites to set as mature. If not provided, you must set the --slug parameter.
+
+	[--slug=<slug>]
+		Path of the site to be set as mature. Subdomain on subdomain installs, directory on subdirectory installs.
 
 **EXAMPLES**
 
     $ wp site mature 123
+    Success: Site 123 marked as mature.
+
+    $ wp site mature --slug=demo
     Success: Site 123 marked as mature.
 
 
@@ -3558,17 +3582,23 @@ wp site option
 Sets one or more sites as private.
 
 ~~~
-wp site private <id>...
+wp site private [<id>...] [--slug=<slug>]
 ~~~
 
 **OPTIONS**
 
-	<id>...
-		One or more IDs of sites to set as private.
+	[<id>...]
+		One or more IDs of sites to set as private. If not provided, you must set the --slug parameter.
+
+	[--slug=<slug>]
+		Path of the site to be set as private. Subdomain on subdomain installs, directory on subdirectory installs.
 
 **EXAMPLES**
 
     $ wp site private 123
+    Success: Site 123 marked as private.
+
+    $ wp site private --slug=demo
     Success: Site 123 marked as private.
 
 
@@ -3578,18 +3608,24 @@ wp site private <id>...
 Sets one or more sites as public.
 
 ~~~
-wp site public <id>...
+wp site public [<id>...] [--slug=<slug>]
 ~~~
 
 **OPTIONS**
 
-	<id>...
-		One or more IDs of sites to set as public.
+	[<id>...]
+		One or more IDs of sites to set as public. If not provided, you must set the --slug parameter.
+
+	[--slug=<slug>]
+		Path of the site to be set as public. Subdomain on subdomain installs, directory on subdirectory installs.
 
 **EXAMPLES**
 
     $ wp site public 123
     Success: Site 123 marked as public.
+
+     $ wp site public --slug=demo
+     Success: Site 123 marked as public.
 
 
 
@@ -3598,13 +3634,16 @@ wp site public <id>...
 Marks one or more sites as spam.
 
 ~~~
-wp site spam <id>...
+wp site spam [<id>...] [--slug=<slug>]
 ~~~
 
 **OPTIONS**
 
-	<id>...
-		One or more IDs of sites to be marked as spam.
+	[<id>...]
+		One or more IDs of sites to be marked as spam. If not provided, you must set the --slug parameter.
+
+	[--slug=<slug>]
+		Path of the site to be marked as spam. Subdomain on subdomain installs, directory on subdirectory installs.
 
 **EXAMPLES**
 
@@ -3618,17 +3657,23 @@ wp site spam <id>...
 Unarchives one or more sites.
 
 ~~~
-wp site unarchive <id>...
+wp site unarchive [<id>...] [--slug=<slug>]
 ~~~
 
 **OPTIONS**
 
-	<id>...
-		One or more IDs of sites to unarchive.
+	[<id>...]
+		One or more IDs of sites to unarchive. If not provided, you must set the --slug parameter.
+
+	[--slug=<slug>]
+		Path of the site to unarchive. Subdomain on subdomain installs, directory on subdirectory installs.
 
 **EXAMPLES**
 
     $ wp site unarchive 123
+    Success: Site 123 unarchived.
+
+    $ wp site unarchive --slug=demo
     Success: Site 123 unarchived.
 
 
@@ -3638,17 +3683,23 @@ wp site unarchive <id>...
 Sets one or more sites as immature.
 
 ~~~
-wp site unmature <id>...
+wp site unmature [<id>...] [--slug=<slug>]
 ~~~
 
 **OPTIONS**
 
-	<id>...
-		One or more IDs of sites to set as unmature.
+	[<id>...]
+		One or more IDs of sites to set as unmature. If not provided, you must set the --slug parameter.
+
+	[--slug=<slug>]
+		Path of the site to be set as unmature. Subdomain on subdomain installs, directory on subdirectory installs.
 
 **EXAMPLES**
 
-    $ wp site general 123
+    $ wp site unmature 123
+    Success: Site 123 marked as unmature.
+
+    $ wp site unmature --slug=demo
     Success: Site 123 marked as unmature.
 
 
@@ -3658,13 +3709,16 @@ wp site unmature <id>...
 Removes one or more sites from spam.
 
 ~~~
-wp site unspam <id>...
+wp site unspam [<id>...] [--slug=<slug>]
 ~~~
 
 **OPTIONS**
 
-	<id>...
-		One or more IDs of sites to remove from spam.
+	[<id>...]
+		One or more IDs of sites to remove from spam. If not provided, you must set the --slug parameter.
+
+	[--slug=<slug>]
+		Path of the site to be removed from spam. Subdomain on subdomain installs, directory on subdirectory installs.
 
 **EXAMPLES**
 

--- a/features/site.feature
+++ b/features/site.feature
@@ -159,6 +159,27 @@ Feature: Manage sites in a multisite installation
       """
     And STDOUT should be empty
 
+  Scenario: Site IDs or a slug can be provided, but not both.
+    Given a WP multisite install
+    And I run `wp site create --slug=first --porcelain`
+
+    When I try `wp site private 1 --slug=first`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: Please specify one or more IDs of sites, or pass the slug for a single site using --slug.
+      """
+
+  Scenario: Errors for an invalid slug
+    Given a WP multisite install
+
+    When I try `wp site private --slug=first`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: Could not find site with slug 'first'.
+      """
+
   Scenario: Archive/unarchive a site
     Given a WP multisite install
     And I run `wp site create --slug=first --porcelain`

--- a/features/site.feature
+++ b/features/site.feature
@@ -148,6 +148,17 @@ Feature: Manage sites in a multisite installation
       {SCHEME}://example.com/first/
       """
 
+  Scenario: Not providing a site ID or slug when running an update blog status command should throw an error
+    Given a WP multisite install
+
+    When I try `wp site private`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: Please specify one or more IDs of sites, or pass the slug for a single site using --slug.
+      """
+    And STDOUT should be empty
+
   Scenario: Archive/unarchive a site
     Given a WP multisite install
     And I run `wp site create --slug=first --porcelain`

--- a/features/site.feature
+++ b/features/site.feature
@@ -440,3 +440,208 @@ Feature: Manage sites in a multisite installation
       """
       My\Site
       """
+
+  Scenario: Activate/deactivate a site by slug
+    Given a WP multisite install
+
+    When I run `wp site create --slug=first`
+    Then STDOUT should contain:
+      """
+      Success: Site 2 created: http
+      """
+    And STDOUT should contain:
+      """
+      ://example.com/first/
+      """
+
+    When I run `wp site deactivate --slug=first`
+    Then STDOUT should contain:
+      """
+      Success: Site 2 deactivated.
+      """
+
+    When I run `wp site list --fields=blog_id,deleted`
+    Then STDOUT should be a table containing rows:
+      | blog_id | deleted |
+      | 2       | 1       |
+
+    When I try `wp site deactivate --slug=first`
+    Then STDERR should be:
+      """
+      Warning: Site 2 already deactivated.
+      """
+
+    When I run `wp site activate --slug=first`
+    Then STDOUT should be:
+      """
+      Success: Site 2 activated.
+      """
+
+    When I run `wp site list --fields=blog_id,deleted`
+    Then STDOUT should be a table containing rows:
+      | blog_id | deleted |
+      | 2       | 0       |
+
+  Scenario: Archive/unarchive a site by slug
+    Given a WP multisite install
+
+    When I run `wp site create --slug=first`
+    Then STDOUT should contain:
+      """
+      Success: Site 2 created: http
+      """
+    And STDOUT should contain:
+      """
+      ://example.com/first/
+      """
+
+    When I run `wp site archive --slug=first`
+    Then STDOUT should contain:
+      """
+      Success: Site 2 archived.
+      """
+
+    When I run `wp site list --fields=blog_id,archived`
+    Then STDOUT should be a table containing rows:
+      | blog_id | archived |
+      | 2       | 1        |
+
+    When I try `wp site archive --slug=first`
+    Then STDERR should be:
+      """
+      Warning: Site 2 already archived.
+      """
+
+    When I run `wp site unarchive --slug=first`
+    Then STDOUT should be:
+      """
+      Success: Site 2 unarchived.
+      """
+
+    When I run `wp site list --fields=blog_id,archived`
+    Then STDOUT should be a table containing rows:
+      | blog_id | archived |
+      | 2       | 0        |
+
+  Scenario: Mark/remove a site by slug from spam
+    Given a WP multisite install
+
+    When I run `wp site create --slug=first`
+    Then STDOUT should contain:
+      """
+      Success: Site 2 created: http
+      """
+    And STDOUT should contain:
+      """
+      ://example.com/first/
+      """
+
+    When I run `wp site spam --slug=first`
+    Then STDOUT should contain:
+      """
+      Success: Site 2 marked as spam.
+      """
+
+    When I run `wp site list --fields=blog_id,spam`
+    Then STDOUT should be a table containing rows:
+      | blog_id | spam |
+      | 2       | 1    |
+
+    When I try `wp site spam --slug=first`
+    Then STDERR should be:
+      """
+      Warning: Site 2 already marked as spam.
+      """
+
+    When I run `wp site unspam --slug=first`
+    Then STDOUT should be:
+      """
+      Success: Site 2 removed from spam.
+      """
+
+    When I run `wp site list --fields=blog_id,spam`
+    Then STDOUT should be a table containing rows:
+      | blog_id | spam |
+      | 2       | 0    |
+
+  Scenario: Mark/remove a site by slug as mature
+    Given a WP multisite install
+
+    When I run `wp site create --slug=first`
+    Then STDOUT should contain:
+      """
+      Success: Site 2 created: http
+      """
+    And STDOUT should contain:
+      """
+      ://example.com/first/
+      """
+
+    When I run `wp site mature --slug=first`
+    Then STDOUT should contain:
+      """
+      Success: Site 2 marked as mature.
+      """
+
+    When I run `wp site list --fields=blog_id,mature`
+    Then STDOUT should be a table containing rows:
+      | blog_id | mature |
+      | 2       | 1      |
+
+    When I try `wp site mature --slug=first`
+    Then STDERR should be:
+      """
+      Warning: Site 2 already marked as mature.
+      """
+
+    When I run `wp site unmature --slug=first`
+    Then STDOUT should be:
+      """
+      Success: Site 2 marked as unmature.
+      """
+
+    When I run `wp site list --fields=blog_id,mature`
+    Then STDOUT should be a table containing rows:
+      | blog_id | mature |
+      | 2       | 0      |
+
+  Scenario: Set/Unset a site by slug as public
+    Given a WP multisite install
+
+    When I run `wp site create --slug=first`
+    Then STDOUT should contain:
+      """
+      Success: Site 2 created: http
+      """
+    And STDOUT should contain:
+      """
+      ://example.com/first/
+      """
+
+    When I run `wp site private --slug=first`
+    Then STDOUT should contain:
+      """
+      Success: Site 2 marked as private.
+      """
+
+    When I run `wp site list --fields=blog_id,public`
+    Then STDOUT should be a table containing rows:
+      | blog_id | public |
+      | 2       | 0      |
+
+    When I try `wp site private --slug=first`
+    Then STDERR should be:
+      """
+      Warning: Site 2 already marked as private.
+      """
+
+    When I run `wp site public --slug=first`
+    Then STDOUT should be:
+      """
+      Success: Site 2 marked as public.
+      """
+
+    When I run `wp site list --fields=blog_id,public`
+    Then STDOUT should be a table containing rows:
+      | blog_id | public |
+      | 2       | 1      |

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -976,17 +976,15 @@ class Site_Command extends CommandWithDBObject {
 	private function get_sites_ids( $args, $assoc_args ) {
 		$slug = Utils\get_flag_value( $assoc_args, 'slug', false );
 
-		$ids = $args;
-
 		if ( $slug ) {
 			$blog = get_blog_details( trim( $slug, '/' ) );
 			if ( ! $blog ) {
-				WP_CLI::error( sprintf( 'Could not find the site with slug %s.', $slug ) );
+				WP_CLI::error( sprintf( 'Could not find site with slug \'%s\'.', $slug ) );
 			}
-			$ids = [ $blog->blog_id ];
+			return [ $blog->blog_id ];
 		}
 
-		return $ids;
+		return $args;
 	}
 
 	/**
@@ -999,7 +997,8 @@ class Site_Command extends CommandWithDBObject {
 	 * @throws ExitException If neither site ids nor site slug using --slug were provided.
 	 */
 	private function check_site_ids_and_slug( $args, $assoc_args ) {
-		if ( empty( $args ) && empty( $assoc_args['slug'] ) ) {
+		if ( ( empty( $args ) && empty( $assoc_args['slug'] ) )
+			|| ( ! empty( $args ) && ! empty( $assoc_args['slug'] ) ) ) {
 			WP_CLI::error( 'Please specify one or more IDs of sites, or pass the slug for a single site using --slug.' );
 		}
 

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -650,12 +650,7 @@ class Site_Command extends CommandWithDBObject {
 	 */
 	public function archive( $args, $assoc_args ) {
 		if ( isset( $assoc_args['slug'] ) ) {
-			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
-
-			if ( ! $blog ) {
-				WP_CLI::error( 'Site not found.' );
-			}
-
+			$blog = $this->get_site_by_slug( $assoc_args['slug'] );
 			$this->update_site_status( [ $blog->blog_id ], 'archived', 1 );
 		} else {
 			$this->update_site_status( $args, 'archived', 1 );
@@ -680,12 +675,7 @@ class Site_Command extends CommandWithDBObject {
 	 */
 	public function unarchive( $args, $assoc_args ) {
 		if ( isset( $assoc_args['slug'] ) ) {
-			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
-
-			if ( ! $blog ) {
-				WP_CLI::error( 'Site not found.' );
-			}
-
+			$blog = $this->get_site_by_slug( $assoc_args['slug'] );
 			$this->update_site_status( [ $blog->blog_id ], 'archived', 0 );
 		} else {
 			$this->update_site_status( $args, 'archived', 0 );
@@ -710,12 +700,7 @@ class Site_Command extends CommandWithDBObject {
 	 */
 	public function activate( $args, $assoc_args ) {
 		if ( isset( $assoc_args['slug'] ) ) {
-			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
-
-			if ( ! $blog ) {
-				WP_CLI::error( 'Site not found.' );
-			}
-
+			$blog = $this->get_site_by_slug( $assoc_args['slug'] );
 			$this->update_site_status( [ $blog->blog_id ], 'deleted', 0 );
 		} else {
 			$this->update_site_status( $args, 'deleted', 0 );
@@ -740,12 +725,7 @@ class Site_Command extends CommandWithDBObject {
 	 */
 	public function deactivate( $args, $assoc_args ) {
 		if ( isset( $assoc_args['slug'] ) ) {
-			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
-
-			if ( ! $blog ) {
-				WP_CLI::error( 'Site not found.' );
-			}
-
+			$blog = $this->get_site_by_slug( $assoc_args['slug'] );
 			$this->update_site_status( [ $blog->blog_id ], 'deleted', 1 );
 		} else {
 			$this->update_site_status( $args, 'deleted', 1 );
@@ -770,12 +750,7 @@ class Site_Command extends CommandWithDBObject {
 	 */
 	public function spam( $args, $assoc_args ) {
 		if ( isset( $assoc_args['slug'] ) ) {
-			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
-
-			if ( ! $blog ) {
-				WP_CLI::error( 'Site not found.' );
-			}
-
+			$blog = $this->get_site_by_slug( $assoc_args['slug'] );
 			$this->update_site_status( [ $blog->blog_id ], 'spam', 1 );
 		} else {
 			$this->update_site_status( $args, 'spam', 1 );
@@ -802,12 +777,7 @@ class Site_Command extends CommandWithDBObject {
 	 */
 	public function unspam( $args, $assoc_args ) {
 		if ( isset( $assoc_args['slug'] ) ) {
-			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
-
-			if ( ! $blog ) {
-				WP_CLI::error( 'Site not found.' );
-			}
-
+			$blog = $this->get_site_by_slug( $assoc_args['slug'] );
 			$this->update_site_status( [ $blog->blog_id ], 'spam', 0 );
 		} else {
 			$this->update_site_status( $args, 'spam', 0 );
@@ -832,12 +802,7 @@ class Site_Command extends CommandWithDBObject {
 	 */
 	public function mature( $args, $assoc_args ) {
 		if ( isset( $assoc_args['slug'] ) ) {
-			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
-
-			if ( ! $blog ) {
-				WP_CLI::error( 'Site not found.' );
-			}
-
+			$blog = $this->get_site_by_slug( $assoc_args['slug'] );
 			$this->update_site_status( [ $blog->blog_id ], 'mature', 1 );
 		} else {
 			$this->update_site_status( $args, 'mature', 1 );
@@ -862,12 +827,7 @@ class Site_Command extends CommandWithDBObject {
 	 */
 	public function unmature( $args, $assoc_args ) {
 		if ( isset( $assoc_args['slug'] ) ) {
-			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
-
-			if ( ! $blog ) {
-				WP_CLI::error( 'Site not found.' );
-			}
-
+			$blog = $this->get_site_by_slug( $assoc_args['slug'] );
 			$this->update_site_status( [ $blog->blog_id ], 'mature', 0 );
 		} else {
 			$this->update_site_status( $args, 'mature', 0 );
@@ -894,12 +854,7 @@ class Site_Command extends CommandWithDBObject {
 	 */
 	public function set_public( $args, $assoc_args ) {
 		if ( isset( $assoc_args['slug'] ) ) {
-			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
-
-			if ( ! $blog ) {
-				WP_CLI::error( 'Site not found.' );
-			}
-
+			$blog = $this->get_site_by_slug( $assoc_args['slug'] );
 			$this->update_site_status( [ $blog->blog_id ], 'public', 1 );
 		} else {
 			$this->update_site_status( $args, 'public', 1 );
@@ -926,12 +881,7 @@ class Site_Command extends CommandWithDBObject {
 	 */
 	public function set_private( $args, $assoc_args ) {
 		if ( isset( $assoc_args['slug'] ) ) {
-			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
-
-			if ( ! $blog ) {
-				WP_CLI::error( 'Site not found.' );
-			}
-
+			$blog = $this->get_site_by_slug( $assoc_args['slug'] );
 			$this->update_site_status( [ $blog->blog_id ], 'public', 0 );
 		} else {
 			$this->update_site_status( $args, 'public', 0 );

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -671,16 +671,29 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <id>...
-	 * : One or more IDs of sites to activate.
+	 * [<id>...]
+	 * : One or more IDs of sites to activate. If not provided, you must set the --slug parameter.
+	 *
+	 * [--slug=<slug>]
+	 * : Path of the blog to be activated. Subdomain on subdomain installs, directory on subdirectory installs.
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp site activate 123
 	 *     Success: Site 123 activated.
 	 */
-	public function activate( $args ) {
-		$this->update_site_status( $args, 'deleted', 0 );
+	public function activate( $args, $assoc_args ) {
+		if ( isset( $assoc_args['slug'] ) ) {
+			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
+
+			if ( ! $blog ) {
+				WP_CLI::error( 'Site not found.' );
+			}
+
+			$this->update_site_status( [ $blog->blog_id ], 'deleted', 0 );
+		} else {
+			$this->update_site_status( $args, 'deleted', 0 );
+		}
 	}
 
 	/**

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -637,16 +637,29 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <id>...
-	 * : One or more IDs of sites to archive.
+	 * [<id>...]
+	 * : One or more IDs of sites to archive. If not provided, you must set the --slug parameter.
+	 *
+	 * [--slug=<slug>]
+	 * : Path of the blog to archive. Subdomain on subdomain installs, directory on subdirectory installs.
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp site archive 123
 	 *     Success: Site 123 archived.
 	 */
-	public function archive( $args ) {
-		$this->update_site_status( $args, 'archived', 1 );
+	public function archive( $args, $assoc_args ) {
+		if ( isset( $assoc_args['slug'] ) ) {
+			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
+
+			if ( ! $blog ) {
+				WP_CLI::error( 'Site not found.' );
+			}
+
+			$this->update_site_status( [ $blog->blog_id ], 'archived', 1 );
+		} else {
+			$this->update_site_status( $args, 'archived', 1 );
+		}
 	}
 
 	/**

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -654,16 +654,29 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <id>...
-	 * : One or more IDs of sites to unarchive.
+	 * [<id>...]
+	 * : One or more IDs of sites to unarchive. If not provided, you must set the --slug parameter.
+	 *
+	 * [--slug=<slug>]
+	 * : Path of the blog to unarchive. Subdomain on subdomain installs, directory on subdirectory installs.
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp site unarchive 123
 	 *     Success: Site 123 unarchived.
 	 */
-	public function unarchive( $args ) {
-		$this->update_site_status( $args, 'archived', 0 );
+	public function unarchive( $args, $assoc_args ) {
+		if ( isset( $assoc_args['slug'] ) ) {
+			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
+
+			if ( ! $blog ) {
+				WP_CLI::error( 'Site not found.' );
+			}
+
+			$this->update_site_status( [ $blog->blog_id ], 'archived', 0 );
+		} else {
+			$this->update_site_status( $args, 'archived', 0 );
+		}
 	}
 
 	/**

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -794,8 +794,11 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <id>...
-	 * : One or more IDs of sites to set as private.
+	 * [<id>...]
+	 * : One or more IDs of sites to set as private. If not provided, you must set the --slug parameter.
+	 *
+	 * [--slug=<slug>]
+	 * : Path of the blog to be set as private. Subdomain on subdomain installs, directory on subdirectory installs.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -804,8 +807,18 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * @subcommand private
 	 */
-	public function set_private( $args ) {
-		$this->update_site_status( $args, 'public', 0 );
+	public function set_private( $args, $assoc_args ) {
+		if ( isset( $assoc_args['slug'] ) ) {
+			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
+
+			if ( ! $blog ) {
+				WP_CLI::error( 'Site not found.' );
+			}
+
+			$this->update_site_status( [ $blog->blog_id ], 'public', 0 );
+		} else {
+			$this->update_site_status( $args, 'public', 0 );
+		}
 	}
 
 	private function update_site_status( $ids, $pref, $value ) {

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -722,8 +722,11 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <id>...
-	 * : One or more IDs of sites to remove from spam.
+	 * [<id>...]
+	 * : One or more IDs of sites to remove from spam. If not provided, you must set the --slug parameter.
+	 *
+	 * [--slug=<slug>]
+	 * : Path of the blog to be removed from spam. Subdomain on subdomain installs, directory on subdirectory installs.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -732,8 +735,18 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * @subcommand unspam
 	 */
-	public function unspam( $args ) {
-		$this->update_site_status( $args, 'spam', 0 );
+	public function unspam( $args, $assoc_args ) {
+		if ( isset( $assoc_args['slug'] ) ) {
+			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
+
+			if ( ! $blog ) {
+				WP_CLI::error( 'Site not found.' );
+			}
+
+			$this->update_site_status( [ $blog->blog_id ], 'spam', 0 );
+		} else {
+			$this->update_site_status( $args, 'spam', 0 );
+		}
 	}
 
 	/**

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -688,16 +688,29 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <id>...
-	 * : One or more IDs of sites to deactivate.
+	 * [<id>...]
+	 * : One or more IDs of sites to deactivate. If not provided, you must set the --slug parameter.
+	 *
+	 * [--slug=<slug>]
+	 * : Path of the blog to be deactivated. Subdomain on subdomain installs, directory on subdirectory installs.
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp site deactivate 123
 	 *     Success: Site 123 deactivated.
 	 */
-	public function deactivate( $args ) {
-		$this->update_site_status( $args, 'deleted', 1 );
+	public function deactivate( $args, $assoc_args ) {
+		if ( isset( $assoc_args['slug'] ) ) {
+			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
+
+			if ( ! $blog ) {
+				WP_CLI::error( 'Site not found.' );
+			}
+
+			$this->update_site_status( [ $blog->blog_id ], 'deleted', 1 );
+		} else {
+			$this->update_site_status( $args, 'deleted', 1 );
+		}
 	}
 
 	/**

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -775,8 +775,11 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <id>...
-	 * : One or more IDs of sites to set as public.
+	 * [<id>...]
+	 * : One or more IDs of sites to set as public. If not provided, you must set the --slug parameter.
+	 *
+	 * [--slug=<slug>]
+	 * : Path of the blog to be set as public. Subdomain on subdomain installs, directory on subdirectory installs.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -785,8 +788,18 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * @subcommand public
 	 */
-	public function set_public( $args ) {
-		$this->update_site_status( $args, 'public', 1 );
+	public function set_public( $args, $assoc_args ) {
+		if ( isset( $assoc_args['slug'] ) ) {
+			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
+
+			if ( ! $blog ) {
+				WP_CLI::error( 'Site not found.' );
+			}
+
+			$this->update_site_status( [ $blog->blog_id ], 'public', 1 );
+		} else {
+			$this->update_site_status( $args, 'public', 1 );
+		}
 	}
 
 	/**

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -978,4 +978,14 @@ class Site_Command extends CommandWithDBObject {
 			WP_CLI::success( "Site {$site->blog_id} {$action}." );
 		}
 	}
+
+	private function get_site_by_slug( $slug ) {
+		$blog = get_blog_details( trim( $slug, '/' ) );
+
+		if ( ! $blog ) {
+			WP_CLI::error( 'Site not found.' );
+		}
+
+		return $blog;
+	}
 }

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -741,16 +741,29 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <id>...
-	 * : One or more IDs of sites to set as mature.
+	 * [<id>...]
+	 * : One or more IDs of sites to set as mature. If not provided, you must set the --slug parameter.
+	 *
+	 * [--slug=<slug>]
+	 * : Path of the blog to be set as mature. Subdomain on subdomain installs, directory on subdirectory installs.
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp site mature 123
 	 *     Success: Site 123 marked as mature.
 	 */
-	public function mature( $args ) {
-		$this->update_site_status( $args, 'mature', 1 );
+	public function mature( $args, $assoc_args ) {
+		if ( isset( $assoc_args['slug'] ) ) {
+			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
+
+			if ( ! $blog ) {
+				WP_CLI::error( 'Site not found.' );
+			}
+
+			$this->update_site_status( [ $blog->blog_id ], 'mature', 1 );
+		} else {
+			$this->update_site_status( $args, 'mature', 1 );
+		}
 	}
 
 	/**

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -758,16 +758,29 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <id>...
-	 * : One or more IDs of sites to set as unmature.
+	 * [<id>...]
+	 * : One or more IDs of sites to set as unmature. If not provided, you must set the --slug parameter.
+	 *
+	 * [--slug=<slug>]
+	 * : Path of the blog to be set as unmature. Subdomain on subdomain installs, directory on subdirectory installs.
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     $ wp site general 123
+	 *     $ wp site unmature 123
 	 *     Success: Site 123 marked as unmature.
 	 */
-	public function unmature( $args ) {
-		$this->update_site_status( $args, 'mature', 0 );
+	public function unmature( $args, $assoc_args ) {
+		if ( isset( $assoc_args['slug'] ) ) {
+			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
+
+			if ( ! $blog ) {
+				WP_CLI::error( 'Site not found.' );
+			}
+
+			$this->update_site_status( [ $blog->blog_id ], 'mature', 0 );
+		} else {
+			$this->update_site_status( $args, 'mature', 0 );
+		}
 	}
 
 	/**

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -705,16 +705,29 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <id>...
-	 * : One or more IDs of sites to be marked as spam.
+	 * [<id>...]
+	 * : One or more IDs of sites to be marked as spam. If not provided, you must set the --slug parameter.
+	 *
+	 * [--slug=<slug>]
+	 * : Path of the blog to be marked as spam. Subdomain on subdomain installs, directory on subdirectory installs.
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp site spam 123
 	 *     Success: Site 123 marked as spam.
 	 */
-	public function spam( $args ) {
-		$this->update_site_status( $args, 'spam', 1 );
+	public function spam( $args, $assoc_args ) {
+		if ( isset( $assoc_args['slug'] ) ) {
+			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
+
+			if ( ! $blog ) {
+				WP_CLI::error( 'Site not found.' );
+			}
+
+			$this->update_site_status( [ $blog->blog_id ], 'spam', 1 );
+		} else {
+			$this->update_site_status( $args, 'spam', 1 );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #257

Slug has been added as an available parameter for the wp site commands listed below

- archive `wp site archive --slug={siteslug}`
- activate  `wp site activate --slug={siteslug}`
- deactivate  `wp site deactivate --slug={siteslug}`
- mature  `wp site mature --slug={siteslug}`
- private  `wp site private --slug={siteslug}`
- public  `wp site public --slug={siteslug}`
- spam  `wp site spam --slug={siteslug}`
- unarchive  `wp site unarchive --slug={siteslug}`
- unmature  `wp site unmature --slug={siteslug}`
- unspam  `wp site unspam --slug={siteslug}`

Related https://github.com/wp-cli/wp-cli/issues/5832