### PR TITLE
Add a flag for getting post meta as a single value or not

### DIFF
--- a/features/post-meta.feature
+++ b/features/post-meta.feature
@@ -219,6 +219,39 @@ Feature: Manage post custom fields
       My\New\Meta
       """
 
+Scenario: List post meta with or without single flag
+    Given a WP install
+
+    When I run `wp post meta add 1 apple banana`
+    And I run `wp post meta add 1 apple banana`
+    Then STDOUT should not be empty
+
+    When I run `wp post meta get 1 apple`
+    Then STDOUT should be:
+      """
+      banana
+      """
+
+    When I run `wp post meta get 1 apple --single`
+    Then STDOUT should be:
+      """
+      banana
+      """
+
+    When I run `wp post meta get 1 apple --no-single`
+    Then STDOUT should be:
+      """
+      array (
+        0 => 'banana',
+        1 => 'banana',
+      )
+      """
+    When I run `wp post meta get 1 apple --no-single --format=json`
+    Then STDOUT should be:
+      """
+      ["banana","banana"]
+      """
+
   @pluck
   Scenario: Nested values can be retrieved.
     Given a WP install

--- a/features/post-meta.feature
+++ b/features/post-meta.feature
@@ -223,7 +223,7 @@ Scenario: List post meta with or without single flag
     Given a WP install
 
     When I run `wp post meta add 1 apple banana`
-    And I run the previous command again
+    And I run `wp post meta add 1 apple mango`
     Then STDOUT should not be empty
 
     When I run `wp post meta get 1 apple`
@@ -243,13 +243,13 @@ Scenario: List post meta with or without single flag
       """
       array (
         0 => 'banana',
-        1 => 'banana',
+        1 => 'mango',
       )
       """
     When I run `wp post meta get 1 apple --no-single --format=json`
     Then STDOUT should be:
       """
-      ["banana","banana"]
+      ["banana","mango"]
       """
 
   @pluck

--- a/features/post-meta.feature
+++ b/features/post-meta.feature
@@ -223,7 +223,7 @@ Scenario: List post meta with or without single flag
     Given a WP install
 
     When I run `wp post meta add 1 apple banana`
-    And I run `wp post meta add 1 apple banana`
+    And I run the previous command again
     Then STDOUT should not be empty
 
     When I run `wp post meta get 1 apple`

--- a/src/WP_CLI/CommandWithMeta.php
+++ b/src/WP_CLI/CommandWithMeta.php
@@ -142,6 +142,15 @@ abstract class CommandWithMeta extends WP_CLI_Command {
 	 * <key>
 	 * : The name of the meta field to get.
 	 *
+	 * [--is-single=<is-single>]
+	 * : Whether to return a single value. This parameter has no effect if $key is not specified.
+	 * ---
+	 * default: 1
+	 * options:
+	 *   - 1
+	 *   - 0
+	 * ---
+	 *
 	 * [--format=<format>]
 	 * : Get value in a particular format.
 	 * ---
@@ -157,7 +166,7 @@ abstract class CommandWithMeta extends WP_CLI_Command {
 
 		$object_id = $this->check_object_id( $object_id );
 
-		$value = $this->get_metadata( $object_id, $meta_key, true );
+		$value = $this->get_metadata( $object_id, $meta_key, $assoc_args['is-single'] );
 
 		if ( '' === $value ) {
 			die( 1 );

--- a/src/WP_CLI/CommandWithMeta.php
+++ b/src/WP_CLI/CommandWithMeta.php
@@ -143,7 +143,7 @@ abstract class CommandWithMeta extends WP_CLI_Command {
 	 * : The name of the meta field to get.
 	 *
 	 * [--single]
-	 * : Whether to return a single value. This parameter has no effect if $key is not specified.
+	 * : Whether to return a single value.
 	 *
 	 * [--format=<format>]
 	 * : Get value in a particular format.
@@ -159,7 +159,7 @@ abstract class CommandWithMeta extends WP_CLI_Command {
 		list( $object_id, $meta_key ) = $args;
 
 		$object_id = $this->check_object_id( $object_id );
-		$single    = Utils\get_flag_value( $assoc_args, 'single', true );
+		$single    = Utils\get_flag_value($assoc_args, 'single', true );
 
 		$value = $this->get_metadata( $object_id, $meta_key, $single );
 

--- a/src/WP_CLI/CommandWithMeta.php
+++ b/src/WP_CLI/CommandWithMeta.php
@@ -159,7 +159,7 @@ abstract class CommandWithMeta extends WP_CLI_Command {
 		list( $object_id, $meta_key ) = $args;
 
 		$object_id = $this->check_object_id( $object_id );
-		$single    = Utils\get_flag_value($assoc_args, 'single', true );
+		$single    = Utils\get_flag_value( $assoc_args, 'single', true );
 
 		$value = $this->get_metadata( $object_id, $meta_key, $single );
 

--- a/src/WP_CLI/CommandWithMeta.php
+++ b/src/WP_CLI/CommandWithMeta.php
@@ -165,8 +165,9 @@ abstract class CommandWithMeta extends WP_CLI_Command {
 		list( $object_id, $meta_key ) = $args;
 
 		$object_id = $this->check_object_id( $object_id );
+		$is_single = isset( $assoc_args['is-single'] ) ? $assoc_args['is-single'] : 1;
 
-		$value = $this->get_metadata( $object_id, $meta_key, $assoc_args['is-single'] );
+		$value = $this->get_metadata( $object_id, $meta_key, $is_single );
 
 		if ( '' === $value ) {
 			die( 1 );

--- a/src/WP_CLI/CommandWithMeta.php
+++ b/src/WP_CLI/CommandWithMeta.php
@@ -142,14 +142,8 @@ abstract class CommandWithMeta extends WP_CLI_Command {
 	 * <key>
 	 * : The name of the meta field to get.
 	 *
-	 * [--is-single=<is-single>]
+	 * [--single]
 	 * : Whether to return a single value. This parameter has no effect if $key is not specified.
-	 * ---
-	 * default: 1
-	 * options:
-	 *   - 1
-	 *   - 0
-	 * ---
 	 *
 	 * [--format=<format>]
 	 * : Get value in a particular format.
@@ -165,9 +159,9 @@ abstract class CommandWithMeta extends WP_CLI_Command {
 		list( $object_id, $meta_key ) = $args;
 
 		$object_id = $this->check_object_id( $object_id );
-		$is_single = isset( $assoc_args['is-single'] ) ? $assoc_args['is-single'] : 1;
+		$single    = Utils\get_flag_value( $assoc_args, 'single', true );
 
-		$value = $this->get_metadata( $object_id, $meta_key, $is_single );
+		$value = $this->get_metadata( $object_id, $meta_key, $single );
 
 		if ( '' === $value ) {
 			die( 1 );


### PR DESCRIPTION
Fixes #325 

- Currently marked as WIP.
- I haven't wrote behat tests for this yet.
- Let's finalize the changes first and then I'll write the tests.

**What I did**
- Added a flag `--is-single`
- Default value will be 1 ( true ) which was already there.
- And we can now pass 0 as false for getting multiple values

**Command Examples**

- `wp post meta get 1 bwp_key --is-single=0`
- `wp post meta get 1 bwp_key --is-single=1`
