### PR TITLE
Fix option list filtering with autoload and transients

### DIFF
--- a/features/option-list.feature
+++ b/features/option-list.feature
@@ -33,6 +33,32 @@ Feature: List WordPress options
       siteurl
       """
 
+  @skip-object-cache
+  Scenario: Using the `--autoload=on` flag excludes transients by default
+    Given a WP install
+    And I run `wp option add sample_autoload_option 'sample_autoload_option' --autoload=yes`
+    And I run `wp transient set sample_autoload_transient 'sample_autoload_transient'`
+
+    When I run `wp option list --autoload=on`
+    Then STDOUT should contain:
+      """
+      sample_autoload_option
+      """
+    And STDOUT should not contain:
+      """
+      sample_autoload_transient
+      """
+
+    When I run `wp option list --transients --autoload=on`
+    Then STDOUT should contain:
+      """
+      sample_autoload_transient
+      """
+    And STDOUT should not contain:
+      """
+      sample_autoload_option
+      """
+
   Scenario: List option with exclude pattern
     Given a WP install
 

--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -294,9 +294,9 @@ class Option_Command extends WP_CLI_Command {
 		if ( isset( $assoc_args['autoload'] ) ) {
 			$autoload = $assoc_args['autoload'];
 			if ( 'on' === $autoload || 'yes' === $autoload ) {
-				$autoload_query = " AND (autoload='on') OR (autoload='yes')";
+				$autoload_query = " AND (autoload='on' OR autoload='yes')";
 			} elseif ( 'off' === $autoload || 'no' === $autoload ) {
-				$autoload_query = " AND (autoload='off') OR (autoload='no')";
+				$autoload_query = " AND (autoload='off' OR autoload='no')";
 			} else {
 				WP_CLI::error( "Value of '--autoload' should be 'on', 'off', 'yes', or 'no'." );
 			}
@@ -306,11 +306,11 @@ class Option_Command extends WP_CLI_Command {
 		$show_transients = Utils\get_flag_value( $assoc_args, 'transients', false );
 
 		if ( $show_transients ) {
-			$transients_query = " AND option_name LIKE '\_transient\_%'
-			OR option_name LIKE '\_site\_transient\_%'";
+			$transients_query = " AND (option_name LIKE '\_transient\_%'
+			OR option_name LIKE '\_site\_transient\_%')";
 		} else {
-			$transients_query = " AND option_name NOT LIKE '\_transient\_%'
-			AND option_name NOT LIKE '\_site\_transient\_%'";
+			$transients_query = " AND (option_name NOT LIKE '\_transient\_%'
+			AND option_name NOT LIKE '\_site\_transient\_%')";
 		}
 
 		$where = '';


### PR DESCRIPTION
Fixes an issue where `wp option list --autoload=on` could still include transient rows.

The command already excludes transients by default unless `--transients` is used. This updates the SQL condition grouping so the autoload and transient filters are applied together correctly.

Tests:
- composer behat features/option-list.feature:37
- composer behat features/option-list.feature:4
- composer behat features/option-list.feature:179
- composer behat features/option-list.feature:204
- composer lint
- composer phpcs
- composer phpstan
- git diff --check