### PR TITLE
Validate site slug and site URL in site create and generate commands

### DIFF
--- a/features/site-create.feature
+++ b/features/site-create.feature
@@ -301,5 +301,16 @@ Feature: Create a new site on a WP multisite
       """
     And the return code should be 1
 
+  Scenario: Error when unsupported components are provided in site-url
+    Given a WP multisite install
+
+    When I try `wp site create --site-url='http://example.com:8080/site'`
+    Then STDERR should be:
+      """
+      Error: Invalid URL format. User credentials, ports, query parameters, and fragments are not supported in --site-url.
+      """
+    And the return code should be 1
+
+
 
 

--- a/features/site-create.feature
+++ b/features/site-create.feature
@@ -291,4 +291,15 @@ Feature: Create a new site on a WP multisite
       """
     And the return code should be 1
 
+  Scenario: Error when duplicate slashes are provided in site-url path
+    Given a WP multisite install
+
+    When I try `wp site create --site-url='http://example.com//foo'`
+    Then STDERR should be:
+      """
+      Error: Invalid path format in --site-url.
+      """
+    And the return code should be 1
+
+
 

--- a/features/site-create.feature
+++ b/features/site-create.feature
@@ -271,3 +271,24 @@ Feature: Create a new site on a WP multisite
       """
     And the return code should be 1
 
+  Scenario: Error when malformed domain with double dots is provided in site-url
+    Given a WP multisite install
+
+    When I try `wp site create --site-url='http://example..com/site'`
+    Then STDERR should be:
+      """
+      Error: Invalid domain format in --site-url.
+      """
+    And the return code should be 1
+
+  Scenario: Error when invalid path format is provided in site-url
+    Given a WP multisite install
+
+    When I try `wp site create --site-url='http://example.com/invalid_path'`
+    Then STDERR should be:
+      """
+      Error: Invalid path format in --site-url.
+      """
+    And the return code should be 1
+
+

--- a/features/site-create.feature
+++ b/features/site-create.feature
@@ -250,3 +250,24 @@ Feature: Create a new site on a WP multisite
       | blog_id | url                          |
       | 1       | https://example.com/         |
       | 2       | http://testsite.example.com/ |
+
+  Scenario: Error when invalid slug containing special characters is provided
+    Given a WP multisite install
+
+    When I try `wp site create --slug='x$(touch /tmp/wpcli_poc)'`
+    Then STDERR should be:
+      """
+      Error: Slug may only contain letters, numbers, and dashes.
+      """
+    And the return code should be 1
+
+  Scenario: Error when invalid domain format is provided in site-url
+    Given a WP multisite install
+
+    When I try `wp site create --site-url='http://invalid$domain.com/site'`
+    Then STDERR should be:
+      """
+      Error: Invalid domain format in --site-url.
+      """
+    And the return code should be 1
+

--- a/features/site-generate.feature
+++ b/features/site-generate.feature
@@ -105,3 +105,14 @@ Feature: Generate new WordPress sites
       """
     And STDOUT should be empty
     And the return code should be 1
