### PR TITLE
Added a 'raw' format to the option get command

### DIFF
--- a/features/option.feature
+++ b/features/option.feature
@@ -120,6 +120,15 @@ Feature: Manage WordPress options
       [1,2]
       """
 
+    # Raw values
+    When I run `wp option set raw_option '[ 1, 2 ]' --format=json`
+    Then STDOUT should not be empty
+
+    When I run `wp option get raw_option --format=raw`
+    Then STDOUT should be:
+      """
+      a:2:{i:0;i:1;i:1;i:2;}
+      """
 
     # Reading from files
     Given a value.json file:

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -47,6 +47,7 @@ class Option_Command extends WP_CLI_Command {
 	 *   - var_export
 	 *   - json
 	 *   - yaml
+	 *   - raw
 	 * ---
 	 *
 	 * ## EXAMPLES
@@ -78,6 +79,16 @@ class Option_Command extends WP_CLI_Command {
 
 		if ( false === $value ) {
 			WP_CLI::error( "Could not get '{$key}' option. Does it exist?" );
+		}
+
+		if ( 'raw' === Utils\get_flag_value( $assoc_args, 'format' ) ) {
+			global $wpdb;
+			$value = $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT option_value FROM $wpdb->options WHERE option_name = %s",
+					$key
+				)
+			);
 		}
 
 		WP_CLI::print_value( $value, $assoc_args );


### PR DESCRIPTION
Fixes: #165 

Adds a `--format=raw` response to the `wp option get` command that returns the value as stored in the database. Used if you want to get the an option in PHP serialized format. 

NOTE: I used the `$wpdb->get_var()` command instead of serializing the `$value` returned from `get_option` because the latter threw an error when running PHP CodeSniffer:

> WARNING | serialize() found. Serialized data has known vulnerability problems with Object Injection. JSON is generally a better approach for serializing data. See https://www.owasp.org/index.php/PHP_Object_Injection
