### PR TITLE
Update example out put of `comment delete` command

### DIFF
--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -21,10 +21,10 @@ use WP_CLI\Utils;
  *     $ wp comment delete 1337 --force
  *     Success: Deleted comment 1337.
  *
- *     # Delete all spam comments.
+ *     # Trash all spam comments.
  *     $ wp comment delete $(wp comment list --status=spam --format=ids)
- *     Success: Deleted comment 264.
- *     Success: Deleted comment 262.
+ *     Success: Trashed comment 264.
+ *     Success: Trashed comment 262.
  *
  * @package wp-cli
  */


### PR DESCRIPTION
Fix the example of comment delete to correct one.

- Now output of `wp comment delete` is different with `--force` arguments
- Without force argument, trash verb is used in the output.