### PR TITLE
`wp post create`: Add JSON input support for `tax_input`

### DIFF
--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -186,7 +186,7 @@ class Post_Command extends CommandWithDBObject {
 			WP_CLI::warning( "The 'meta_input' field was only introduced in WordPress 4.4 so will have no effect." );
 		}
 
-		$array_arguments = [ 'meta_input' ];
+		$array_arguments = [ 'meta_input', 'tax_input' ];
 		$assoc_args      = Utils\parse_shell_arrays( $assoc_args, $array_arguments );
 
 		if ( isset( $assoc_args['from-post'] ) ) {


### PR DESCRIPTION
Fixes this 10 year old issue https://github.com/wp-cli/wp-cli/issues/1323 (closed, but not fixed).

`wp post create` parameter `--tax_input` is supposed to be an array, but no JSON parsing is done and therefore is unusable.
