### PR TITLE
Remove WP 4.2 requirement note

### DIFF
--- a/src/Option_Command.php
+++ b/src/Option_Command.php
@@ -379,7 +379,7 @@ class Option_Command extends WP_CLI_Command {
 	 * : The new value. If omitted, the value is read from STDIN.
 	 *
 	 * [--autoload=<autoload>]
-	 * : Requires WP 4.2. Should this option be automatically loaded.
+	 * : Should this option be automatically loaded.
 	 * ---
 	 * options:
 	 *   - 'on'


### PR DESCRIPTION
We require WP 4.9+ nowadays, so this is obsolete

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `--autoload` option description for the `update` command by removing an outdated WordPress version requirement note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->