### PR TITLE
Add examples on listing unapproved, spam and trash comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,32 @@ These fields are optionally available:
     | 29         | 2013-03-14 11:56:08 | Jane Doe       |
     +------------+---------------------+----------------+
 
+    # List unapproved comments.
+    $ wp comment list --number=3 --status=hold --fields=ID,comment_date,comment_author
+    +------------+---------------------+----------------+
+    | comment_ID | comment_date        | comment_author |
+    +------------+---------------------+----------------+
+    | 8          | 2023-11-10 13:13:06 | John Doe       |
+    | 7          | 2023-11-10 13:09:55 | Mr WordPress   |
+    | 9          | 2023-11-10 11:22:31 | Jane Doe       |
+    +------------+---------------------+----------------+
+
+    # List comments marked as spam.
+    $ wp comment list --status=spam --fields=ID,comment_date,comment_author
+    +------------+---------------------+----------------+
+    | comment_ID | comment_date        | comment_author |
+    +------------+---------------------+----------------+
+    | 2          | 2023-11-10 11:22:31 | Jane Doe       |
+    +------------+---------------------+----------------+
+
+    # List comments in trash.
+    $ wp comment list --status=trash --fields=ID,comment_date,comment_author
+    +------------+---------------------+----------------+
+    | comment_ID | comment_date        | comment_author |
+    +------------+---------------------+----------------+
+    | 3          | 2023-11-10 11:22:31 | John Doe       |
+    +------------+---------------------+----------------+
+
 
 
 ### wp comment meta

--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -335,6 +335,32 @@ class Comment_Command extends CommandWithDBObject {
 	 *     | 29         | 2013-03-14 11:56:08 | Jane Doe       |
 	 *     +------------+---------------------+----------------+
 	 *
+	 *     # List unapproved comments.
+	 *     $ wp comment list --number=3 --status=hold --fields=ID,comment_date,comment_author
+	 *     +------------+---------------------+----------------+
+	 *     | comment_ID | comment_date        | comment_author |
+	 *     +------------+---------------------+----------------+
+	 *     | 8          | 2023-11-10 13:13:06 | John Doe       |
+	 *     | 7          | 2023-11-10 13:09:55 | Mr WordPress   |
+	 *     | 9          | 2023-11-10 11:22:31 | Jane Doe       |
+	 *     +------------+---------------------+----------------+
+	 *
+	 *     # List comments marked as spam.
+	 *     $ wp comment list --status=spam --fields=ID,comment_date,comment_author
+	 *     +------------+---------------------+----------------+
+	 *     | comment_ID | comment_date        | comment_author |
+	 *     +------------+---------------------+----------------+
+	 *     | 2          | 2023-11-10 11:22:31 | Jane Doe       |
+	 *     +------------+---------------------+----------------+
+	 *
+	 *     # List comments in trash.
+	 *     $ wp comment list --status=trash --fields=ID,comment_date,comment_author
+	 *     +------------+---------------------+----------------+
+	 *     | comment_ID | comment_date        | comment_author |
+	 *     +------------+---------------------+----------------+
+	 *     | 3          | 2023-11-10 11:22:31 | John Doe       |
+	 *     +------------+---------------------+----------------+
+	 *
 	 * @subcommand list
 	 */
 	public function list_( $args, $assoc_args ) {


### PR DESCRIPTION
This PR enhances the documentation related to `wp comment list`.

Related https://github.com/wp-cli/entity-command/issues/405