### PR TITLE
Feature test for `wp network option` suggestion

### DIFF
--- a/features/network-meta.feature
+++ b/features/network-meta.feature
@@ -16,3 +16,14 @@ Feature: Manage network-wide custom fields.
       This is not a multisite install
       """
     And the return code should be 1
+
+  Scenario: Suggest 'meta' when 'option' subcommand is run
+    Given a WP install
+
+    When I try `wp network option`
+    Then STDERR should contain:
+      """
+      Error: 'option' is not a registered subcommand of 'network'. See 'wp help network' for available subcommands.
+      Did you mean 'meta'?
+      """
+    And the return code should be 1


### PR DESCRIPTION
Relates to https://github.com/wp-cli/entity-command/issues/322

This PR adds a feature test for suggesting `wp network meta` if the user types `wp network option`.

NOTE:  This PR will fail until https://github.com/wp-cli/wp-cli/pull/5879 is merged. This suggestion is changed in the `wp-cli` repo - but the command to test it is in the `entity-command` repo.

