### PR TITLE
Fix example for post create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2208,7 +2208,7 @@ wp post create [--post_author=<post_author>] [--post_date=<post_date>] [--post_d
 **EXAMPLES**
 
     # Create post and schedule for future
-    $ wp post create --post_type=page --post_title='A future post' --post_status=future --post_date='2020-12-01 07:00:00'
+    $ wp post create --post_type=post --post_title='A future post' --post_status=future --post_date='2030-12-01 07:00:00'
     Success: Created post 1921.
 
     # Create post with content from given file

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -147,7 +147,7 @@ class Post_Command extends CommandWithDBObject {
 	 * ## EXAMPLES
 	 *
 	 *     # Create post and schedule for future
-	 *     $ wp post create --post_type=page --post_title='A future post' --post_status=future --post_date='2020-12-01 07:00:00'
+	 *     $ wp post create --post_type=post --post_title='A future post' --post_status=future --post_date='2030-12-01 07:00:00'
 	 *     Success: Created post 1921.
 	 *
 	 *     # Create post with content from given file


### PR DESCRIPTION
Current:

```
# Create post and schedule for future
$ wp post create --post_type=page --post_title='A future post' --post_status=future --post_date='2020-12-01 07:00:00'
```

Example command does not match with its description.

Changed to:
```
# Create post and schedule for future
$ wp post create --post_type=post --post_title='A future post' --post_status=future --post_date='2030-12-01 07:00:00'
```