### PR TITLE
Fix broken term recount test

### DIFF
--- a/features/term-recount.feature
+++ b/features/term-recount.feature
@@ -49,6 +49,7 @@ Feature: Recount terms on a taxonomy
 
     When I run `wp term recount category`
     And I run `wp term get category {TERM_ID} --field=count`
+    Then STDOUT should be:
       """
       1
       """


### PR DESCRIPTION
There was a missing step that is now caught thanks to a new change in Behat v3.24.0

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
