### PR TITLE
Fix menu command output examples

### DIFF
--- a/src/Menu_Command.php
+++ b/src/Menu_Command.php
@@ -29,7 +29,7 @@ use WP_CLI\Utils;
  *
  *     # Assign the 'my-menu' menu to the 'primary' location
  *     $ wp menu location assign my-menu primary
- *     Success: Assigned location to menu.
+ *     Success: Assigned location primary to menu my-menu.
  *
  * @package wp-cli
  */
@@ -87,7 +87,8 @@ class Menu_Command extends WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *     $ wp menu delete "My Menu"
-	 *     Success: 1 menu deleted.
+	 *     Deleted menu 'My Menu'.
+	 *     Success: Deleted 1 of 1 menus.
 	 */
 	public function delete( $args, $assoc_args ) {
 

--- a/src/Menu_Item_Command.php
+++ b/src/Menu_Item_Command.php
@@ -18,7 +18,7 @@ use WP_CLI\Utils;
  *
  *     # Delete menu item
  *     $ wp menu item delete 45
- *     Success: 1 menu item deleted.
+ *     Success: Deleted 1 of 1 menu items.
  */
 class Menu_Item_Command extends WP_CLI_Command {
 
@@ -355,7 +355,7 @@ class Menu_Item_Command extends WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *     $ wp menu item delete 45
-	 *     Success: 1 menu item deleted.
+	 *     Success: Deleted 1 of 1 menu items.
 	 *
 	 * @subcommand delete
 	 */

--- a/src/Menu_Location_Command.php
+++ b/src/Menu_Location_Command.php
@@ -19,7 +19,7 @@ use WP_CLI\Utils;
  *
  *     # Assign the 'primary-menu' menu to the 'primary' location
  *     $ wp menu location assign primary-menu primary
- *     Success: Assigned location to menu.
+ *     Success: Assigned location primary to menu primary-menu.
  *
  *     # Remove the 'primary-menu' menu from the 'primary' location
  *     $ wp menu location remove primary-menu primary


### PR DESCRIPTION
Menu commands

* Output examples of several menu commands and fixed which was missed when we implemented `report_batch_operation_results()` feature.