### PR TITLE
Fix deleting a site by a slug that is an integer

### DIFF
--- a/features/site.feature
+++ b/features/site.feature
@@ -120,6 +120,29 @@ Feature: Manage sites in a multisite installation
     When I try the previous command again
     Then the return code should be 1
 
+    When I run `wp site create --slug=42`
+    Then STDOUT should contain:
+      """
+      Success: Site 3 created: http
+      """
+    And STDOUT should contain:
+      """
+      ://example.com/42/
+      """
+
+    When I run `wp site delete --slug=42 --yes`
+    Then STDOUT should contain:
+      """
+      ://example.com/42/' was deleted.
+      """
+
+    When I try the previous command again
+    Then STDERR should contain:
+      """
+      Site with slug '42' does not exist.
+      """
+    And the return code should be 1
+
   Scenario: Get site info
     Given a WP multisite install
 

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -332,7 +332,11 @@ class Site_Command extends CommandWithDBObject {
 		}
 
 		if ( isset( $assoc_args['slug'] ) ) {
-			$blog = get_blog_details( trim( $assoc_args['slug'], '/' ) );
+			$blog_id = get_id_from_blogname( $assoc_args['slug'] );
+			if ( null === $blog_id ) {
+				WP_CLI::error( "Site with slug '{$assoc_args['slug']}' does not exist." );
+			}
+			$blog = get_blog_details( $blog_id );
 		} else {
 			if ( empty( $args ) ) {
 				WP_CLI::error( 'Need to specify a blog id.' );


### PR DESCRIPTION
Fixes: #441 

Calls `get_id_from_blogname` to look up the slug before calling `get_blog_details`.  This lookup works with slugs that are made up of strings or integers. 


