### PR TITLE
Support arrays/JSON in pluck and patch

### DIFF
--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -619,12 +619,12 @@ class Option_Command extends WP_CLI_Command {
 			array_slice( $args, 1 )
 		);
 
-		if (function_exists( 'maybe_unserialize' )) {
-		    $value = maybe_unserialize( $value );
+		if ( function_exists( 'maybe_unserialize' ) ) {
+			$value = maybe_unserialize( $value );
 		}
 
-		if (Utils\is_json( $value )) {
-		    $value = json_decode( $value );
+		if ( Utils\is_json( $value ) ) {
+			$value = json_decode( $value );
 		}
 
 		$traverser = new RecursiveDataStructureTraverser( $value );
@@ -635,10 +635,10 @@ class Option_Command extends WP_CLI_Command {
 			die( 1 );
 		}
 
-		if (function_exists( 'is_serialized' ) &&
-		    function_exists( 'maybe_serialize' ) &&
-		    !is_serialized( $value ) ) {
-	        $value = maybe_serialize( $value );
+		if ( function_exists( 'is_serialized' ) &&
+			function_exists( 'maybe_serialize' ) &&
+			! is_serialized( $value ) ) {
+			$value = maybe_serialize( $value );
 		}
 
 		WP_CLI::print_value( $value, $assoc_args );
@@ -759,12 +759,12 @@ class Option_Command extends WP_CLI_Command {
 			$old_value = clone $current_value;
 		}
 
-		if (function_exists('maybe_unserialize')) {
-		    $current_value = maybe_unserialize($current_value);
+		if ( function_exists( 'maybe_unserialize' ) ) {
+			$current_value = maybe_unserialize( $current_value );
 		}
 
-		if (Utils\is_json($current_value)) {
-		    $current_value = json_decode($current_value);
+		if ( Utils\is_json( $current_value ) ) {
+			$current_value = json_decode( $current_value );
 		}
 
 		$traverser = new RecursiveDataStructureTraverser( $current_value );

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -635,6 +635,10 @@ class Option_Command extends WP_CLI_Command {
 			die( 1 );
 		}
 
+		if ( $value instanceof \stdClass ) {
+		    $value = json_encode( $value );
+		}
+
 		if ( function_exists( 'is_serialized' ) &&
 			function_exists( 'maybe_serialize' ) &&
 			! is_serialized( $value ) ) {

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -619,12 +619,12 @@ class Option_Command extends WP_CLI_Command {
 			array_slice( $args, 1 )
 		);
 
-		if (function_exists('maybe_unserialize')) {
-		    $value = maybe_unserialize($value);
+		if (function_exists( 'maybe_unserialize' )) {
+		    $value = maybe_unserialize( $value );
 		}
 
-		if (Utils\is_json($value)) {
-		    $value = json_decode($value);
+		if (Utils\is_json( $value )) {
+		    $value = json_decode( $value );
 		}
 
 		$traverser = new RecursiveDataStructureTraverser( $value );
@@ -633,6 +633,12 @@ class Option_Command extends WP_CLI_Command {
 			$value = $traverser->get( $key_path );
 		} catch ( Exception $exception ) {
 			die( 1 );
+		}
+
+		if (function_exists( 'is_serialized' ) &&
+		    function_exists( 'maybe_serialize' ) &&
+		    !is_serialized( $value ) ) {
+	        $value = maybe_serialize( $value );
 		}
 
 		WP_CLI::print_value( $value, $assoc_args );

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -636,7 +636,7 @@ class Option_Command extends WP_CLI_Command {
 		}
 
 		if ( $value instanceof \stdClass ) {
-		    $value = json_encode( $value );
+			$value = json_encode( $value );
 		}
 
 		if ( function_exists( 'is_serialized' ) &&


### PR DESCRIPTION
Add support to for serialized arrays and JSON to both pluck and patch. Add additional examples and a note about the stdin blocking issue with patch.


Fixes #459 