### PR TITLE
Implement network-specific metadata handling in commands

### DIFF
--- a/features/network-meta.feature
+++ b/features/network-meta.feature
@@ -17,7 +17,6 @@ Feature: Manage network-wide custom fields.
       """
     And the return code should be 1
 
-  # TODO: FIXME
   Scenario: Network meta is actually network options
     Given a WP multisite install
 
@@ -44,4 +43,42 @@ Feature: Manage network-wide custom fields.
     Then STDOUT should be:
       """
       456
+      """
+
+  @require-object-cache
+  Scenario: Object cache correctly handles network meta updates
+    Given a WP multisite install
+
+    When I run `wp eval 'update_network_option( 1, "objkey", "123" );'`
+
+    When I run `wp network meta get 1 objkey`
+    Then STDOUT should be:
+      """
+      123
+      """
+
+    When I run `wp eval 'update_network_option( 1, "objkey", "456" );'`
+
+    When I run `wp network meta get 1 objkey`
+    Then STDOUT should be:
+      """
+      456
+      """
+
+    When I run `wp network meta update 1 objkey 789`
+    Then STDOUT should be:
+      """
+      Success: Updated custom field 'objkey'.
+      """
+
+    When I run `wp network meta get 1 objkey`
+    Then STDOUT should be:
+      """
+      789
+      """
+
+    When I run `wp eval 'echo get_network_option( 1, "objkey" );'`
+    Then STDOUT should be:
+      """
+      789
       """

--- a/features/network-meta.feature
+++ b/features/network-meta.feature
@@ -16,3 +16,32 @@ Feature: Manage network-wide custom fields.
       This is not a multisite install
       """
     And the return code should be 1
+
+  # TODO: FIXME
+  Scenario: Network meta is actually network options
+    Given a WP multisite install
+
+    When I run `wp eval 'update_network_option( 1, "mykey", "123" );'`
+    And I run `wp eval 'echo get_network_option( 1, "mykey" );'`
+    Then STDOUT should be:
+      """
+      123
+      """
+
+    When I run `wp network meta update 1 mykey 456`
+    Then STDOUT should be:
+      """
+      Success: Updated custom field 'mykey'.
+      """
+
+    When I run `wp network meta get 1 mykey`
+    Then STDOUT should be:
+      """
+      456
+      """
+
+    When I run `wp eval 'echo get_network_option( 1, "mykey" );'`
+    Then STDOUT should be:
+      """
+      456
+      """

--- a/features/network-meta.feature
+++ b/features/network-meta.feature
@@ -51,7 +51,7 @@ Feature: Manage network-wide custom fields.
 
     When I run `wp eval 'update_network_option( 1, "objkey", "123" );'`
 
-    When I run `wp network meta get 1 objkey`
+    And I run `wp network meta get 1 objkey`
     Then STDOUT should be:
       """
       123
@@ -59,7 +59,7 @@ Feature: Manage network-wide custom fields.
 
     When I run `wp eval 'update_network_option( 1, "objkey", "456" );'`
 
-    When I run `wp network meta get 1 objkey`
+    And I run `wp network meta get 1 objkey`
     Then STDOUT should be:
       """
       456

