### PR TITLE
Fix PHP notice in comment recount with invalid ID

### DIFF
--- a/features/comment-recount.feature
+++ b/features/comment-recount.feature
@@ -23,3 +23,9 @@ Feature: Recount comments on a post
       """
       Updated post 1 comment count to 3.
       """
+
+    When I run `wp comment recount 99999999`
+    Then STDOUT should be:
+      """
+      Warning: Post 99999999 doesn't exist.
+      """

--- a/features/comment-recount.feature
+++ b/features/comment-recount.feature
@@ -24,8 +24,8 @@ Feature: Recount comments on a post
       Updated post 1 comment count to 3.
       """
 
-    When I run `wp comment recount 99999999`
-    Then STDOUT should be:
+    When I try `wp comment recount 99999999`
+    Then STDERR should be:
       """
       Warning: Post 99999999 doesn't exist.
       """

--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -672,12 +672,12 @@ class Comment_Command extends CommandWithDBObject {
 	 */
 	public function recount( $args ) {
 		foreach ( $args as $id ) {
-			wp_update_comment_count( $id );
 			$post = get_post( $id );
 			if ( $post ) {
+				wp_update_comment_count( $id );
 				WP_CLI::log( "Updated post {$post->ID} comment count to {$post->comment_count}." );
 			} else {
-				WP_CLI::warning( "Post {$post->ID} doesn't exist." );
+				WP_CLI::warning( "Post {$id} doesn't exist." );
 			}
 		}
 	}

--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -672,9 +672,8 @@ class Comment_Command extends CommandWithDBObject {
 	 */
 	public function recount( $args ) {
 		foreach ( $args as $id ) {
-			$post = get_post( $id );
-			if ( $post ) {
-				wp_update_comment_count( $id );
+			if ( wp_update_comment_count( $id ) ) {
+				$post = get_post( $id );
 				WP_CLI::log( "Updated post {$post->ID} comment count to {$post->comment_count}." );
 			} else {
 				WP_CLI::warning( "Post {$id} doesn't exist." );


### PR DESCRIPTION
Fixes https://github.com/wp-cli/entity-command/issues/464