### PR TITLE
Validate reassign user in user delete command

### DIFF
--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -280,8 +280,10 @@ class User_Command extends CommandWithDBObject {
 			WP_CLI::error( 'Reassigning content to a different user is not supported on multisite.' );
 		}
 
-		if ( ! $reassign ) {
-			WP_CLI::confirm( '--reassign parameter not passed. All associated posts will be deleted. Proceed?', $assoc_args );
+		$is_reassign_valid = ( false === get_userdata( $reassign ) ) ? false : true;
+
+		if ( ! $reassign || ! $is_reassign_valid ) {
+			WP_CLI::confirm( '--reassign parameter not passed or invalid. All associated posts will be deleted. Proceed?', $assoc_args );
 		}
 
 		$users = $this->fetcher->get_many( $args );

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -280,7 +280,7 @@ class User_Command extends CommandWithDBObject {
 			WP_CLI::error( 'Reassigning content to a different user is not supported on multisite.' );
 		}
 
-		$is_reassign_valid = ( false === get_userdata( $reassign ) ) ? false : true;
+		$is_reassign_valid = ( $reassign && false === get_userdata( $reassign ) ) ? false : true;
 
 		if ( ! $reassign ) {
 			WP_CLI::confirm( '--reassign parameter not passed. All associated posts will be deleted. Proceed?', $assoc_args );

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -282,8 +282,10 @@ class User_Command extends CommandWithDBObject {
 
 		$is_reassign_valid = ( false === get_userdata( $reassign ) ) ? false : true;
 
-		if ( ! $reassign || ! $is_reassign_valid ) {
-			WP_CLI::confirm( '--reassign parameter not passed or invalid. All associated posts will be deleted. Proceed?', $assoc_args );
+		if ( ! $reassign ) {
+			WP_CLI::confirm( '--reassign parameter not passed. All associated posts will be deleted. Proceed?', $assoc_args );
+		} elseif ( ! $is_reassign_valid ) {
+			WP_CLI::confirm( '--reassign parameter is invalid. All associated posts will be deleted. Proceed?', $assoc_args );
 		}
 
 		$users = $this->fetcher->get_many( $args );


### PR DESCRIPTION
Fixes https://github.com/wp-cli/entity-command/issues/461

* This will perform sanity check for reassign value whether user is valid or not
* Asks for confirmation if not valid