### PR TITLE
Return a proper `WP_Error` object when failing to update a comment

### DIFF
--- a/features/comment.feature
+++ b/features/comment.feature
@@ -70,6 +70,16 @@ Feature: Manage WordPress comments
       """
     And the return code should be 1
 
+  Scenario: Updating an invalid comment should return an error
+    Given a WP install
+
+    When I try `wp comment update 22 --comment_author=Foo`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      Warning: Could not update comment.
+      """
+
   Scenario: Get details about an existing comment
     When I run `wp comment get 1`
     Then STDOUT should be a table containing rows:

--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -118,7 +118,7 @@ class Comment_Command extends CommandWithDBObject {
 			$assoc_args,
 			function ( $params ) {
 				if ( ! wp_update_comment( $params ) ) {
-					return new WP_Error( 'Could not update comment.' );
+					return new WP_Error( 'db_error', 'Could not update comment.' );
 				}
 
 				return true;


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/5960