### PR TITLE
Validate Parameter Names in wp user update Command

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -376,22 +376,10 @@ Feature: Manage WordPress users
       administrator
       """
 
-    And a user exists with login 9999
-
-    When I run `wp user update 9999 --user-pass=admin`
-    Then STDERR should contain:
-      """
-      Error: Parameter errors:
-      unknown --user-pass parameter
-      Did you mean '--user_pass'?
-      """
-
-    And a user exists with login 9999
-    
-    When I run `wp user update 9999 --user_pass=admin`
+    When I run `wp user update 1 --user_pass=new_password`
     Then STDOUT should contain:
       """
-      Success: Updated user 9999.
+      Success: Updated user 1.
       """
 
   Scenario: Managing user capabilities

--- a/features/user.feature
+++ b/features/user.feature
@@ -376,6 +376,24 @@ Feature: Manage WordPress users
       administrator
       """
 
+    And a user exists with login 9999
+
+    When I run `wp user update 9999 --user-pass=admin`
+    Then STDERR should contain:
+      """
+      Error: Parameter errors:
+      unknown --user-pass parameter
+      Did you mean '--user_pass'?
+      """
+
+    And a user exists with login 9999
+    
+    When I run `wp user update 9999 --user_pass=admin`
+    Then STDOUT should contain:
+      """
+      Success: Updated user 9999.
+      """
+
   Scenario: Managing user capabilities
     Given a WP install
 

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -536,6 +536,49 @@ class User_Command extends CommandWithDBObject {
 			unset( $assoc_args['user_login'] );
 		}
 
+		// Define valid fields for wp_update_user().
+		$valid_fields = array(
+			'user_pass',
+			'user_nicename',
+			'user_url',
+			'user_email',
+			'display_name',
+			'nickname',
+			'first_name',
+			'last_name',
+			'description',
+			'rich_editing',
+			'user_registered',
+			'role',
+			'syntax_highlighting',
+			'comment_shortcuts',
+			'admin_color',
+			'use_ssl',
+			'show_admin_bar_front',
+			'locale',
+		);
+
+		// Check for invalid field names.
+		$invalid_fields = array();
+		foreach ( array_keys( $assoc_args ) as $field ) {
+			// Skip special flags like 'skip-email'.
+			if ( 'skip-email' === $field ) {
+				continue;
+			}
+
+			if ( ! in_array( $field, $valid_fields, true ) ) {
+				$invalid_fields[] = $field;
+			}
+		}
+
+		// Warn about invalid fields.
+		if ( ! empty( $invalid_fields ) ) {
+			foreach ( $invalid_fields as $field ) {
+				WP_CLI::warning( "Unknown --{$field} parameter." );
+				unset( $assoc_args[ $field ] );
+			}
+		}
+
 		if ( isset( $assoc_args['role'] ) ) {
 			self::validate_role( $assoc_args['role'], true );
 		}

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -518,9 +518,6 @@ class User_Command extends CommandWithDBObject {
 	 * [--role=<role>]
 	 * : A string used to set the user's role.
 	 *
-	 * --<field>=<value>
-	 * : One or more fields to update. For accepted fields, see wp_update_user().
-	 *
 	 * [--skip-email]
 	 * : Don't send an email notification to the user.
 	 *
@@ -534,49 +531,6 @@ class User_Command extends CommandWithDBObject {
 		if ( isset( $assoc_args['user_login'] ) ) {
 			WP_CLI::warning( "User logins can't be changed." );
 			unset( $assoc_args['user_login'] );
-		}
-
-		// Define valid fields for wp_update_user().
-		$valid_fields = array(
-			'user_pass',
-			'user_nicename',
-			'user_url',
-			'user_email',
-			'display_name',
-			'nickname',
-			'first_name',
-			'last_name',
-			'description',
-			'rich_editing',
-			'user_registered',
-			'role',
-			'syntax_highlighting',
-			'comment_shortcuts',
-			'admin_color',
-			'use_ssl',
-			'show_admin_bar_front',
-			'locale',
-		);
-
-		// Check for invalid field names.
-		$invalid_fields = array();
-		foreach ( array_keys( $assoc_args ) as $field ) {
-			// Skip special flags like 'skip-email'.
-			if ( 'skip-email' === $field ) {
-				continue;
-			}
-
-			if ( ! in_array( $field, $valid_fields, true ) ) {
-				$invalid_fields[] = $field;
-			}
-		}
-
-		// Warn about invalid fields.
-		if ( ! empty( $invalid_fields ) ) {
-			foreach ( $invalid_fields as $field ) {
-				WP_CLI::warning( "Unknown --{$field} parameter." );
-				unset( $assoc_args[ $field ] );
-			}
 		}
 
 		if ( isset( $assoc_args['role'] ) ) {


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-cli/issues/5286

Summary

This PR addresses issue [#5286](https://github.com/wp-cli/wp-cli/issues/5286), where `wp user update `silently ignored incorrect parameter names (e.g., `--user-pass` instead of `--user_pass`) without providing an error message.

With this fix, WP-CLI will now validate parameter names and issue a warning when an unknown parameter is used.
Changes Introduced

 Added validation to check whether the parameters passed to `wp user update` match the expected field names from `wp_update_user().` If an unrecognized parameter is provided, WP-CLI will display a warning and prevent the update from proceeding.

**Behavior Before Fix**

```
$ wp user update 6 --user-pass=mypass  
Success: Updated user 6.  
```

(Note: The password was not updated, and no warning was shown.)

**Behavior After Fix**

```
$ wp user update 6 --user-pass=mypass  
Warning: Unknown --user-pass parameter.  
Error: Need some fields to update.  
```

(This prevents silent failures and informs the user of incorrect parameter usage.)

**How to Test**

1. Setup a WordPress environment with WP-CLI installed.
2. Create a test user (if not already available):

`wp user create testuser test@example.com --role=subscriber --user_pass=oldpass`

3. Run a valid update command:

`wp user update testuser --user_pass=newpass  `

✅ Expected: User password should update successfully.

4. Run an update command with a typo:

`wp user update testuser --user-pass=newpass  `

**❌ Expected:**

```
Warning: Unknown --user-pass parameter.  
Error: Need some fields to update.  
```

(This ensures that incorrect parameters are flagged.)

5. Test with another incorrect parameter:

`wp user update testuser --wrong_flag=value  `

❌ Expected: Similar warning about an unknown parameter.

6. Verify that no changes were made when incorrect parameters were used.


**Screenshots**

![user_update_params](https://github.com/user-attachments/assets/cb04c843-1fb7-49f1-9138-f459d5bd4bcc)
