### PR TITLE
Avoid `setAccessible` deprecation warnings

### DIFF
--- a/src/User_Session_Command.php
+++ b/src/User_Session_Command.php
@@ -173,7 +173,9 @@ class User_Session_Command extends WP_CLI_Command {
 	protected function get_all_sessions( WP_Session_Tokens $manager ) {
 		// Make the private session data accessible to WP-CLI
 		$get_sessions = new ReflectionMethod( $manager, 'get_sessions' );
-		$get_sessions->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$get_sessions->setAccessible( true );
+		}
 
 		/**
 		 * @var array<array{token: string|int, login_time: string, login: int, expiration_time: string, expiration: int}> $sessions
@@ -194,7 +196,9 @@ class User_Session_Command extends WP_CLI_Command {
 
 	protected function destroy_session( WP_Session_Tokens $manager, $token ) {
 		$update_session = new ReflectionMethod( $manager, 'update_session' );
-		$update_session->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$update_session->setAccessible( true );
+		}
 		return $update_session->invoke( $manager, $token, null );
 	}
 


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/6110