### PR TITLE
Update doc for user spam and unspam command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6248,7 +6248,7 @@ wp user set-role <user> [<role>]
 
 ### wp user spam
 
-Marks one or more users as spam.
+Marks one or more users as spam on multisite.
 
 ~~~
 wp user spam <id>...
@@ -6261,6 +6261,7 @@ wp user spam <id>...
 
 **EXAMPLES**
 
+    # Mark user as spam.
     $ wp user spam 123
     User 123 marked as spam.
     Success: Spammed 1 of 1 users.
@@ -6432,7 +6433,7 @@ Replaces existing terms on the object.
 
 ### wp user unspam
 
-Removes one or more users from spam.
+Removes one or more users from spam on multisite.
 
 ~~~
 wp user unspam <id>...
@@ -6445,6 +6446,7 @@ wp user unspam <id>...
 
 **EXAMPLES**
 
+    # Remove user from spam.
     $ wp user unspam 123
     User 123 removed from spam.
     Success: Unspamed 1 of 1 users.

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -1282,7 +1282,7 @@ class User_Command extends CommandWithDBObject {
 	}
 
 	/**
-	 * Marks one or more users as spam.
+	 * Marks one or more users as spam on multisite.
 	 *
 	 * ## OPTIONS
 	 *
@@ -1291,6 +1291,7 @@ class User_Command extends CommandWithDBObject {
 	 *
 	 * ## EXAMPLES
 	 *
+	 *     # Mark user as spam.
 	 *     $ wp user spam 123
 	 *     User 123 marked as spam.
 	 *     Success: Spammed 1 of 1 users.
@@ -1300,7 +1301,7 @@ class User_Command extends CommandWithDBObject {
 	}
 
 	/**
-	 * Removes one or more users from spam.
+	 * Removes one or more users from spam on multisite.
 	 *
 	 * ## OPTIONS
 	 *
@@ -1309,6 +1310,7 @@ class User_Command extends CommandWithDBObject {
 	 *
 	 * ## EXAMPLES
 	 *
+	 *     # Remove user from spam.
 	 *     $ wp user unspam 123
 	 *     User 123 removed from spam.
 	 *     Success: Unspamed 1 of 1 users.


### PR DESCRIPTION
Fixes https://github.com/wp-cli/entity-command/issues/412

- Update doc for `user spam` and `user unspam` command to reflect that those commands are applicable on multisite.