### PR TITLE
Add test case for publishing post and updating date behavior

### DIFF
--- a/features/post.feature
+++ b/features/post.feature
@@ -438,3 +438,39 @@ Feature: Manage WordPress posts
       """
       0
       """
+
+  Scenario: Publishing a post and setting a date fails if the edit_date flag is not passed.
+    Given a WP install
+
+    When I run `wp post create --post_title='test' --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp post update {POST_ID} --post_date='2005-01-24T09:52:00.000Z' --post_status='publish'`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp post get {POST_ID} --field=post_date`
+    Then STDOUT should not contain:
+      """
+      2005-01-24 09:52:00
+      """
+
+  Scenario: Publishing a post and setting a date succeeds if the edit_date flag is passed.
+    Given a WP install
+
+    When I run `wp post create --post_title='test' --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp post update {POST_ID} --post_date='2005-01-24T09:52:00.000Z' --post_status='publish' --edit_date=1`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp post get {POST_ID} --field=post_date`
+    Then STDOUT should contain:
+      """
+      2005-01-24 09:52:00
+      """


### PR DESCRIPTION
When publishing a post and updating its date at the same time, `--edit_date=1` must be included:

https://github.com/WordPress/wordpress-develop/blob/a1852bd49b0995317ebdde8f2ee33eb818e8da9c/src/wp-includes/post.php#L4817-L4825

Resolves https://github.com/wp-cli/entity-command/issues/427