### PR TITLE
Fix variable name in application_name_exists polyfill

### DIFF
--- a/src/User_Application_Password_Command.php
+++ b/src/User_Application_Password_Command.php
@@ -540,7 +540,7 @@ final class User_Application_Password_Command {
 			$passwords = WP_Application_Passwords::get_user_application_passwords( $user_id );
 
 			foreach ( $passwords as $password ) {
-				if ( strtolower( $password['name'] ) === strtolower( $name ) ) {
+				if ( strtolower( $password['name'] ) === strtolower( $app_name ) ) {
 					return true;
 				}
 			}


### PR DESCRIPTION
Non existing `$name` variable has been used in `application_name_exists_for_user` in `User_Application_Password_Command` class. It should have been `$app_name`
