### PR TITLE
Support new upstream autoload options

### DIFF
--- a/features/option-get-autoload.feature
+++ b/features/option-get-autoload.feature
@@ -8,7 +8,7 @@ Feature: Get 'autoload' value for an option
       """
       Error: Could not get 'foo' option. Does it exist?
       """
-
+  @less-than-wp-6.6
   Scenario: Displays 'autoload' value
     Given a WP install
 
@@ -22,4 +22,19 @@ Feature: Get 'autoload' value for an option
     Then STDOUT should be:
       """
       yes
+      """
+  @require-wp-6.6
+  Scenario: Displays 'autoload' value
+    Given a WP install
+
+    When I run `wp option add foo bar`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp option get-autoload foo`
+    Then STDOUT should be:
+      """
+      on
       """

--- a/features/option-set-autoload.feature
+++ b/features/option-set-autoload.feature
@@ -24,6 +24,7 @@ Feature: Set 'autoload' value for an option
       Error: Invalid value specified for positional arg.
       """
 
+  @less-than-wp-6.6
   Scenario: Successfully updates autoload value
     Given a WP install
 
@@ -55,4 +56,38 @@ Feature: Set 'autoload' value for an option
     Then STDOUT should be:
       """
       no
+      """
+
+  @require-wp-6.6
+  Scenario: Successfully updates autoload value
+    Given a WP install
+
+    When I run `wp option add foo bar`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp option get-autoload foo`
+    Then STDOUT should be:
+      """
+      on
+      """
+
+    When I run `wp option set-autoload foo off`
+    Then STDOUT should be:
+      """
+      Success: Updated autoload value for 'foo' option.
+      """
+
+    When I run the previous command again
+    Then STDOUT should be:
+      """
+      Success: Autoload value passed for 'foo' option is unchanged.
+      """
+
+    When I run `wp option get-autoload foo`
+    Then STDOUT should be:
+      """
+      off
       """

--- a/features/option.feature
+++ b/features/option.feature
@@ -140,6 +140,7 @@ Feature: Manage WordPress options
       """
 
   @require-wp-4.2
+  @less-than-wp-6.6
   Scenario: Update autoload value for custom option
     Given a WP install
     And I run `wp option add hello world --autoload=no`
@@ -160,7 +161,30 @@ Feature: Manage WordPress options
       | option_name  | option_value   | autoload |
       | hello        | island         | yes      |
 
+  @require-wp-6.6
+  Scenario: Update autoload value for custom option
+    Given a WP install
+    And I run `wp option add hello world --autoload=off`
+
+    When I run `wp option update hello universe`
+    Then STDOUT should not be empty
+
+    When I run `wp option list --search='hello' --fields=option_name,option_value,autoload`
+    Then STDOUT should be a table containing rows:
+      | option_name  | option_value   | autoload |
+      | hello        | universe       | off       |
+
+    When I run `wp option update hello island --autoload=on`
+    Then STDOUT should not be empty
+
+    When I run `wp option list --search='hello' --fields=option_name,option_value,autoload`
+    Then STDOUT should be a table containing rows:
+      | option_name  | option_value   | autoload |
+      | hello        | island         | on      |
+
+
   @require-wp-4.2
+  @less-than-wp-6.6
   Scenario: Managed autoloaded options
     Given a WP install
 
@@ -248,11 +272,11 @@ Feature: Manage WordPress options
       """
     And the return code should be 0
 
-    When I try `wp option list --search='auto_opt' --autoload=no`
+    When I try `wp option list --search='auto_opt' --autoload=nope`
     Then STDOUT should be empty
-    And STDERR should be:
+    And STDERR should contain:
       """
-      Error: Value of '--autoload' should be on or off.
+      Error: Value of '--autoload' should be
       """
     And the return code should be 1
 
@@ -264,7 +288,7 @@ Feature: Manage WordPress options
       """
     And the return code should be 0
 
-    When I try `wp option add str_opt_foo 'bar' --autoload=off`
+    When I try `wp option add str_opt_foo 'bar' --autoload=bad`
     Then STDOUT should be empty
     And STDERR should contain:
       """

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -109,6 +109,8 @@ class Option_Command extends WP_CLI_Command {
 	 * : Should this option be automatically loaded.
 	 * ---
 	 * options:
+	 *   - 'on'
+	 *   - 'off'
 	 *   - 'yes'
 	 *   - 'no'
 	 * ---
@@ -125,7 +127,7 @@ class Option_Command extends WP_CLI_Command {
 		$value = WP_CLI::get_value_from_arg_or_stdin( $args, 1 );
 		$value = WP_CLI::read_value( $value, $assoc_args );
 
-		if ( Utils\get_flag_value( $assoc_args, 'autoload' ) === 'no' ) {
+		if ( in_array( Utils\get_flag_value( $assoc_args, 'autoload' ), [ 'no', 'off' ], true ) ) {
 			$autoload = 'no';
 		} else {
 			$autoload = 'yes';
@@ -271,12 +273,13 @@ class Option_Command extends WP_CLI_Command {
 		}
 
 		if ( isset( $assoc_args['autoload'] ) ) {
-			if ( 'on' === $assoc_args['autoload'] ) {
+			$autoload = $assoc_args['autoload'];
+			if ( 'on' === $autoload || 'yes' === $autoload ) {
 				$autoload_query = " AND autoload='yes'";
-			} elseif ( 'off' === $assoc_args['autoload'] ) {
+			} elseif ( 'off' === $autoload || 'no' === $autoload ) {
 				$autoload_query = " AND autoload='no'";
 			} else {
-				WP_CLI::error( "Value of '--autoload' should be on or off." );
+				WP_CLI::error( "Value of '--autoload' should be 'on', 'off', 'yes', or 'no'." );
 			}
 		}
 
@@ -360,6 +363,8 @@ class Option_Command extends WP_CLI_Command {
 	 * : Requires WP 4.2. Should this option be automatically loaded.
 	 * ---
 	 * options:
+	 *   - 'on'
+	 *   - 'off'
 	 *   - 'yes'
 	 *   - 'no'
 	 * ---
@@ -413,7 +418,7 @@ class Option_Command extends WP_CLI_Command {
 		$value = WP_CLI::read_value( $value, $assoc_args );
 
 		$autoload = Utils\get_flag_value( $assoc_args, 'autoload' );
-		if ( ! in_array( $autoload, [ 'yes', 'no' ], true ) ) {
+		if ( ! in_array( $autoload, [ 'on', 'off', 'yes', 'no' ], true ) ) {
 			$autoload = null;
 		}
 
@@ -479,6 +484,8 @@ class Option_Command extends WP_CLI_Command {
 	 * : Should this option be automatically loaded.
 	 * ---
 	 * options:
+	 *   - 'on'
+	 *   - 'off'
 	 *   - 'yes'
 	 *   - 'no'
 	 * ---


### PR DESCRIPTION
Fixes #491

See: https://core.trac.wordpress.org/changeset/57920

This should get all of the tests working again