### PR TITLE
Improve wp remove-cap command

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -392,7 +392,7 @@ Feature: Manage WordPress users
       contributor
       """
 
-    When I run `wp user remove-cap {USER_ID}` contributor
+    When I run `wp user remove-cap {USER_ID} contributor`
     Then the return code should be 1
     And STDERR should be:
       """

--- a/features/user.feature
+++ b/features/user.feature
@@ -379,26 +379,6 @@ Feature: Manage WordPress users
       administrator
       """
 
-  Scenario: Show error when trying to remove capability same as role
-    Given a WP install
-
-    When I run `wp user create testuser2 testuser2@example.com --first_name=test --last_name=user --role=contributor --porcelain`
-    Then STDOUT should be a number
-    And save STDOUT as {USER_ID}
-
-    When I run `wp user list-caps {USER_ID}`
-    Then STDOUT should contain:
-      """
-      contributor
-      """
-
-    When I run `wp user remove-cap {USER_ID} contributor`
-    Then the return code should be 1
-    And STDERR should be:
-      """
-      Error: There is a role similar to 'contributor' capability. Use `wp user remove-role` instead.
-      """
-
   Scenario: Managing user capabilities
     Given a WP install
 
@@ -451,6 +431,33 @@ Feature: Manage WordPress users
       """
       publish_posts
       """
+
+  Scenario: Show error when trying to remove capability same as role
+    Given a WP install
+
+    When I run `wp user create testuser2 testuser2@example.com --first_name=test --last_name=user --role=contributor --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {USER_ID}
+
+    When I run `wp user list-caps {USER_ID}`
+    Then STDOUT should contain:
+      """
+      contributor
+      """
+
+    When I run `wp user get {USER_ID} --field=roles`
+    Then STDOUT should contain:
+      """
+      contributor
+      """
+
+    When I try `wp user remove-cap {USER_ID} contributor`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: There is a role similar to 'contributor' capability. Use `wp user remove-role` instead.
+      """
+    And STDOUT should be empty
 
   Scenario: Show password when creating a user
     Given a WP install

--- a/features/user.feature
+++ b/features/user.feature
@@ -455,9 +455,15 @@ Feature: Manage WordPress users
     Then the return code should be 1
     And STDERR should be:
       """
-      Error: There is a role similar to 'contributor' capability. Use `wp user remove-role` instead.
+      Error: There is a role similar to 'contributor' capability. Use `wp user remove-cap {USER_ID} contributor --force` to remove capability.
       """
     And STDOUT should be empty
+
+    When I run `wp user remove-cap {USER_ID} contributor --force`
+    Then STDOUT should be:
+      """
+      Success: Removed 'contributor' cap for testuser2 ({USER_ID}).
+      """
 
   Scenario: Show password when creating a user
     Given a WP install

--- a/features/user.feature
+++ b/features/user.feature
@@ -455,7 +455,7 @@ Feature: Manage WordPress users
     Then the return code should be 1
     And STDERR should be:
       """
-      Error: There is a role similar to 'contributor' capability. Use `wp user remove-cap {USER_ID} contributor --force` to remove capability.
+      Error: Aborting because a role has the same name as 'contributor'. Use `wp user remove-cap {USER_ID} contributor --force` to proceed with the removal.
       """
     And STDOUT should be empty
 

--- a/features/user.feature
+++ b/features/user.feature
@@ -379,6 +379,26 @@ Feature: Manage WordPress users
       administrator
       """
 
+  Scenario: Show error when trying to remove capability same as role
+    Given a WP install
+
+    When I run `wp user create testuser2 testuser2@example.com --first_name=test --last_name=user --role=contributor --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {USER_ID}
+
+    When I run `wp user list-caps {USER_ID}`
+    Then STDOUT should contain:
+      """
+      contributor
+      """
+
+    When I run `wp user remove-cap {USER_ID}` contributor
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: There is a role similar to 'contributor' capability. Use `wp user remove-role` instead.
+      """
+
   Scenario: Managing user capabilities
     Given a WP install
 

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -884,8 +884,9 @@ class User_Command extends CommandWithDBObject {
 				}
 				WP_CLI::error( "No such '{$cap}' cap for {$user->user_login} ({$user->ID})." );
 			}
