### PR TITLE
Adapt Behat tests to SQLite integration plugin v3.0.0

### DIFF
--- a/features/post.feature
+++ b/features/post.feature
@@ -526,7 +526,6 @@ Feature: Manage WordPress posts
       2005-01-24 09:52:00
       """
 
-  @require-mysql
   Scenario: Publishing a post and setting a date succeeds if the edit_date flag is passed.
     Given a WP install
 
@@ -543,28 +542,6 @@ Feature: Manage WordPress posts
     Then STDOUT should contain:
       """
       2005-01-24 09:52:00
-      """
-
-  # Separate test because of a known bug in the SQLite plugin.
-  # See https://github.com/WordPress/sqlite-database-integration/issues/52.
-  # Once the bug is resolved, this separate test can be removed again.
-  @require-sqlite
-  Scenario: Publishing a post and setting a date succeeds if the edit_date flag is passed.
-    Given a WP install
-
-    When I run `wp post create --post_title='test' --porcelain`
-    Then save STDOUT as {POST_ID}
-
-    When I run `wp post update {POST_ID} --post_date='2005-01-24T09:52:00.000Z' --post_status='publish' --edit_date=1`
-    Then STDOUT should contain:
-      """
-      Success:
-      """
-
-    When I run `wp post get {POST_ID} --field=post_date`
-    Then STDOUT should contain:
-      """
-      2005-01-24T09:52:00.000Z
       """
 
   @require-wp-5.0

--- a/features/site-create.feature
+++ b/features/site-create.feature
@@ -1,5 +1,12 @@
 Feature: Create a new site on a WP multisite
 
+  # Skipped on SQLite because of a bug in the SQLite plugin (as of v3.0.0):
+  # when `MULTISITE` is defined in wp-config.php but the database is still
+  # empty, the information schema reconstructor queries the `wp_blogs` table
+  # while establishing the connection. That table does not exist yet, so the
+  # connection fails with "One or more database tables are unavailable."
+  # Once the bug is resolved, this tag can be removed again.
+  @skip-sqlite
   Scenario: Respect defined `$base` in wp-config
     Given an empty directory
     And WP files
@@ -47,6 +54,8 @@ Feature: Create a new site on a WP multisite
       | 1       | http://localhost/dev/         |
       | 2       | http://localhost/dev/newsite/ |
 
+  # See the note on the scenario above for why this is skipped on SQLite.
+  @skip-sqlite
   Scenario: Create new site with custom `$super_admins` global
     Given an empty directory
     And WP files

--- a/features/site-create.feature
+++ b/features/site-create.feature
@@ -5,6 +5,7 @@ Feature: Create a new site on a WP multisite
   # empty, the information schema reconstructor queries the `wp_blogs` table
   # while establishing the connection. That table does not exist yet, so the
   # connection fails with "One or more database tables are unavailable."
+  # See https://github.com/WordPress/sqlite-database-integration/issues/490.
   # Once the bug is resolved, this tag can be removed again.
   @skip-sqlite
   Scenario: Respect defined `$base` in wp-config


### PR DESCRIPTION
## Why

The nightly Behat runs started failing on all SQLite jobs, on a commit that had passed a few hours earlier ([run 31708330441](https://github.com/wp-cli/entity-command/actions/runs/31708330441) green vs. [run 31762015299](https://github.com/wp-cli/entity-command/actions/runs/31762015299) red, both on `893fbd6`). Nothing changed here — [SQLite Database Integration v3.0.0](https://github.com/WordPress/sqlite-database-integration/releases/tag/v3.0.0) was released on 2026-08-13, and `wp-cli-tests` always fetches the current stable version from wordpress.org. v3.0.0 replaces the old translation layer with a new MySQL-on-SQLite driver, which changes behaviour in two places we assert on.

## What changed

**`post.feature`: the SQLite workaround is now the bug.** Passing a date in ISO 8601 format used to be stored verbatim by the old driver (https://github.com/WordPress/sqlite-database-integration/issues/52), so the suite carried a separate `@require-sqlite` copy of the scenario asserting `2005-01-24T09:52:00.000Z`. The new driver normalizes it the way MySQL does, so `wp post get --field=post_date` now returns `2005-01-24 09:52:00` on both. The two scenarios are merged back into a single untagged one, as the comment on the duplicate anticipated.

**`site-create.feature`: two scenarios marked `@skip-sqlite`.** Establishing a database connection now fails when `MULTISITE` is defined in `wp-config.php` while the database is still empty:

```
WP_SQLite_Information_Schema_Reconstructor->get_wp_create_table_statements()
  → SELECT blog_id FROM wp_blogs
  → SQLSTATE[HY000]: General error: 1 no such table: wp_blogs
```

The reconstructor checks `is_multisite()` during `db_connect()` and queries `wp_blogs` to collect the schema of every site, but that table does not exist yet during `wp core multisite-install`. The exception leaves `$wpdb->last_error` set, so `is_blog_installed()` takes the `dead_db()` branch and the command fails with "One or more database tables are unavailable. The database may need to be repaired."

Only these two scenarios hit it, because they define `MULTISITE` up front. The other multisite scenarios install a single site first and then run `wp core multisite-convert`, so `wp_blogs` exists by the time `MULTISITE` is defined. This one is an upstream bug rather than something to fix here, reported as https://github.com/WordPress/sqlite-database-integration/issues/490 — the scenarios carry a `@skip-sqlite` tag and a note pointing at it, so the tag can come off once it is resolved.

## Testing

Run locally against WordPress 6.9 with the SQLite plugin at v3.0.0: `features/post.feature` 19/19 and `features/site-create.feature` 18/18 scenarios passing, and the full suite at 445 passed / 9 failed — all nine failures being scenarios that need network access to `wordpress.org` and `s.w.org`, which my sandbox blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated publishing scenarios to remove redundant database-specific coverage.
  - Marked initial multisite site-creation scenarios as unsupported for SQLite and documented the related setup limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->