### PR TITLE
Modernize deprecated syntax in Behat tests

### DIFF
--- a/features/comment-meta.feature
+++ b/features/comment-meta.feature
@@ -3,10 +3,10 @@ Feature: Manage comment custom fields
   Scenario: Comment meta CRUD
     Given a WP install
 
-    When I run `wp comment-meta add 1 foo 'bar'`
+    When I run `wp comment meta add 1 foo 'bar'`
     Then STDOUT should not be empty
 
-    When I run `wp comment-meta get 1 foo`
+    When I run `wp comment meta get 1 foo`
     Then STDOUT should be:
       """
       bar
@@ -19,19 +19,19 @@ Feature: Manage comment custom fields
       """
     And the return code should be 1
 
-    When I run `wp comment-meta set 1 foo '[ "1", "2" ]' --format=json`
+    When I run `wp comment meta set 1 foo '[ "1", "2" ]' --format=json`
     Then STDOUT should not be empty
 
-    When I run `wp comment-meta get 1 foo --format=json`
+    When I run `wp comment meta get 1 foo --format=json`
     Then STDOUT should be:
       """
       ["1","2"]
       """
 
-    When I run `wp comment-meta delete 1 foo`
+    When I run `wp comment meta delete 1 foo`
     Then STDOUT should not be empty
 
-    When I try `wp comment-meta get 1 foo`
+    When I try `wp comment meta get 1 foo`
     Then the return code should be 1
 
   Scenario: Add comment meta with JSON serialization

--- a/features/comment.feature
+++ b/features/comment.feature
@@ -109,7 +109,7 @@ Feature: Manage WordPress comments
       1
       """
 
-    When I run `wp comment url 1`
+    When I run `wp comment list --comment__in=1 --orderby=comment__in --field=url`
     Then STDOUT should contain:
       """
       #comment-1
@@ -125,14 +125,14 @@ Feature: Manage WordPress comments
     When I run `wp comment create --comment_post_ID=1 --porcelain`
     Then save STDOUT as {COMMENT_ID}
 
-    When I run `wp comment url 1 {COMMENT_ID}`
+    When I run `wp comment list --comment__in=1,{COMMENT_ID} --orderby=comment__in --field=url`
     Then STDOUT should be:
       """
       https://example.com/?p=1#comment-1
       https://example.com/?p=1#comment-{COMMENT_ID}
       """
 
-    When I run `wp comment url {COMMENT_ID} 1`
+    When I run `wp comment list --comment__in={COMMENT_ID},1 --orderby=comment__in --field=url`
     Then STDOUT should be:
       """
       https://example.com/?p=1#comment-{COMMENT_ID}

--- a/features/menu-item.feature
+++ b/features/menu-item.feature
@@ -9,14 +9,14 @@ Feature: Manage WordPress menu items
     Then STDOUT should be a number
     And save STDOUT as {POST_ID}
 
-    When I run `wp post url {POST_ID}`
+    When I run `wp post list --post__in={POST_ID} --post_type=any --orderby=post__in --field=url`
     Then save STDOUT as {POST_LINK}
 
     When I run `wp term create post_tag 'Test term' --slug=test --description='This is a test term' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {TERM_ID}
 
-    When I run `wp term url post_tag {TERM_ID}`
+    When I run `wp term list post_tag --include={TERM_ID} --orderby=include --field=url`
     Then save STDOUT as {TERM_LINK}
 
     When I run `wp menu create "Sidebar Menu"`

--- a/features/network-meta.feature
+++ b/features/network-meta.feature
@@ -3,13 +3,13 @@ Feature: Manage network-wide custom fields.
   Scenario: Non-multisite
     Given a WP install
 
-    When I run `wp network-meta`
+    When I run `wp network meta`
     Then STDOUT should contain:
       """
       usage: wp network meta
       """
 
-    When I try `wp network-meta get 1 site_admins`
+    When I try `wp network meta get 1 site_admins`
     Then STDOUT should be empty
     And STDERR should contain:
       """

--- a/features/post-meta.feature
+++ b/features/post-meta.feature
@@ -5,10 +5,10 @@ Feature: Manage post custom fields
   Scenario: Postmeta CRUD
     Given a WP install
 
