### PR TITLE
`wp post list`: Add JSON input support for `date_query` argument

### DIFF
--- a/features/post.feature
+++ b/features/post.feature
@@ -365,6 +365,18 @@ Feature: Manage WordPress posts
       | Publish post | publish-post | publish      |
       | Sample Page  | sample-page  | publish      |
 
+	When I run `wp post create --post_title='old post' --post_date='2023-01-24T09:52:00.000Z'`
+	And I run `wp post create --post_title='new post' --post_date='2025-01-24T09:52:00.000Z'`
+	And I run `wp post list --field=post_title --date_query='{"before":{"year":"2024"}}'`
+	Then STDOUT should contain:
+      """
+      old post
+      """
+	And STDOUT should not contain:
+	  """
+      new post
+      """
+
   Scenario: Update categories on a post
     When I run `wp term create category "Test Category" --porcelain`
     Then save STDOUT as {TERM_ID}

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -632,12 +632,14 @@ class Post_Command extends CommandWithDBObject {
 	public function list_( $args, $assoc_args ) {
 		$formatter = $this->get_formatter( $assoc_args );
 
-		$defaults   = [
+		$defaults        = [
 			'posts_per_page' => -1,
 			'post_status'    => 'any',
 		];
-		$query_args = array_merge( $defaults, $assoc_args );
-		$query_args = self::process_csv_arguments_to_arrays( $query_args );
+		$array_arguments = [ 'date_query' ];
+		$assoc_args      = Utils\parse_shell_arrays( $assoc_args, $array_arguments );
+		$query_args      = array_merge( $defaults, $assoc_args );
+		$query_args      = self::process_csv_arguments_to_arrays( $query_args );
 		if ( isset( $query_args['post_type'] ) && 'any' !== $query_args['post_type'] ) {
 			$query_args['post_type'] = explode( ',', $query_args['post_type'] );
 		}


### PR DESCRIPTION

Added `Utils\parse_shell_arrays` for list in post command which will convert argument values from json to array before passing to the query. currently only `date_query` is added to the list of arguments to be considered for the conversion.
It can be used as `wp post list --date_query='{"before":{"year":"2025"}}'`
this fixes #519 

Thank you @swissspidy for suggesting this solution.