+
 			$user_roles = $user->roles;
-			if ( ! empty( $user_role ) && in_array( $cap, $user_roles, true ) ) {
+			if ( ! empty( $user_roles ) && in_array( $cap, $user_roles, true ) ) {
 				WP_CLI::error( "There is a role similar to '{$cap}' capability. Use `wp user remove-role` instead." );
 			}
 			$user->remove_cap( $cap );

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -884,6 +884,10 @@ class User_Command extends CommandWithDBObject {
 				}
 				WP_CLI::error( "No such '{$cap}' cap for {$user->user_login} ({$user->ID})." );
 			}
+			$user_roles = $user->roles;
+			if ( ! empty( $user_role ) && in_array( $cap, $user_roles, true ) ) {
+				WP_CLI::error( "There is a role similar to '{$cap}' capability. Use `wp user remove-role` instead." );
+			}
 			$user->remove_cap( $cap );
 
 			WP_CLI::success( "Removed '{$cap}' cap for {$user->user_login} ({$user->ID})." );

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -861,6 +861,9 @@ class User_Command extends CommandWithDBObject {
 	 * <cap>
 	 * : The capability to be removed.
 	 *
+	 * [--force]
+	 * : Forcefully remove a capability.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp user remove-cap 11 publish_newsletters
@@ -871,6 +874,9 @@ class User_Command extends CommandWithDBObject {
 	 *
 	 *     $ wp user remove-cap 11 nonexistent_cap
 	 *     Error: No such 'nonexistent_cap' cap for supervisor (11).
+	 *
+	 *     $ wp user remove-cap 11 publish_newsletters --force
+	 *     Success: Removed 'publish_newsletters' cap for supervisor (11).
 	 *
 	 * @subcommand remove-cap
 	 */
@@ -886,8 +892,8 @@ class User_Command extends CommandWithDBObject {
 			}
 
 			$user_roles = $user->roles;
-			if ( ! empty( $user_roles ) && in_array( $cap, $user_roles, true ) ) {
-				WP_CLI::error( "There is a role similar to '{$cap}' capability. Use `wp user remove-role` instead." );
+			if ( ! empty( $user_roles ) && in_array( $cap, $user_roles, true ) && ! Utils\get_flag_value( $assoc_args, 'force' ) ) {
+				WP_CLI::error( "There is a role similar to '{$cap}' capability. Use `wp user remove-cap {$user->ID} {$cap} --force` to remove capability." );
 			}
 			$user->remove_cap( $cap );
 

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -893,7 +893,7 @@ class User_Command extends CommandWithDBObject {
 
 			$user_roles = $user->roles;
 			if ( ! empty( $user_roles ) && in_array( $cap, $user_roles, true ) && ! Utils\get_flag_value( $assoc_args, 'force' ) ) {
-				WP_CLI::error( "There is a role similar to '{$cap}' capability. Use `wp user remove-cap {$user->ID} {$cap} --force` to remove capability." );
+				WP_CLI::error( "Aborting because a role has the same name as '{$cap}'. Use `wp user remove-cap {$user->ID} {$cap} --force` to proceed with the removal." );
 			}
 			$user->remove_cap( $cap );
 


### PR DESCRIPTION
Fixes #98 

---

Let's start with this:

---

- Added Role `ExMember` and capability `exmember`
- Now when we try to run comman: `wp user remove-cap 1 exmember`
- It will have error ( see the screenshot below ): There is a role similar to 'exmember' capability. Use `wp user remove-role` instead.
<img width="799" alt="image" src="https://github.com/user-attachments/assets/0b34f83f-78d0-49b1-80fb-a4d5d51288d1" />