-    When I run `wp post-meta add 1 foo 'bar'`
+    When I run `wp post meta add 1 foo 'bar'`
     Then STDOUT should not be empty
 
-    When I run `wp post-meta get 1 foo`
+    When I run `wp post meta get 1 foo`
     Then STDOUT should be:
       """
       bar
@@ -21,7 +21,7 @@ Feature: Manage post custom fields
       """
     And the return code should be 1
 
-    When I run `wp post-meta set 1 foo '[ "1", "2" ]' --format=json`
+    When I run `wp post meta set 1 foo '[ "1", "2" ]' --format=json`
     Then STDOUT should not be empty
 
     When I run the previous command again
@@ -30,23 +30,23 @@ Feature: Manage post custom fields
       Success: Value passed for custom field 'foo' is unchanged.
       """
 
-    When I run `wp post-meta get 1 foo --format=json`
+    When I run `wp post meta get 1 foo --format=json`
     Then STDOUT should be:
       """
       ["1","2"]
       """
 
-    When I run `echo "via STDIN" | wp post-meta set 1 foo`
-    And I run `wp post-meta get 1 foo`
+    When I run `echo "via STDIN" | wp post meta set 1 foo`
+    And I run `wp post meta get 1 foo`
     Then STDOUT should be:
       """
       via STDIN
       """
 
-    When I run `wp post-meta delete 1 foo`
+    When I run `wp post meta delete 1 foo`
     Then STDOUT should not be empty
 
-    When I try `wp post-meta get 1 foo`
+    When I try `wp post meta get 1 foo`
     Then the return code should be 1
 
   Scenario: List post meta
@@ -194,16 +194,16 @@ Feature: Manage post custom fields
   Scenario: Make sure WordPress receives the slashed data it expects in meta fields
     Given a WP install
 
-    When I run `wp post-meta add 1 foo 'My\Meta'`
+    When I run `wp post meta add 1 foo 'My\Meta'`
     Then STDOUT should not be empty
 
-    When I run `wp post-meta get 1 foo`
+    When I run `wp post meta get 1 foo`
     Then STDOUT should be:
       """
       My\Meta
       """
 
-    When I run `wp post-meta update 1 foo 'My\New\Meta'`
+    When I run `wp post meta update 1 foo 'My\New\Meta'`
     Then STDOUT should be:
       """
       Success: Updated custom field 'foo'.
@@ -215,7 +215,7 @@ Feature: Manage post custom fields
       Success: Value passed for custom field 'foo' is unchanged.
       """
 
-    When I run `wp post-meta get 1 foo`
+    When I run `wp post meta get 1 foo`
     Then STDOUT should be:
       """
       My\New\Meta

--- a/features/post.feature
+++ b/features/post.feature
@@ -285,7 +285,7 @@ Feature: Manage WordPress posts
       This is some bunkum.
       """
 
-    When I run `wp post url 1 {POST_ID}`
+    When I run `wp post list --post__in=1,{POST_ID} --post_type=any --orderby=post__in --field=url`
     Then STDOUT should be:
       """
       https://example.com/?p=1

--- a/features/site-create.feature
+++ b/features/site-create.feature
@@ -63,7 +63,7 @@ Feature: Create a new site on a WP multisite
 
       $super_admins = array( 1 => 'admin' );
       """
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --skip-check --extra-php < extra-config`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --extra-php < extra-config`
     Then STDOUT should be:
       """
       Success: Generated 'wp-config.php' file.

--- a/features/site-empty.feature
+++ b/features/site-empty.feature
@@ -26,7 +26,7 @@ Feature: Empty a WordPress site of its data
     When I run `wp media import {CACHE_DIR}/large-image.jpg --post_id=1`
     Then the wp-content/uploads/large-image.jpg file should exist
 
-    When I try `wp site url 1`
+    When I try `wp site list --site__in=1 --field=url`
     Then STDERR should be:
       """
       Error: This is not a multisite installation.

--- a/features/site.feature
+++ b/features/site.feature
@@ -260,7 +260,7 @@ Feature: Manage sites in a multisite installation
     And I run `wp site list --site__in={SITE_ID} --field=url | sed -e's,^\(.*\)://.*,\1,g'`
     And save STDOUT as {SCHEME}
 
-    When I run `wp site url {SITE_ID}`
+    When I run `wp site list --site__in={SITE_ID} --field=url`
     Then STDOUT should be:
       """
       {SCHEME}://example.com/first/