--- a/src/Network_Meta_Command.php
+++ b/src/Network_Meta_Command.php
@@ -15,4 +15,90 @@ use WP_CLI\CommandWithMeta;
  */
 class Network_Meta_Command extends CommandWithMeta {
 	protected $meta_type = 'site';
+
+	/**
+	 * Override add_metadata() to use add_network_option() if available.
+	 *
+	 * @param int    $object_id  ID of the object the metadata is for.
+	 * @param string $meta_key   Metadata key to use.
+	 * @param mixed  $meta_value Metadata value. Must be serializable if
+	 *                           non-scalar.
+	 * @param bool   $unique     Optional, default is false. Whether the
+	 *                           specified metadata key should be unique for the
+	 *                           object. If true, and the object already has a
+	 *                           value for the specified metadata key, no change
+	 *                           will be made.
+	 *
+	 * @return int|false The meta ID on success, false on failure.
+	 */
+	protected function add_metadata( $object_id, $meta_key, $meta_value, $unique = false ) {
+		if ( function_exists( 'add_network_option' ) && $unique ) {
+			return add_network_option( $object_id, $meta_key, $meta_value );
+		}
+		return add_metadata( $this->meta_type, $object_id, $meta_key, $meta_value, $unique );
+	}
+
+	/**
+	 * Override update_metadata() to use update_network_option() if available.
+	 *
+	 * @param int    $object_id  ID of the object the metadata is for.
+	 * @param string $meta_key   Metadata key to use.
+	 * @param mixed  $meta_value Metadata value. Must be serializable if
+	 *                           non-scalar.
+	 * @param mixed  $prev_value Optional. If specified, only update existing
+	 *                           metadata entries with the specified value.
+	 *                           Otherwise, update all entries.
+	 *
+	 * @return int|bool Meta ID if the key didn't exist, true on successful
+	 *                  update, false on failure.
+	 */
+	protected function update_metadata( $object_id, $meta_key, $meta_value, $prev_value = '' ) {
+		if ( function_exists( 'update_network_option' ) && '' === $prev_value ) {
+			return update_network_option( $object_id, $meta_key, $meta_value );
+		}
+		return update_metadata( $this->meta_type, $object_id, $meta_key, $meta_value, $prev_value );
+	}
+
+	/**
+	 * Override get_metadata() to use get_network_option() if available.
+	 *
+	 * @param int    $object_id ID of the object the metadata is for.
+	 * @param string $meta_key  Optional. Metadata key. If not specified,
+	 *                          retrieve all metadata for the specified object.
+	 * @param bool   $single    Optional, default is false. If true, return only
+	 *                          the first value of the specified meta_key. This
+	 *                          parameter has no effect if meta_key is not
+	 *                          specified.
+	 *
+	 * @return mixed Single metadata value, or array of values.
+	 */
+	protected function get_metadata( $object_id, $meta_key = '', $single = false ) {
+		if ( function_exists( 'get_network_option' ) && '' !== $meta_key && $single ) {
+			return get_network_option( $object_id, $meta_key );
+		}
+		return get_metadata( $this->meta_type, $object_id, $meta_key, $single );
+	}
+
+	/**
+	 * Override delete_metadata() to use delete_network_option() if available.
+	 *
+	 * @param int    $object_id  ID of the object metadata is for
+	 * @param string $meta_key   Metadata key
+	 * @param mixed $meta_value  Optional. Metadata value. Must be serializable
+	 *                           if non-scalar. If specified, only delete
+	 *                           metadata entries with this value. Otherwise,
+	 *                           delete all entries with the specified meta_key.
+	 *                           Pass `null, `false`, or an empty string to skip
+	 *                           this check. For backward compatibility, it is
+	 *                           not possible to pass an empty string to delete
+	 *                           those entries with an empty string for a value.
+	 *
+	 * @return bool True on successful delete, false on failure.
+	 */
+	protected function delete_metadata( $object_id, $meta_key, $meta_value = '' ) {
+		if ( function_exists( 'delete_network_option' ) && '' === $meta_value ) {
+			return delete_network_option( $object_id, $meta_key );
+		}
+		return delete_metadata( $this->meta_type, $object_id, $meta_key, $meta_value, false );
+	}
 }

