### PR TITLE
Make term-migrate test more robust

### DIFF
--- a/features/term-migrate.feature
+++ b/features/term-migrate.feature
@@ -17,7 +17,7 @@ Feature: Manage term custom fields
     When I run `wp term migrate apple --by=slug --from=category --to=post_tag`
     Then STDOUT should be:
       """
-      Term 'apple' assigned to post 4.
+      Term 'apple' assigned to post {POST_ID}.
       Term 'apple' migrated.
       Old instance of term 'apple' removed from its original taxonomy.
       Success: Migrated the term 'apple' from taxonomy 'category' to taxonomy 'post_tag' for 1 post.
@@ -41,12 +41,12 @@ Feature: Manage term custom fields
     When I run `wp term migrate {TERM_ID} --by=slug --from=category --to=post_tag`
     Then STDOUT should be:
       """
-      Term '{TERM_ID}' assigned to post 4.
+      Term '{TERM_ID}' assigned to post {POST_ID}.
       Term '{TERM_ID}' migrated.
       Old instance of term '{TERM_ID}' removed from its original taxonomy.
       Success: Migrated the term '{TERM_ID}' from taxonomy 'category' to taxonomy 'post_tag' for 1 post.
       """
-  
+
   @require-wp-4.4
   Scenario: Migrate a term in multiple posts
     Given a WP install
@@ -63,16 +63,16 @@ Feature: Manage term custom fields
 
     When I run `wp post create --post_title='Test post 2' --porcelain`
     Then STDOUT should be a number
-    And save STDOUT as {POST_ID}
+    And save STDOUT as {POST_ID_2}
 
-    When I run `wp post term set {POST_ID} category orange`
+    When I run `wp post term set {POST_ID_2} category orange`
     Then STDOUT should not be empty
 
     When I run `wp term migrate orange --by=slug --from=category --to=post_tag`
     Then STDOUT should be:
       """
-      Term 'orange' assigned to post 4.
-      Term 'orange' assigned to post 5.
+      Term 'orange' assigned to post {POST_ID}.
+      Term 'orange' assigned to post {POST_ID_2}.
       Term 'orange' migrated.
       Old instance of term 'orange' removed from its original taxonomy.
       Success: Migrated the term 'orange' from taxonomy 'category' to taxonomy 'post_tag' for 2 posts.


### PR DESCRIPTION
Avoid hardcoded post IDs, as these are not consistent across WordPress versions.

Addresses this test failure on WP 4.9: https://github.com/wp-cli/entity-command/actions/runs/13689420820/job/38279794564#step:11:156
