### PR TITLE
Add origin and exclude-role-names filters to list-caps command

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -443,6 +443,34 @@ Feature: Manage WordPress users
       6
       """
 
+    When I run `wp user list-caps bob --exclude-role-names`
+    Then STDOUT should be:
+      """
+      edit_posts
+      read
+      level_1
+      level_0
+      delete_posts
+      """
+
+    When I run `wp user add-cap bob newcap`
+    And I run `wp user list-caps bob --origin=role`
+    Then STDOUT should be:
+      """
+      edit_posts
+      read
+      level_1
+      level_0
+      delete_posts
+      contributor
+      """
+
+    And I run `wp user list-caps bob --origin=user`
+    Then STDOUT should be:
+      """
+      newcap
+      """
+
   Scenario: Make sure WordPress receives the slashed data it expects
     Given a WP install
 


### PR DESCRIPTION
This PR adds two new arguments to the `list-caps` command.  

### Capability Origin

Fixes: #99 

The first is the `--origin=` attribute which allows you to specify:

- `all` (default) Returns all capabilities
- `role` returns only the capabilities inherited because a user has a role 
- `user` returns only the capabilities directly assigned to a user (ex: `wp user add-cap bob newcap)

### Exclude Role Names

The second is a flag `--exclude-role-names` that removes a capability from the returned list if it matches the name of a role.  For example, if a user has the `contributor` role, the value 'contributor' would not be returned if `--exclude-role-names` was specified, but the individual capabilities that role included, like `read` would be.

