### PR TITLE
Support nickname creating user

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -708,3 +708,24 @@ Feature: Manage WordPress users
     Then STDOUT should be a table containing rows:
       | Field        | Value                   |
       | user_url     | http://www.testsite.com |
+
+  Scenario: Support nickname creating and updating user
+    Given a WP install
+
+    When I run `wp user create testuser testuser@example.com --nickname=customtestuser --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {USER_ID}
+
+    When I run `wp user meta get {USER_ID} nickname`
+    Then STDOUT should be:
+      """
+      customtestuser
+      """
+
+    When I run `wp user update {USER_ID} --nickname=newtestuser`
+    And I run `wp user meta get {USER_ID} nickname`
+    Then STDOUT should be:
+      """
+      newtestuser
+      """
+

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -407,6 +407,8 @@ class User_Command extends CommandWithDBObject {
 
 		$user->display_name = Utils\get_flag_value( $assoc_args, 'display_name', false );
 
+		$user->nickname = Utils\get_flag_value( $assoc_args, 'nickname', false );
+
 		$user->first_name = Utils\get_flag_value( $assoc_args, 'first_name', false );
 
 		$user->last_name = Utils\get_flag_value( $assoc_args, 'last_name', false );


### PR DESCRIPTION
Fixes https://github.com/wp-cli/entity-command/issues/274

* Support nickname creating user
* Add tests for user creation with nickname