+
+  Scenario: Error when invalid slug containing special characters is provided
+    Given a WP multisite install
+
+    When I try `wp site generate --slug='x$(touch /tmp/wpcli_poc)'`
+    Then STDERR should be:
+      """
+      Error: Slug may only contain letters, numbers, and dashes.
+      """
+    And the return code should be 1
+

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -592,6 +592,14 @@ class Site_Command extends CommandWithDBObject {
 			$custom_domain = sanitize_text_field( $parsed_url['host'] );
 			$custom_path   = isset( $parsed_url['path'] ) ? sanitize_text_field( '/' . ltrim( $parsed_url['path'], '/' ) ) : '/';
 
+			if ( ! preg_match( '|^[a-zA-Z0-9.-]+$|', $custom_domain ) ) {
+				WP_CLI::error( 'Invalid domain format in --site-url.' );
+			}
+
+			if ( ! preg_match( '|^[a-zA-Z0-9/_.-]+$|', $custom_path ) ) {
+				WP_CLI::error( 'Invalid path format in --site-url.' );
+			}
+
 			// Ensure path ends with /
 			if ( '/' !== substr( $custom_path, -1 ) ) {
 				$custom_path .= '/';
@@ -651,9 +659,10 @@ class Site_Command extends CommandWithDBObject {
 		$public = ! Utils\get_flag_value( $assoc_args, 'private' );
 
 		// Sanitize
-		if ( preg_match( '|^([a-zA-Z0-9-])+$|', $base ) ) {
-			$base = strtolower( $base );
+		if ( ! preg_match( '|^([a-zA-Z0-9-])+$|', $base ) ) {
+			WP_CLI::error( 'Slug may only contain letters, numbers, and dashes.' );
 		}
+		$base = strtolower( $base );
 
 		// If not a subdomain install, make sure the domain isn't a reserved word
 		if ( ! is_subdomain_install() ) {
@@ -792,9 +801,10 @@ class Site_Command extends CommandWithDBObject {
 
 		// Base.
 		$base = $assoc_args['slug'];
-		if ( preg_match( '|^([a-zA-Z0-9-])+$|', $base ) ) {
-			$base = strtolower( $base );
+		if ( ! preg_match( '|^([a-zA-Z0-9-])+$|', $base ) ) {
+			WP_CLI::error( 'Slug may only contain letters, numbers, and dashes.' );
 		}
+		$base = strtolower( $base );
 
 		$is_subdomain_install = is_subdomain_install();
 		// If not a subdomain install, make sure the domain isn't a reserved word

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -579,7 +579,7 @@ class Site_Command extends CommandWithDBObject {
 
 		if ( $has_site_url ) {
 			$parsed_url = wp_parse_url( $assoc_args['site-url'] );
-			if ( ! is_array( $parsed_url ) || ! isset( $parsed_url['host'] ) ) {
+			if ( ! is_array( $parsed_url ) || ! isset( $parsed_url['host'] ) || ! is_string( $parsed_url['host'] ) ) {
 				WP_CLI::error( 'Invalid URL format. Please provide a valid URL (e.g., http://site.example.com).' );
 			}
 
@@ -588,8 +588,14 @@ class Site_Command extends CommandWithDBObject {
 				WP_CLI::error( 'Invalid URL scheme. Only http and https schemes are supported.' );
 			}
 
+			// Reject unsupported URL components (user, pass, port, query, fragment)
+			$unsupported = array_intersect_key( $parsed_url, array_flip( [ 'user', 'pass', 'port', 'query', 'fragment' ] ) );
+			if ( ! empty( $unsupported ) ) {
+				WP_CLI::error( 'Invalid URL format. User credentials, ports, query parameters, and fragments are not supported in --site-url.' );
+			}
+
 			// Sanitize domain and path
-			$raw_path      = isset( $parsed_url['path'] ) ? $parsed_url['path'] : '/';
+			$raw_path      = isset( $parsed_url['path'] ) && is_string( $parsed_url['path'] ) ? $parsed_url['path'] : '/';
 			$custom_domain = sanitize_text_field( $parsed_url['host'] );
 			$custom_path   = sanitize_text_field( '/' . ltrim( $raw_path, '/' ) );
 
@@ -674,7 +680,7 @@ class Site_Command extends CommandWithDBObject {
 		$public = ! Utils\get_flag_value( $assoc_args, 'private' );
 
 		// Sanitize
-		if ( ! preg_match( '|^([a-zA-Z0-9-])+$|', $base ) ) {
+		if ( ! preg_match( '|^([a-zA-Z0-9-])+$|D', $base ) ) {
 			WP_CLI::error( 'Slug may only contain letters, numbers, and dashes.' );
 		}
 		$base = strtolower( $base );
@@ -816,7 +822,7 @@ class Site_Command extends CommandWithDBObject {
 
 		// Base.
 		$base = $assoc_args['slug'];
-		if ( ! preg_match( '|^([a-zA-Z0-9-])+$|', $base ) ) {
+		if ( ! preg_match( '|^([a-zA-Z0-9-])+$|D', $base ) ) {
 			WP_CLI::error( 'Slug may only contain letters, numbers, and dashes.' );
 		}
 		$base = strtolower( $base );

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -579,7 +579,7 @@ class Site_Command extends CommandWithDBObject {
 
 		if ( $has_site_url ) {
 			$parsed_url = wp_parse_url( $assoc_args['site-url'] );
-			if ( false === $parsed_url || ! isset( $parsed_url['host'] ) ) {
+			if ( ! is_array( $parsed_url ) || ! isset( $parsed_url['host'] ) ) {
 				WP_CLI::error( 'Invalid URL format. Please provide a valid URL (e.g., http://site.example.com).' );
 			}
 
@@ -589,8 +589,9 @@ class Site_Command extends CommandWithDBObject {
 			}
 
 			// Sanitize domain and path
+			$raw_path      = isset( $parsed_url['path'] ) ? $parsed_url['path'] : '/';
 			$custom_domain = sanitize_text_field( $parsed_url['host'] );
-			$custom_path   = isset( $parsed_url['path'] ) ? sanitize_text_field( '/' . ltrim( $parsed_url['path'], '/' ) ) : '/';
+			$custom_path   = sanitize_text_field( '/' . ltrim( $raw_path, '/' ) );
 
 			$domain_parts = explode( '.', $custom_domain );
 			$valid_domain = true;
@@ -605,7 +606,7 @@ class Site_Command extends CommandWithDBObject {
 				WP_CLI::error( 'Invalid domain format in --site-url.' );
 			}
 
-			if ( ! preg_match( '|^[a-zA-Z0-9/-]+$|', $custom_path ) || false !== strpos( $custom_path, '//' ) ) {
+			if ( ! preg_match( '|^[a-zA-Z0-9/-]+$|', $custom_path ) || false !== strpos( $raw_path, '//' ) ) {
 				WP_CLI::error( 'Invalid path format in --site-url.' );
 			}
 
@@ -630,7 +631,12 @@ class Site_Command extends CommandWithDBObject {
 					$base = strtolower( $base );
 				} else {
 					// For subdirectory installs, derive slug from the last part of the path.
-					$path_parts = array_filter( explode( '/', trim( $custom_path, '/' ) ) );
+					$path_parts = array_filter(
+						explode( '/', trim( $custom_path, '/' ) ),
+						function ( $part ) {
+							return '' !== $part;
+						}
+					);
 					$base       = (string) array_pop( $path_parts );
 
 					// If base is empty (root path), require explicit slug.

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -579,7 +579,7 @@ class Site_Command extends CommandWithDBObject {
 
 		if ( $has_site_url ) {
 			$parsed_url = wp_parse_url( $assoc_args['site-url'] );
-			if ( ! isset( $parsed_url['host'] ) ) {
+			if ( false === $parsed_url || ! isset( $parsed_url['host'] ) ) {
 				WP_CLI::error( 'Invalid URL format. Please provide a valid URL (e.g., http://site.example.com).' );
 			}
 
@@ -592,11 +592,20 @@ class Site_Command extends CommandWithDBObject {
 			$custom_domain = sanitize_text_field( $parsed_url['host'] );
 			$custom_path   = isset( $parsed_url['path'] ) ? sanitize_text_field( '/' . ltrim( $parsed_url['path'], '/' ) ) : '/';
 
-			if ( ! preg_match( '|^[a-zA-Z0-9.-]+$|', $custom_domain ) ) {
+			$domain_parts = explode( '.', $custom_domain );
+			$valid_domain = true;
+			foreach ( $domain_parts as $part ) {
+				if ( '' === $part || ! preg_match( '/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/', $part ) ) {
+					$valid_domain = false;
+					break;
+				}
+			}
+
+			if ( ! $valid_domain ) {
 				WP_CLI::error( 'Invalid domain format in --site-url.' );
 			}
 
-			if ( ! preg_match( '|^[a-zA-Z0-9/_.-]+$|', $custom_path ) ) {
+			if ( ! preg_match( '|^[a-zA-Z0-9/-]+$|', $custom_path ) || false !== strpos( $custom_path, '//' ) ) {
 				WP_CLI::error( 'Invalid path format in --site-url.' );
 			}
 


### PR DESCRIPTION
Applying some slight hardening here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation for site slugs during site creation and generation.
  - Valid slugs are normalized to lowercase.
  - Custom site URLs are checked for valid domains, paths, and supported components.

- **Bug Fixes**
  - Invalid slugs, domains, paths, and URLs now display clear errors and prevent site creation or generation.
  - Invalid inputs return an appropriate failure status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->