### PR TITLE
Improve SQLite compatibility

### DIFF
--- a/features/post.feature
+++ b/features/post.feature
@@ -476,6 +476,9 @@ Feature: Manage WordPress posts
       2005-01-24 09:52:00
       """
 
+  # Separate test because of a known bug in the SQLite plugin.
+  # See https://github.com/WordPress/sqlite-database-integration/issues/52.
+  # Once the bug is resolved, this separate test can be removed again.
   @require-sqlite
   Scenario: Publishing a post and setting a date succeeds if the edit_date flag is passed.
     Given a WP install

--- a/features/post.feature
+++ b/features/post.feature
@@ -457,6 +457,7 @@ Feature: Manage WordPress posts
       2005-01-24 09:52:00
       """
 
+  @require-mysql
   Scenario: Publishing a post and setting a date succeeds if the edit_date flag is passed.
     Given a WP install
 
@@ -473,4 +474,23 @@ Feature: Manage WordPress posts
     Then STDOUT should contain:
       """
       2005-01-24 09:52:00
+      """
+
+  @require-sqlite
+  Scenario: Publishing a post and setting a date succeeds if the edit_date flag is passed.
+    Given a WP install
+
+    When I run `wp post create --post_title='test' --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp post update {POST_ID} --post_date='2005-01-24T09:52:00.000Z' --post_status='publish' --edit_date=1`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp post get {POST_ID} --field=post_date`
+    Then STDOUT should contain:
+      """
+      2005-01-24T09:52:00.000Z
       """

--- a/features/site-create.feature
+++ b/features/site-create.feature
@@ -16,7 +16,7 @@ Feature: Create a new site on a WP multisite
       define( 'BLOG_ID_CURRENT_SITE', 1 );
       """
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --extra-php < extra-config`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --extra-php < extra-config`
     Then STDOUT should be:
       """
       Success: Generated 'wp-config.php' file.

--- a/features/site-empty.feature
+++ b/features/site-empty.feature
@@ -1,5 +1,6 @@
 Feature: Empty a WordPress site of its data
 
+  @require-mysql
   Scenario: Empty a site
     Given a WP installation
     And I run `wp option update uploads_use_yearmonth_folders 0`

--- a/features/site-option.feature
+++ b/features/site-option.feature
@@ -127,6 +127,7 @@ Feature: Manage WordPress site options
       """
     And the return code should be 1
 
+  @require-mysql
   Scenario: Filter options by `--site_id`
     Given a WP multisite installation
 

--- a/features/user-application-password.feature
+++ b/features/user-application-password.feature
@@ -1,6 +1,6 @@
 Feature: Manage user custom fields
 
-  @less-than-php-8.0
+  @less-than-php-8.0 @require-mysql
   Scenario: User application passwords are disabled for WordPress lower than 5.6
     Given a WP install
     And I try `wp theme install twentytwenty --activate`

--- a/features/user-application-password.feature
+++ b/features/user-application-password.feature
@@ -1,5 +1,6 @@
 Feature: Manage user custom fields
 
+  # SQLite requires WordPress 6.0+.
   @less-than-php-8.0 @require-mysql
   Scenario: User application passwords are disabled for WordPress lower than 5.6
     Given a WP install

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -52,8 +52,8 @@ class Site_Command extends CommandWithDBObject {
 			wp_cache_delete( $comment_id, 'comment' );
 			wp_cache_delete( $comment_id, 'comment_meta' );
 		}
-		$wpdb->query( "TRUNCATE $wpdb->comments" );
-		$wpdb->query( "TRUNCATE $wpdb->commentmeta" );
+		$wpdb->query( "TRUNCATE TABLE $wpdb->comments" );
+		$wpdb->query( "TRUNCATE TABLE $wpdb->commentmeta" );
 	}
 
 	/**
@@ -80,8 +80,8 @@ class Site_Command extends CommandWithDBObject {
 
 			$posts->next();
 		}
-		$wpdb->query( "TRUNCATE $wpdb->posts" );
-		$wpdb->query( "TRUNCATE $wpdb->postmeta" );
+		$wpdb->query( "TRUNCATE TABLE $wpdb->posts" );
+		$wpdb->query( "TRUNCATE TABLE $wpdb->postmeta" );
 	}
 
 	/**
@@ -110,11 +110,11 @@ class Site_Command extends CommandWithDBObject {
 			wp_cache_delete( 'get', $taxonomy );
 			delete_option( "{$taxonomy}_children" );
 		}
-		$wpdb->query( "TRUNCATE $wpdb->terms" );
-		$wpdb->query( "TRUNCATE $wpdb->term_taxonomy" );
-		$wpdb->query( "TRUNCATE $wpdb->term_relationships" );
+		$wpdb->query( "TRUNCATE TABLE $wpdb->terms" );
+		$wpdb->query( "TRUNCATE TABLE $wpdb->term_taxonomy" );
+		$wpdb->query( "TRUNCATE TABLE $wpdb->term_relationships" );
 		if ( ! empty( $wpdb->termmeta ) ) {
-			$wpdb->query( "TRUNCATE $wpdb->termmeta" );
+			$wpdb->query( "TRUNCATE TABLE $wpdb->termmeta" );
 		}
 	}
 
@@ -143,7 +143,7 @@ class Site_Command extends CommandWithDBObject {
 		}
 
 		// Empty the table once link related cache and term is removed.
-		$wpdb->query( "TRUNCATE {$wpdb->links}" );
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->links}" );
 	}
 
 	/**


### PR DESCRIPTION
As for `TRUNCATE TABLE`, this works better with the SQLite plugin right now. See https://github.com/WordPress/sqlite-database-integration/issues/51



Fixes #430
Related: https://github.com/wp-cli/wp-cli/issues/5859