### PR TITLE
Ensure wp user update Returns Non-Zero Exit Code for Invalid Users

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -147,6 +147,13 @@ Feature: Manage WordPress users
       3
       """
 
+    When I try `wp user update 9999 --user_pass=securepassword`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      Error: No valid users found.
+      """
+
   Scenario: Delete user with invalid reassign
     Given a WP install
     And a session_no file:
@@ -728,12 +735,3 @@ Feature: Manage WordPress users
       """
       newtestuser
       """
-  Scenario: Updating an invalid user should return an error
-    Given a WP install
-    When I try `wp user update 9999 --user_pass=securepassword`
-    Then the return code should be 1
-    And STDERR should contain:
-      """
-      Error: No valid users found.
-      """
-

--- a/features/user.feature
+++ b/features/user.feature
@@ -735,3 +735,4 @@ Feature: Manage WordPress users
       """
       newtestuser
       """
+

--- a/features/user.feature
+++ b/features/user.feature
@@ -728,4 +728,12 @@ Feature: Manage WordPress users
       """
       newtestuser
       """
+  Scenario: Updating an invalid user should return an error
+    Given a WP install
+    When I try `wp user update 9999 --user_pass=securepassword`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      Error: No valid users found.
+      """
 

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -546,7 +546,7 @@ class User_Command extends CommandWithDBObject {
 		}
 
 		if ( empty( $user_ids ) ) {
-			exit( 1 );
+			WP_CLI::error( 'No valid users found.' );
 		}
 
 		$skip_email = Utils\get_flag_value( $assoc_args, 'skip-email' );

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -545,6 +545,10 @@ class User_Command extends CommandWithDBObject {
 			$user_ids[] = $user->ID;
 		}
 
+		if ( empty( $user_ids ) ) {
+			exit( 1 );
+		}
+
 		$skip_email = Utils\get_flag_value( $assoc_args, 'skip-email' );
 		if ( $skip_email ) {
 			add_filter( 'send_email_change_email', '__return_false' );


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-cli/issues/5960

This PR fixes the issue where `wp user update` incorrectly exits with **0** when the provided user ID is invalid. Now, when an invalid user ID, email, or login is supplied, the command will return an exit code of **1** instead of **0**, ensuring proper error handling.

**Testing Instructions**

**Try updating a non-existent user:**
`wp user update 9999 --user_pass=securepassword`

**Expected output:**
`Warning: Invalid user ID, email or login: '9999'`

**Expected exit code: 1**
`echo $?`
_Should return 1_

**Try updating a existent user:**
`wp user update 1 --user_pass=securepassword`

**Expected output:**
`Success: Updated user 1.`

**Expected exit code: 0**
`echo $?`
_Should return 0_

**Screenshot**

![user_update_command](https://github.com/user-attachments/assets/93299caf-17bc-4f42-96c0-7649dac4ceee)