--- a/src/Network_Meta_Command.php
+++ b/src/Network_Meta_Command.php
@@ -30,7 +30,7 @@ class Network_Meta_Command extends CommandWithMeta {
 	 *                           will be made.
 	 *
 	 * @return bool The meta ID on success, false on failure.
-	 * 
+	 *
 	 * @phpstan-ignore method.childReturnType
 	 */
 	protected function add_metadata( $object_id, $meta_key, $meta_value, $unique = false ) {

--- a/src/Network_Meta_Command.php
+++ b/src/Network_Meta_Command.php
@@ -17,7 +17,7 @@ class Network_Meta_Command extends CommandWithMeta {
 	protected $meta_type = 'site';
 
 	/**
-	 * Override add_metadata() to use add_network_option() if available.
+	 * Override add_metadata() to use add_network_option().
 	 *
 	 * @param int    $object_id  ID of the object the metadata is for.
 	 * @param string $meta_key   Metadata key to use.
@@ -29,14 +29,16 @@ class Network_Meta_Command extends CommandWithMeta {
 	 *                           value for the specified metadata key, no change
 	 *                           will be made.
 	 *
-	 * @return int|false The meta ID on success, false on failure.
+	 * @return bool The meta ID on success, false on failure.
+	 * 
+	 * @phpstan-ignore method.childReturnType
 	 */
 	protected function add_metadata( $object_id, $meta_key, $meta_value, $unique = false ) {
 		return add_network_option( $object_id, $meta_key, $meta_value );
 	}
 
 	/**
-	 * Override update_metadata() to use update_network_option() if available.
+	 * Override update_metadata() to use update_network_option().
 	 *
 	 * @param int    $object_id  ID of the object the metadata is for.
 	 * @param string $meta_key   Metadata key to use.
@@ -54,7 +56,7 @@ class Network_Meta_Command extends CommandWithMeta {
 	}
 
 	/**
-	 * Override get_metadata() to use get_network_option() if available.
+	 * Override get_metadata() to use get_network_option().
 	 *
 	 * @param int    $object_id ID of the object the metadata is for.
 	 * @param string $meta_key  Optional. Metadata key. If not specified,
@@ -65,13 +67,15 @@ class Network_Meta_Command extends CommandWithMeta {
 	 *                          specified.
 	 *
 	 * @return mixed Single metadata value, or array of values.
+	 *
+	 * @phpstan-ignore method.childReturnType
 	 */
 	protected function get_metadata( $object_id, $meta_key = '', $single = false ) {
 		return get_network_option( $object_id, $meta_key );
 	}
 
 	/**
-	 * Override delete_metadata() to use delete_network_option() if available.
+	 * Override delete_metadata() to use delete_network_option().
 	 *
 	 * @param int    $object_id  ID of the object metadata is for
 	 * @param string $meta_key   Metadata key

--- a/src/Network_Meta_Command.php
+++ b/src/Network_Meta_Command.php
@@ -32,10 +32,7 @@ class Network_Meta_Command extends CommandWithMeta {
 	 * @return int|false The meta ID on success, false on failure.
 	 */
 	protected function add_metadata( $object_id, $meta_key, $meta_value, $unique = false ) {
-		if ( function_exists( 'add_network_option' ) && $unique ) {
-			return add_network_option( $object_id, $meta_key, $meta_value );
-		}
-		return add_metadata( $this->meta_type, $object_id, $meta_key, $meta_value, $unique );
+		return add_network_option( $object_id, $meta_key, $meta_value );
 	}
 
 	/**
@@ -53,10 +50,7 @@ class Network_Meta_Command extends CommandWithMeta {
 	 *                  update, false on failure.
 	 */
 	protected function update_metadata( $object_id, $meta_key, $meta_value, $prev_value = '' ) {
-		if ( function_exists( 'update_network_option' ) && '' === $prev_value ) {
-			return update_network_option( $object_id, $meta_key, $meta_value );
-		}
-		return update_metadata( $this->meta_type, $object_id, $meta_key, $meta_value, $prev_value );
+		return update_network_option( $object_id, $meta_key, $meta_value );
 	}
 
 	/**
@@ -73,10 +67,7 @@ class Network_Meta_Command extends CommandWithMeta {
 	 * @return mixed Single metadata value, or array of values.
 	 */
 	protected function get_metadata( $object_id, $meta_key = '', $single = false ) {
-		if ( function_exists( 'get_network_option' ) && '' !== $meta_key && $single ) {
-			return get_network_option( $object_id, $meta_key );
-		}
-		return get_metadata( $this->meta_type, $object_id, $meta_key, $single );
+		return get_network_option( $object_id, $meta_key );
 	}
 
 	/**
@@ -96,9 +87,6 @@ class Network_Meta_Command extends CommandWithMeta {
 	 * @return bool True on successful delete, false on failure.
 	 */
 	protected function delete_metadata( $object_id, $meta_key, $meta_value = '' ) {
-		if ( function_exists( 'delete_network_option' ) && '' === $meta_value ) {
-			return delete_network_option( $object_id, $meta_key );
-		}
-		return delete_metadata( $this->meta_type, $object_id, $meta_key, $meta_value, false );
+		return delete_network_option( $object_id, $meta_key );
 	}
 }


### PR DESCRIPTION
Added overrides for add, update, get, and delete metadata methods to utilize network-specific options when available. This ensures compatibility and functionality for multisite network scenarios. Fallbacks to standard metadata functions are maintained for non-network environments.

Add function exists, to ensure compatablity with 4.2 below. 

Fixes #504 

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