@@ -272,7 +272,7 @@ Feature: Manage sites in a multisite installation
     And I run `wp site list --site__in={SECOND_ID} --field=url | sed -e's,^\(.*\)://.*,\1,g'`
     And save STDOUT as {SECOND_SCHEME}
 
-    When I run `wp site url {SECOND_ID} {SITE_ID}`
+    When I run `wp site list --site__in={SECOND_ID},{SITE_ID} --field=url`
     Then STDOUT should be:
       """
       {SECOND_SCHEME}://example.com/second/

--- a/features/term.feature
+++ b/features/term.feature
@@ -139,20 +139,20 @@ Feature: Manage WordPress terms
     When I run `wp term create category "Second Category" --porcelain`
     Then save STDOUT as {SECOND_TERM_ID}
 
-    When I run `wp term url category {TERM_ID}`
+    When I run `wp term list category --include={TERM_ID} --orderby=include --field=url`
     Then STDOUT should be:
       """
       https://example.com/?cat=2
       """
 
-    When I run `wp term url category {TERM_ID} {SECOND_TERM_ID}`
+    When I run `wp term list category --include={TERM_ID},{SECOND_TERM_ID} --orderby=include --field=url`
     Then STDOUT should be:
       """
       https://example.com/?cat=2
       https://example.com/?cat=3
       """
 
-    When I run `wp term url category {SECOND_TERM_ID} {TERM_ID}`
+    When I run `wp term list category --include={SECOND_TERM_ID},{TERM_ID} --orderby=include --field=url`
     Then STDOUT should be:
       """
       https://example.com/?cat=3

--- a/features/user-meta.feature
+++ b/features/user-meta.feature
@@ -3,35 +3,35 @@ Feature: Manage user custom meta fields
   Scenario: Usermeta CRUD
     Given a WP install
 
-    When I run `wp user-meta add 1 foo 'bar'`
+    When I run `wp user meta add 1 foo 'bar'`
     Then STDOUT should not be empty
 
-    When I run `wp user-meta get 1 foo`
+    When I run `wp user meta get 1 foo`
     Then STDOUT should be:
       """
       bar
       """
 
-    When I try `wp user-meta get 2 foo`
+    When I try `wp user meta get 2 foo`
     Then STDERR should be:
       """
       Error: Invalid user ID, email or login: '2'
       """
     And the return code should be 1
 
-    When I run `wp user-meta set admin foo '[ "1", "2" ]' --format=json`
+    When I run `wp user meta set admin foo '[ "1", "2" ]' --format=json`
     Then STDOUT should not be empty
 
-    When I run `wp user-meta get admin foo --format=json`
+    When I run `wp user meta get admin foo --format=json`
     Then STDOUT should be:
       """
       ["1","2"]
       """
 
-    When I run `wp user-meta delete 1 foo`
+    When I run `wp user meta delete 1 foo`
     Then STDOUT should not be empty
 
-    When I try `wp user-meta get 1 foo`
+    When I try `wp user meta get 1 foo`
     Then the return code should be 1
 
     When I run `wp user meta add 1 foo bar`
@@ -177,7 +177,7 @@ Feature: Manage user custom meta fields
     When I try the previous command again
     Then the return code should be 1
 
-    When I try `wp user-meta get {USER_ID} description`
+    When I try `wp user meta get {USER_ID} description`
     Then STDOUT should be:
       """
       This is description


### PR DESCRIPTION
## What

Updates the Behat tests to use the current command syntax instead of forms deprecated by wp-cli/wp-cli#6356.

## Why

The framework now emits a deprecation warning to STDERR when it rewrites these legacy forms. This breaks `When I run` steps, which expect STDERR to remain empty.

## Tests

- `composer lint`
- `composer phpcs`
- `composer phpunit`
- `composer behat` (447 of 449 scenarios passed; the two failures require GD or Imagick for `wp media import`)
- `composer phpstan` (currently fails on two pre-existing unmatched `method.deprecated` ignores in `User_Session_Command.php`)
