### PR TITLE
Expose add_to_blog, new_role, and blog_id fields in signup list and get

### DIFF
--- a/features/signup.feature
+++ b/features/signup.feature
@@ -246,3 +246,19 @@ Feature: Manage signups in a multisite installation
       228
       """
 
+  Scenario: Filter signups by metadata with per_page pagination
+    Given a WP multisite install
+    And I run `wp eval "wpmu_signup_user( 'plainuser', 'plainuser@example.com' );"`
+    And I run `wp eval "wpmu_signup_user( 'adminuser', 'adminuser@example.com', array( 'add_to_blog' => 228, 'new_role' => 'administrator' ) );"`
+    And I run `wp eval "wpmu_signup_user( 'editoruser', 'editoruser@example.com', array( 'add_to_blog' => 228, 'new_role' => 'editor' ) );"`
+    And I run `wp eval "wpmu_signup_user( 'otherbloguser', 'otherbloguser@example.com', array( 'add_to_blog' => 300, 'new_role' => 'administrator' ) );"`
+
+    When I run `wp user signup list --blog_id=228 --per_page=2 --fields=user_login,blog_id --format=csv`
+    Then STDOUT should be:
+      """
+      user_login,blog_id
+      adminuser,228
+      editoruser,228
+      """
+
+

--- a/features/signup.feature
+++ b/features/signup.feature
@@ -11,8 +11,8 @@ Feature: Manage signups in a multisite installation
 
   Scenario: List signups
     Given a WP multisite install
-    And I run `wp eval 'wpmu_signup_user( "bobuser", "bobuser@example.com" );'`
-    And I run `wp eval 'wpmu_signup_user( "johnuser", "johnuser@example.com" );'`
+    And I run `wp eval "wpmu_signup_user( 'bobuser', 'bobuser@example.com' );"`
+    And I run `wp eval "wpmu_signup_user( 'johnuser', 'johnuser@example.com' );"`
 
     When I run `wp user signup list --fields=signup_id,user_login,user_email,active --format=csv`
     Then STDOUT should be:
@@ -50,7 +50,7 @@ Feature: Manage signups in a multisite installation
 
   Scenario: Get signup
     Given a WP multisite install
-    And I run `wp eval 'wpmu_signup_user( "bobuser", "bobuser@example.com" );'`
+    And I run `wp eval "wpmu_signup_user( 'bobuser', 'bobuser@example.com' );"`
 
     When I run `wp user signup get 1 --field=user_login`
     Then STDOUT should be:
@@ -67,7 +67,7 @@ Feature: Manage signups in a multisite installation
 
   Scenario: Activate signup
     Given a WP multisite install
-    And I run `wp eval 'wpmu_signup_user( "bobuser", "bobuser@example.com" );'`
+    And I run `wp eval "wpmu_signup_user( 'bobuser', 'bobuser@example.com' );"`
 
     When I run `wp user signup get bobuser --field=active`
     Then STDOUT should be:
@@ -101,8 +101,8 @@ Feature: Manage signups in a multisite installation
 
   Scenario: Activate multiple signups
     Given a WP multisite install
-    And I run `wp eval 'wpmu_signup_user( "bobuser", "bobuser@example.com" );'`
-    And I run `wp eval 'wpmu_signup_user( "johnuser", "johnuser@example.com" );'`
+    And I run `wp eval "wpmu_signup_user( 'bobuser', 'bobuser@example.com' );"`
+    And I run `wp eval "wpmu_signup_user( 'johnuser', 'johnuser@example.com' );"`
 
     When I run `wp user signup list --active=0 --format=count`
     Then STDOUT should be:
@@ -124,7 +124,7 @@ Feature: Manage signups in a multisite installation
 
   Scenario: Activate blog signup entry
     Given a WP multisite install
-    And I run `wp eval 'wpmu_signup_blog( "example.com", "/bobsite/", "My Awesome Title", "bobuser", "bobuser@example.com" );'`
+    And I run `wp eval "wpmu_signup_blog( 'example.com', '/bobsite/', 'My Awesome Title', 'bobuser', 'bobuser@example.com' );"`
 
     When I run `wp user signup get bobuser --fields=user_login,domain,path,active --format=csv`
     Then STDOUT should be:
@@ -147,8 +147,8 @@ Feature: Manage signups in a multisite installation
 
   Scenario: Delete signups
     Given a WP multisite install
-    And I run `wp eval 'wpmu_signup_user( "bobuser", "bobuser@example.com" );'`
-    And I run `wp eval 'wpmu_signup_user( "johnuser", "johnuser@example.com" );'`
+    And I run `wp eval "wpmu_signup_user( 'bobuser', 'bobuser@example.com' );"`
+    And I run `wp eval "wpmu_signup_user( 'johnuser', 'johnuser@example.com' );"`
 
     When I run `wp user signup get bobuser --field=user_email`
     Then STDOUT should be:
@@ -176,8 +176,8 @@ Feature: Manage signups in a multisite installation
 
   Scenario: Delete all signups
     Given a WP multisite install
-    And I run `wp eval 'wpmu_signup_user( "bobuser", "bobuser@example.com" );'`
-    And I run `wp eval 'wpmu_signup_user( "johnuser", "johnuser@example.com" );'`
+    And I run `wp eval "wpmu_signup_user( 'bobuser', 'bobuser@example.com' );"`
+    And I run `wp eval "wpmu_signup_user( 'johnuser', 'johnuser@example.com' );"`
 
     When I try `wp user signup delete`
     Then STDERR should be:
@@ -196,3 +196,53 @@ Feature: Manage signups in a multisite installation
       """
       0
       """
+
+  Scenario: Expose add_to_blog, new_role, and blog_id fields and support filtering by them
+    Given a WP multisite install
+    And I run `wp eval "wpmu_signup_user( 'adminuser', 'adminuser@example.com', array( 'add_to_blog' => 228, 'new_role' => 'administrator' ) );"`
+    And I run `wp eval "wpmu_signup_user( 'editoruser', 'editoruser@example.com', array( 'add_to_blog' => 228, 'new_role' => 'editor' ) );"`
+    And I run `wp eval "wpmu_signup_user( 'otherbloguser', 'otherbloguser@example.com', array( 'add_to_blog' => 300, 'new_role' => 'administrator' ) );"`
+    And I run `wp eval "wpmu_signup_user( 'plainuser', 'plainuser@example.com' );"`
+
+    When I run `wp user signup list --active=0 --new_role=administrator --fields=user_login,new_role,blog_id --format=csv`
+    Then STDOUT should be:
+      """
+      user_login,new_role,blog_id
+      adminuser,administrator,228
+      otherbloguser,administrator,300
+      """
+
+    When I run `wp user signup list --active=0 --blog_id=228 --fields=user_login,new_role,add_to_blog --format=csv`
+    Then STDOUT should be:
+      """
+      user_login,new_role,add_to_blog
+      adminuser,administrator,228
+      editoruser,editor,228
+      """
+
+    When I run `wp user signup list --active=0 --add_to_blog=228 --fields=user_login,new_role,add_to_blog --format=csv`
+    Then STDOUT should be:
+      """
+      user_login,new_role,add_to_blog
+      adminuser,administrator,228
+      editoruser,editor,228
+      """
+
+    When I run `wp user signup get adminuser --field=add_to_blog`
+    Then STDOUT should be:
+      """
+      228
+      """
+
+    When I run `wp user signup get adminuser --field=new_role`
+    Then STDOUT should be:
+      """
+      administrator
+      """
+
+    When I run `wp user signup get adminuser --field=blog_id`
+    Then STDOUT should be:
+      """
+      228
+      """
+

--- a/src/Signup_Command.php
+++ b/src/Signup_Command.php
@@ -99,6 +99,9 @@ class Signup_Command extends CommandWithDBObject {
 	 * * title
 	 * * activated
 	 * * meta
+	 * * add_to_blog
+	 * * new_role
+	 * * blog_id
 	 *
 	 * ## EXAMPLES
 	 *
@@ -143,10 +146,19 @@ class Signup_Command extends CommandWithDBObject {
 		$results = $wpdb->get_results( $query, ARRAY_A );
 
 		if ( $results ) {
+			$filter_args = array_diff_key(
+				$assoc_args,
+				array_flip( array( 'fields', 'field', 'format', 'per_page' ) )
+			);
+
 			foreach ( $results as $item ) {
-				// Support features like --active=0.
-				foreach ( array_keys( $item ) as $field ) {
-					if ( isset( $assoc_args[ $field ] ) && $assoc_args[ $field ] !== $item[ $field ] ) {
+				$item = $this->prepare_signup_array( $item );
+
+				// Support features like --active=0, --new_role=administrator, --blog_id=228.
+				foreach ( $filter_args as $field => $value ) {
+					$item_val   = is_scalar( $item[ $field ] ?? null ) ? (string) $item[ $field ] : '';
+					$filter_val = is_scalar( $value ) ? (string) $value : '';
+					if ( ! isset( $item[ $field ] ) || $item_val !== $filter_val ) {
 						continue 2;
 					}
 				}
@@ -204,6 +216,7 @@ class Signup_Command extends CommandWithDBObject {
 	 */
 	public function get( $args, $assoc_args ) {
 		$signup = $this->fetcher->get_check( $args[0] );
+		$signup = (object) $this->prepare_signup_array( (array) $signup );
 
 		if ( empty( $assoc_args['fields'] ) ) {
 			$assoc_args['fields'] = array_keys( (array) $signup );
@@ -335,5 +348,32 @@ class Signup_Command extends CommandWithDBObject {
 		$results = $wpdb->query( 'DELETE FROM ' . $wpdb->signups );
 
 		return $results ? true : false;
+	}
+
+	/**
+	 * Prepare a signup item by extracting meta properties.
+	 *
+	 * @param array<string, mixed> $item Signup array item.
+	 * @return array<string, mixed> Prepared signup array item.
+	 */
+	private function prepare_signup_array( array $item ) {
+		if ( ! empty( $item['meta'] ) && is_string( $item['meta'] ) ) {
+			$meta_data = maybe_unserialize( $item['meta'] );
+			if ( is_array( $meta_data ) ) {
+				foreach ( $meta_data as $meta_key => $meta_value ) {
+					if ( ! isset( $item[ $meta_key ] ) ) {
+						$item[ $meta_key ] = $meta_value;
+					}
+				}
+
+				if ( isset( $meta_data['add_to_blog'] ) && ! isset( $item['blog_id'] ) ) {
+					$item['blog_id'] = $meta_data['add_to_blog'];
+				} elseif ( isset( $meta_data['blog_id'] ) && ! isset( $item['add_to_blog'] ) ) {
+					$item['add_to_blog'] = $meta_data['blog_id'];
+				}
+			}
+		}
+
+		return $item;
 	}
 }

--- a/src/Signup_Command.php
+++ b/src/Signup_Command.php
@@ -138,7 +138,12 @@ class Signup_Command extends CommandWithDBObject {
 		 */
 		$per_page = Utils\get_flag_value( $assoc_args, 'per_page' );
 
-		$limit = $per_page ? $wpdb->prepare( 'LIMIT %d', (int) $per_page ) : '';
+		$filter_args = array_diff_key(
+			$assoc_args,
+			array_flip( array( 'fields', 'field', 'format', 'per_page' ) )
+		);
+
+		$limit = ( $per_page && empty( $filter_args ) ) ? $wpdb->prepare( 'LIMIT %d', (int) $per_page ) : '';
 
 		$query = "SELECT * FROM $wpdb->signups {$limit}";
 
@@ -146,11 +151,6 @@ class Signup_Command extends CommandWithDBObject {
 		$results = $wpdb->get_results( $query, ARRAY_A );
 
 		if ( $results ) {
-			$filter_args = array_diff_key(
-				$assoc_args,
-				array_flip( array( 'fields', 'field', 'format', 'per_page' ) )
-			);
-
 			foreach ( $results as $item ) {
 				$item = $this->prepare_signup_array( $item );
 
@@ -165,6 +165,10 @@ class Signup_Command extends CommandWithDBObject {
 
 				$signups[] = $item;
 			}
+		}
+
+		if ( $per_page ) {
+			$signups = array_slice( $signups, 0, (int) $per_page );
 		}
 
 		$format = Utils\get_flag_value( $assoc_args, 'format', 'table' );


### PR DESCRIPTION
Exposes `add_to_blog`, `new_role`, and `blog_id` as available fields for `wp user signup list` and `wp user signup get`, and enables filtering by them.

- Unserializes signup meta properties so `add_to_blog` and `new_role` are accessible as fields.
- Aliases `add_to_blog` and `blog_id` to allow querying and filtering by either name.
- Updates filtering logic in `Signup_Command::list_()` to support filtering by `--new_role`, `--blog_id`, and `--add_to_blog`.
- Added acceptance test scenarios covering field output and filtering.

Closes #629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added signup list and detail fields for `add_to_blog`, `new_role`, and `blog_id`.
  * Enabled filtering of signup lists by `blog_id`, `add_to_blog`, and `new_role`, plus corresponding retrieval via `get`.
* **Bug Fixes**
  * Improved signup list behavior so filtering and pagination produce consistent results.
  * Enhanced how signup metadata is surfaced in list/get output for consistent field selection.
* **Tests**
  * Extended signup scenarios to cover new fields, filtering, pagination, and detailed lookups.
  * Updated multisite signup test execution for more reliable command runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->