### PR TITLE
Require `wp-cli/wp-cli` v2.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "wp-cli/wp-cli": "^2.11"
+        "wp-cli/wp-cli": "^2.12"
     },
     "require-dev": {
         "wp-cli/cache-command": "^1 || ^2",


### PR DESCRIPTION
For improved PHP 8.4 compatibility.