### PR TITLE
Add missing options header in signup list command

### DIFF
--- a/src/Signup_Command.php
+++ b/src/Signup_Command.php
@@ -54,6 +54,8 @@ class Signup_Command extends CommandWithDBObject {
 	/**
 	 * Lists signups.
 	 *
+	 * ## OPTIONS
+	 *
 	 * [--<field>=<value>]
 	 * : Filter the list by a specific field.
 	 *


### PR DESCRIPTION
This PR adds missing `## OPTIONS` header in user signup list docs.