### PR TITLE
Fix dynamic property issue in user session class

### DIFF
--- a/src/User_Session_Command.php
+++ b/src/User_Session_Command.php
@@ -30,6 +30,8 @@ class User_Session_Command extends WP_CLI_Command {
 		'ua',
 	];
 
+	private $fetcher;
+
 	public function __construct() {
 		$this->fetcher = new UserFetcher();
 	}


### PR DESCRIPTION
Make PHP 8.2 happy with defining $fetcher property in User_Session_Command class
