### PR TITLE
Fix typo for `$parent_instance` param in `RecursiveDataStructureTraverser` constructor

### DIFF
--- a/src/WP_CLI/Entity/RecursiveDataStructureTraverser.php
+++ b/src/WP_CLI/Entity/RecursiveDataStructureTraverser.php
@@ -24,9 +24,9 @@ class RecursiveDataStructureTraverser {
 	/**
 	 * RecursiveDataStructureTraverser constructor.
 	 *
-	 * @param mixed $data The data to read/manipulate by reference.
-	 * @param string|int $key The key/property the data belongs to.
-	 * @param static $parent_instance
+	 * @param mixed       $data            The data to read/manipulate by reference.
+	 * @param string|int  $key             The key/property the data belongs to.
+	 * @param static|null $parent_instance The parent instance of the traverser.
 	 */
 	public function __construct( &$data, $key = null, $parent_instance = null ) {
 		$this->data   =& $data;

--- a/src/WP_CLI/Entity/RecursiveDataStructureTraverser.php
+++ b/src/WP_CLI/Entity/RecursiveDataStructureTraverser.php
@@ -26,7 +26,7 @@ class RecursiveDataStructureTraverser {
 	 *
 	 * @param mixed $data The data to read/manipulate by reference.
 	 * @param string|int $key The key/property the data belongs to.
-	 * @param static $parent
+	 * @param static $parent_instance
 	 */
 	public function __construct( &$data, $key = null, $parent_instance = null ) {
 		$this->data   =& $data;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
