### PR TITLE
Fix menu ordering on item update

### DIFF
--- a/features/menu-item.feature
+++ b/features/menu-item.feature
@@ -195,3 +195,49 @@ Feature: Manage WordPress menu items
       | type   | title  | position | link               |
       | custom | First  | 1        | https://first.com  |
       | custom | Third  | 2        | https://third.com  |
+
+  Scenario: Menu order is updated after item update
+    When I run `wp menu create "Sidebar Menu"`
+    Then STDOUT should not be empty
+
+    When I run `wp menu item add-custom sidebar-menu First https://first.com --porcelain`
+    Then save STDOUT as {ITEM_ID_1}
+
+    When I run `wp menu item add-custom sidebar-menu Second https://second.com --porcelain`
+    Then save STDOUT as {ITEM_ID_2}
+
+    When I run `wp menu item add-custom sidebar-menu Third https://third.com --porcelain`
+    Then save STDOUT as {ITEM_ID_3}
+
+    When I run `wp menu item list sidebar-menu --fields=type,title,position,link`
+    Then STDOUT should be a table containing rows:
+      | type   | title  | position | link               |
+      | custom | First  | 1        | https://first.com  |
+      | custom | Second | 2        | https://second.com |
+      | custom | Third  | 3        | https://third.com  |
+
+    When I run `wp menu item update {ITEM_ID_3} --position=1`
+    Then STDOUT should be:
+      """
+      Success: Menu item updated.
+      """
+
+    When I run `wp menu item list sidebar-menu --fields=type,title,position,link`
+    Then STDOUT should be a table containing rows:
+      | type   | title  | position | link               |
+      | custom | Third  | 1        | https://third.com  |
+      | custom | First  | 2        | https://first.com  |
+      | custom | Second | 3        | https://second.com |
+
+    When I run `wp menu item update {ITEM_ID_3} --position=2`
+    Then STDOUT should be:
+      """
+      Success: Menu item updated.
+      """
+
+    When I run `wp menu item list sidebar-menu --fields=type,title,position,link`
+    Then STDOUT should be a table containing rows:
+      | type   | title  | position | link               |
+      | custom | First  | 1        | https://first.com  |
+      | custom | Third  | 2        | https://third.com  |
+      | custom | Second | 3        | https://second.com |

--- a/src/Menu_Item_Command.php
+++ b/src/Menu_Item_Command.php
@@ -488,6 +488,14 @@ class Menu_Item_Command extends WP_CLI_Command {
 				$this->reorder_menu_items( $menu->term_id, $menu_item_args['menu-item-position'], +1, $result );
 			}
 
+			if ( ( 'update' === $method ) && $menu_item_args['menu-item-position'] ) {
+				if ( $menu_item_args['menu-item-position'] > $position ) {
+					$this->reorder_menu_items( $menu->term_id, $menu_item_args['menu-item-position'], -1, $result );
+				} elseif ( $menu_item_args['menu-item-position'] < $position ) {
+					$this->reorder_menu_items( $menu->term_id, $menu_item_args['menu-item-position'] - 1, +1, $result );
+				}
+			}
+
 			/**
 			 * Set the menu
 			 *
@@ -504,7 +512,7 @@ class Menu_Item_Command extends WP_CLI_Command {
 			if ( 'add' === $method && ! empty( $assoc_args['porcelain'] ) ) {
 				WP_CLI::line( $result );
 			} elseif ( 'add' === $method ) {
-					WP_CLI::success( 'Menu item added.' );
+				WP_CLI::success( 'Menu item added.' );
 			} elseif ( 'update' === $method ) {
 				WP_CLI::success( 'Menu item updated.' );
 			}


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

Fixes https://github.com/wp-cli/entity-command/issues/463

This PR reorders menu items when using `wp menu item update` command with the `--position` flag

Previous behavior is described in #463

New behavior:
```sh
$ wp menu item list sample-menu --format=csv
db_id,type,title,link,position
4,custom,Alpha,https://alpha.com,1
5,custom,Beta,https://beta.com,2

$ wp menu item update 5 --position=1
Success: Menu item updated.

$ wp menu item list sample-menu --format=csv
db_id,type,title,link,position
5,custom,Beta,https://beta.com,1
4,custom,Alpha,https://alpha.com,2

$ wp menu item update 5 --position=2        
Success: Menu item updated.

$ wp menu item list sample-menu --format=csv
db_id,type,title,link,position
4,custom,Alpha,https://alpha.com,1
5,custom,Beta,https://beta.com,2
```

While this fix works, it utilizes `reorder_menu_items()` which I believe is potentially error prone in situations where there are gaps in menu item ordering. Menu ordering gaps can be introduced using the same `wp menu item update` command and can cause abnormal behavior when reordering position. I'm curious about the maintainer's interest in enforcing menu item ordering without allowing gaps?

Another potential bug could be the `position` shown when listing the menu does not match the `menu_order` column in the `posts` table. By not displaying the exact `menu_order` value we can cause [confusion like I had](https://github.com/wp-cli/entity-command/issues/463#issuecomment-2116104111) when investigating this issue.