### PR TITLE
Increase precision of `wp post generate` test

### DIFF
--- a/features/post-generate.feature
+++ b/features/post-generate.feature
@@ -52,17 +52,19 @@ Feature: Generate new WordPress posts
 
   Scenario: Generating post and outputting title and name
     When I run `wp post generate --count=3 --post_title=Howdy!`
-    And I run `wp post list --field=post_title --posts_per_page=3`
+    And I run `wp post list --field=post_title --posts_per_page=4 --orderby=ID --order=asc`
     Then STDOUT should contain:
       """
+      Hello world!
       Howdy!
       Howdy! 2
       Howdy! 3
       """
     And STDERR should be empty
-    And I run `wp post list --field=post_name --posts_per_page=3`
+    And I run `wp post list --field=post_name --posts_per_page=4 --orderby=ID --order=asc`
     Then STDOUT should contain:
       """
+      hello-world
       howdy
       howdy-2
       howdy-3


### PR DESCRIPTION
This test became flaky after https://github.com/wp-cli/entity-command/pull/418 (e.g. https://github.com/wp-cli/entity-command/actions/runs/6230040634/job/16909485370)

The test was introduced in https://github.com/wp-cli/entity-command/pull/94 and isn't dependent on any time elements.