### PR TITLE
Add user exists command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4769,6 +4769,36 @@ make sure to reassign their posts prior to deleting the user.
 
 
 
+### wp user exists
+
+Verifies whether a user exists.
+
+~~~
+wp user exists <id>
+~~~
+
+Displays a success message if the user does exist.
+
+**OPTIONS**
+
+	<id>
+		The ID of the user to check.
+
+**EXAMPLES**
+
+    # The user exists.
+    $ wp user exists 1337
+    Success: User with ID 1337 exists.
+    $ echo $?
+    0
+
+    # The user does not exist.
+    $ wp user exists 10000
+    $ echo $?
+    1
+
+
+
 ### wp user generate
 
 Generates some users.

--- a/composer.json
+++ b/composer.json
@@ -158,6 +158,7 @@
             "user add-role",
             "user create",
             "user delete",
+            "user exists",
             "user generate",
             "user get",
             "user import-csv",

--- a/features/user.feature
+++ b/features/user.feature
@@ -17,6 +17,17 @@ Feature: Manage WordPress users
       | ID           | {USER_ID}  |
       | roles        | author     |
 
+    When I run `wp user exists {USER_ID}`
+    Then STDOUT should be:
+      """
+      Success: User with ID {USER_ID} exists.
+      """
+    And the return code should be 0
+
+    When I try `wp user exists 1000`
+    And STDOUT should be empty
+    And the return code should be 1
+
     When I run `wp user get {USER_ID} --field=user_registered`
     Then STDOUT should not contain:
       """

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -648,6 +648,37 @@ class User_Command extends CommandWithDBObject {
 	}
 
 	/**
+	 * Verifies whether a user exists.
+	 *
+	 * Displays a success message if the user does exist.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <id>
+	 * : The ID of the user to check.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # The user exists.
+	 *     $ wp user exists 1337
+	 *     Success: User with ID 1337 exists.
+	 *     $ echo $?
+	 *     0
+	 *
+	 *     # The user does not exist.
+	 *     $ wp user exists 10000
+	 *     $ echo $?
+	 *     1
+	 */
+	public function exists( $args ) {
+		if ( $this->fetcher->get( $args[0] ) ) {
+			WP_CLI::success( "User with ID {$args[0]} exists." );
+		} else {
+			WP_CLI::halt( 1 );
+		}
+	}
+
+	/**
 	 * Sets the user role.
 	 *
 	 * ## OPTIONS


### PR DESCRIPTION
Adds a user  `wp user exists` command that works the same way `wp post exists` does.

Fixes #484  