### PR TITLE
Add command to get the post ID by URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3111,6 +3111,27 @@ wp post update <id>... [--post_author=<post_author>] [--post_date=<post_date>] [
 
 
 
+### wp post url-to-id
+
+Gets the post ID for a given URL.
+
+~~~
+wp post url-to-id <url>
+~~~
+
+**OPTIONS**
+
+	<url>
+		The URL of the post to get.
+
+**EXAMPLES**
+
+    # Get post ID by URL
+    $ wp post url-to-id https://example.com/?p=1
+    1
+
+
+
 ### wp post-type
 
 Retrieves details on the site's registered post types.

--- a/composer.json
+++ b/composer.json
@@ -115,6 +115,7 @@
             "post term remove",
             "post term set",
             "post update",
+            "post url-to-id",
             "post-type",
             "post-type get",
             "post-type list",

--- a/features/post-url-to-id.feature
+++ b/features/post-url-to-id.feature
@@ -3,7 +3,6 @@ Feature: Get the post ID for a given URL
   Background:
     Given a WP install
 
-  @daniel
   Scenario: Get the post ID for a given URL
     When I run `wp post get 1 --field=url`
     Then STDOUT should be:

--- a/features/post-url-to-id.feature
+++ b/features/post-url-to-id.feature
@@ -1,0 +1,25 @@
+Feature: Get the post ID for a given URL
+
+  Background:
+    Given a WP install
+
+  @daniel
+  Scenario: Get the post ID for a given URL
+    When I run `wp post get 1 --field=url`
+    Then STDOUT should be:
+      """
+      https://example.com/?p=1
+      """
+    And save STDOUT as {POST_URL}
+
+    When I run `wp post url-to-id {POST_URL}`
+    Then STDOUT should contain:
+      """
+      1
+      """
+
+    When I try `wp post url-to-id 'https://example.com/?p=404'`
+    Then STDERR should contain:
+      """
+      Could not get post with url https://example.com/?p=404.
+      """

--- a/features/post.feature
+++ b/features/post.feature
@@ -264,13 +264,13 @@ Feature: Manage WordPress posts
     When I run `wp post url-to-id {POST_URL}`
     Then STDOUT should contain:
       """
-      {POST_ID}
+      1
       """
 
-    When I run `wp post url-to-id non-existent-url`
-    Then STDOUT should contain:
+    When I try `wp post url-to-id 'https://example.com/?p=404'`
+    Then STDERR should contain:
       """
-      Could not get post with url 'non-existent-url'.
+      Could not get post with url https://example.com/?p=404.
       """
 
   Scenario: Update a post from file or STDIN

--- a/features/post.feature
+++ b/features/post.feature
@@ -259,19 +259,6 @@ Feature: Manage WordPress posts
       """
       https://example.com/?p=1
       """
-    And save STDOUT as {POST_URL}
-
-    When I run `wp post url-to-id {POST_URL}`
-    Then STDOUT should contain:
-      """
-      1
-      """
-
-    When I try `wp post url-to-id 'https://example.com/?p=404'`
-    Then STDERR should contain:
-      """
-      Could not get post with url https://example.com/?p=404.
-      """
 
   Scenario: Update a post from file or STDIN
     Given a content.html file:

--- a/features/post.feature
+++ b/features/post.feature
@@ -259,6 +259,13 @@ Feature: Manage WordPress posts
       """
       https://example.com/?p=1
       """
+    And save STDOUT as {POST_URL}
+
+    When I run `wp post url-to-id {POST_URL}`
+    Then STDOUT should contain:
+      """
+      {POST_ID}
+      """
 
   Scenario: Update a post from file or STDIN
     Given a content.html file:

--- a/features/post.feature
+++ b/features/post.feature
@@ -267,6 +267,12 @@ Feature: Manage WordPress posts
       {POST_ID}
       """
 
+    When I run `wp post url-to-id non-existent-url`
+    Then STDOUT should contain:
+      """
+      Could not get post with url 'non-existent-url'.
+      """
+
   Scenario: Update a post from file or STDIN
     Given a content.html file:
       """

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -897,7 +897,7 @@ class Post_Command extends CommandWithDBObject {
 		$post_id = url_to_postid( $args[0] );
 
 		if ( ! $value ) {
-			WP_CLI::error( "Could not get post with url '{$args[0]}'." );
+			WP_CLI::error( "Could not get post with url '$args[0]'." );
 		}
 
 		WP_CLI::print_value( $post_id, $assoc_args );

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -878,6 +878,31 @@ class Post_Command extends CommandWithDBObject {
 		}
 	}
 
+	/**
+	 * Gets post ID by URL.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <url>
+	 * : The URL of the post to get.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Get post ID by URL
+	 *     $ wp post url-to-id post-url
+	 *
+	 * @subcommand url-to-id
+	 */
+	public function url_to_id( $args, $assoc_args ) {
+		$post_id = url_to_postid( $args[0] );
+
+		if ( ! $value ) {
+			WP_CLI::error( "Could not get post with url '{$args[0]}'." );
+		}
+
+		WP_CLI::print_value( $post_id, $assoc_args );
+	}
+
 	private function maybe_make_child() {
 		// 50% chance of making child post.
 		return ( wp_rand( 1, 2 ) === 1 );

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -896,7 +896,7 @@ class Post_Command extends CommandWithDBObject {
 	public function url_to_id( $args, $assoc_args ) {
 		$post_id = url_to_postid( $args[0] );
 
-		if ( ! $value ) {
+		if ( ! $post_id ) {
 			WP_CLI::error( "Could not get post with url '$args[0]'." );
 		}
 

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -879,7 +879,7 @@ class Post_Command extends CommandWithDBObject {
 	}
 
 	/**
-	 * Gets post ID by URL.
+	 * Gets the post ID for a given URL.
 	 *
 	 * ## OPTIONS
 	 *
@@ -890,6 +890,7 @@ class Post_Command extends CommandWithDBObject {
 	 *
 	 *     # Get post ID by URL
 	 *     $ wp post url-to-id https://example.com/?p=1
+	 *     1
 	 *
 	 * @subcommand url-to-id
 	 */

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -889,15 +889,17 @@ class Post_Command extends CommandWithDBObject {
 	 * ## EXAMPLES
 	 *
 	 *     # Get post ID by URL
-	 *     $ wp post url-to-id post-url
+	 *     $ wp post url-to-id https://example.com/?p=1
 	 *
 	 * @subcommand url-to-id
 	 */
 	public function url_to_id( $args, $assoc_args ) {
 		$post_id = url_to_postid( $args[0] );
 
-		if ( ! $post_id ) {
-			WP_CLI::error( "Could not get post with url '$args[0]'." );
+		$post = get_post( $post_id );
+
+		if ( null === $post ) {
+			WP_CLI::error( "Could not get post with url $args[0]." );
 		}
 
 		WP_CLI::print_value( $post_id, $assoc_args );


### PR DESCRIPTION
See #429 

- Adds url-to-id command to get the post ID from its URL.
- url_to_postid() doesn't check if the post exists when the URL contains the post id as a parameter.