### PR TITLE
Fix empty STDIN handling in user import-csv

### DIFF
--- a/features/user-import-csv.feature
+++ b/features/user-import-csv.feature
@@ -140,7 +140,6 @@ Feature: Import users from CSV
       | Bob Jones         | contributor          |
       | Bill Jones        | administrator,author |
 
-  @broken
   Scenario: Importing users from STDIN
     Given a WP install
     And a users.csv file:

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -1150,6 +1150,10 @@ class User_Command extends CommandWithDBObject {
 
 				$csv_data[] = $data;
 			}
+
+			if ( empty( $indexes ) || empty( $csv_data ) ) {
+				WP_CLI::error( 'Unable to read content from STDIN.' );
+			}
 		} else {
 			$csv_data = new CsvIterator( $filename );
 		}

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -1151,7 +1151,7 @@ class User_Command extends CommandWithDBObject {
 				$csv_data[] = $data;
 			}
 
-			if ( empty( $indexes ) || empty( $csv_data ) ) {
+			if ( empty( $indexes ) && empty( $csv_data ) ) {
 				WP_CLI::error( 'Unable to read content from STDIN.' );
 			}
 		} else {


### PR DESCRIPTION
## Summary

Fixes `wp user import-csv -` when no CSV content is provided on STDIN.

The old broken test could not just be re-enabled, because the command could exit successfully when STDIN was detected but no CSV header or rows were read. This adds a small check after parsing STDIN so the command returns the existing error instead of silently doing nothing.

## Testing

- `composer behat features/user-import-csv.feature:143`
- `composer behat features/user-import-csv.feature`
- `composer lint`
- `composer phpcs`
- `composer phpstan`
- `composer phpunit`
- `git diff --check`