### PR TITLE
Site_Command: Do not assume `get_super_admins()` has the `0` array index

### DIFF
--- a/features/site-create.feature
+++ b/features/site-create.feature
@@ -46,3 +46,51 @@ Feature: Create a new site on a WP multisite
       | blog_id | url                           |
       | 1       | http://localhost/dev/         |
       | 2       | http://localhost/dev/newsite/ |
+
+  Scenario: Create new site with custom `$super_admins` global
+    Given an empty directory
+    And WP files
+    And a database
+    And a extra-config file:
+      """
+      define( 'WP_ALLOW_MULTISITE', true );
+      define( 'MULTISITE', true );
+      define( 'SUBDOMAIN_INSTALL', false );
+      define( 'DOMAIN_CURRENT_SITE', 'localhost' );
+      define( 'PATH_CURRENT_SITE', '/' );
+      define('SITE_ID_CURRENT_SITE', 1);
+      define('BLOG_ID_CURRENT_SITE', 1);
+
+      $super_admins = array( 1 => 'admin' );
+      """
+    When I run `wp core config {CORE_CONFIG_SETTINGS} --extra-php < extra-config`
+    Then STDOUT should be:
+      """
+      Success: Generated 'wp-config.php' file.
+      """
+
+    # Old versions of WP can generate wpdb database errors if the WP tables don't exist, so STDERR may or may not be empty
+    When I try `wp core multisite-install --url=localhost --title=Test --admin_user=admin --admin_email=admin@example.org`
+    Then STDOUT should contain:
+      """
+      Success: Network installed. Don't forget to set up rewrite rules
+      """
+    And the return code should be 0
+
+    When I run `wp site list --fields=blog_id,url`
+    Then STDOUT should be a table containing rows:
+      | blog_id | url                   |
+      | 1       | http://localhost/ |
+
+    When I run `wp site create --slug=newsite`
+    Then STDOUT should be:
+      """
+      Success: Site 2 created: http://localhost/newsite/
+      """
+
+    When I run `wp site list --fields=blog_id,url`
+    Then STDOUT should be a table containing rows:
+      | blog_id | url                           |
+      | 1       | http://localhost/         |
+      | 2       | http://localhost/newsite/ |
+

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -435,7 +435,7 @@ class Site_Command extends CommandWithDBObject {
 			$email        = '';
 			if ( ! empty( $super_admins ) && is_array( $super_admins ) ) {
 				// Just get the first one
-				$super_login = $super_admins[0];
+				$super_login = reset( $super_admins );
 				$super_user  = get_user_by( 'login', $super_login );
 				if ( $super_user ) {
 					$email = $super_user->user_email;


### PR DESCRIPTION
Fixes https://github.com/wp-cli/entity-command/issues/392

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
