### PR TITLE
Document all accepted fields for the catch-all write commands

### DIFF
--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -76,32 +76,6 @@ class Comment_Command extends CommandWithDBObject {
 	}
 
 	/**
-	 * Decodes the `--comment_meta` argument from its JSON representation.
-	 *
-	 * Utils\parse_shell_arrays() is typed for string values throughout, while
-	 * comment arguments are not, so narrow to the single key it needs to see.
-	 * It only ever acts on strings anyway, since is_json() rejects everything
-	 * else.
-	 *
-	 * @param array<string, mixed> $assoc_args Associative arguments.
-	 * @return array<string, mixed> Associative arguments, with comment_meta decoded.
-	 */
-	private static function parse_comment_meta( $assoc_args ) {
-		if ( ! isset( $assoc_args['comment_meta'] ) || ! is_string( $assoc_args['comment_meta'] ) ) {
-			return $assoc_args;
-		}
-
-		$parsed = Utils\parse_shell_arrays(
-			[ 'comment_meta' => $assoc_args['comment_meta'] ],
-			[ 'comment_meta' ]
-		);
-
-		$assoc_args['comment_meta'] = $parsed['comment_meta'];
-
-		return $assoc_args;
-	}
-
-	/**
 	 * Creates a new comment.
 	 *
 	 * ## OPTIONS
@@ -171,7 +145,7 @@ class Comment_Command extends CommandWithDBObject {
 	 * @param array<string, mixed> $assoc_args Associative arguments.
 	 */
 	public function create( $args, $assoc_args ) {
-		$assoc_args = self::parse_comment_meta( $assoc_args );
+		$assoc_args = Utils\parse_shell_arrays( $assoc_args, [ 'comment_meta' ] );
 
 		$assoc_args = wp_slash( $assoc_args );
 		parent::_create(
@@ -269,7 +243,7 @@ class Comment_Command extends CommandWithDBObject {
 	 * @param array<string, mixed> $assoc_args Associative arguments.
 	 */
 	public function update( $args, $assoc_args ) {
-		$assoc_args = self::parse_comment_meta( $assoc_args );
+		$assoc_args = Utils\parse_shell_arrays( $assoc_args, [ 'comment_meta' ] );
 
 		$assoc_args = wp_slash( $assoc_args );
 		parent::_update(

--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -76,6 +76,32 @@ class Comment_Command extends CommandWithDBObject {
 	}
 
 	/**
+	 * Decodes the `--comment_meta` argument from its JSON representation.
+	 *
+	 * Utils\parse_shell_arrays() is typed for string values throughout, while
+	 * comment arguments are not, so narrow to the single key it needs to see.
+	 * It only ever acts on strings anyway, since is_json() rejects everything
+	 * else.
+	 *
+	 * @param array<string, mixed> $assoc_args Associative arguments.
+	 * @return array<string, mixed> Associative arguments, with comment_meta decoded.
+	 */
+	private static function parse_comment_meta( $assoc_args ) {
+		if ( ! isset( $assoc_args['comment_meta'] ) || ! is_string( $assoc_args['comment_meta'] ) ) {
+			return $assoc_args;
+		}
+
+		$parsed = Utils\parse_shell_arrays(
+			[ 'comment_meta' => $assoc_args['comment_meta'] ],
+			[ 'comment_meta' ]
+		);
+
+		$assoc_args['comment_meta'] = $parsed['comment_meta'];
+
+		return $assoc_args;
+	}
+
+	/**
 	 * Creates a new comment.
 	 *
 	 * ## OPTIONS
@@ -145,7 +171,7 @@ class Comment_Command extends CommandWithDBObject {
 	 * @param array<string, mixed> $assoc_args Associative arguments.
 	 */
 	public function create( $args, $assoc_args ) {
-		$assoc_args = Utils\parse_shell_arrays( $assoc_args, [ 'comment_meta' ] );
+		$assoc_args = self::parse_comment_meta( $assoc_args );
 
 		$assoc_args = wp_slash( $assoc_args );
 		parent::_create(
@@ -243,7 +269,7 @@ class Comment_Command extends CommandWithDBObject {
 	 * @param array<string, mixed> $assoc_args Associative arguments.
 	 */
 	public function update( $args, $assoc_args ) {
-		$assoc_args = Utils\parse_shell_arrays( $assoc_args, [ 'comment_meta' ] );
+		$assoc_args = self::parse_comment_meta( $assoc_args );
 
 		$assoc_args = wp_slash( $assoc_args );
 		parent::_update(

--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -80,6 +80,51 @@ class Comment_Command extends CommandWithDBObject {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--comment_agent=<comment_agent>]
+	 * : The HTTP user agent of the comment author.
+	 *
+	 * [--comment_approved=<comment_approved>]
+	 * : Whether the comment has been approved. Default 1.
+	 *
+	 * [--comment_author=<comment_author>]
+	 * : The name of the author of the comment.
+	 *
+	 * [--comment_author_email=<comment_author_email>]
+	 * : The email address of the comment author.
+	 *
+	 * [--comment_author_IP=<comment_author_IP>]
+	 * : The IP address of the comment author.
+	 *
+	 * [--comment_author_url=<comment_author_url>]
+	 * : The URL address of the comment author.
+	 *
+	 * [--comment_content=<comment_content>]
+	 * : The content of the comment.
+	 *
+	 * [--comment_date=<yyyy-mm-dd-hh-ii-ss>]
+	 * : The date the comment was submitted.
+	 *
+	 * [--comment_date_gmt=<yyyy-mm-dd-hh-ii-ss>]
+	 * : The date the comment was submitted in the GMT timezone.
+	 *
+	 * [--comment_karma=<comment_karma>]
+	 * : The karma of the comment. Default 0.
+	 *
+	 * [--comment_parent=<comment_parent>]
+	 * : ID of this comment's parent, if any. Default 0.
+	 *
+	 * [--comment_post_ID=<comment_post_ID>]
+	 * : ID of the post that relates to the comment, if any.
+	 *
+	 * [--comment_type=<comment_type>]
+	 * : Comment type. Default 'comment'.
+	 *
+	 * [--comment_meta=<comment_meta>]
+	 * : Array in JSON format of comment meta values keyed by their comment meta key.
+	 *
+	 * [--user_id=<user_id>]
+	 * : ID of the user who submitted the comment. Default 0.
+	 *
 	 * [--<field>=<value>]
 	 * : Associative args for the new comment. See wp_insert_comment().
 	 *
@@ -100,6 +145,8 @@ class Comment_Command extends CommandWithDBObject {
 	 * @param array<string, mixed> $assoc_args Associative arguments.
 	 */
 	public function create( $args, $assoc_args ) {
+		$assoc_args = Utils\parse_shell_arrays( $assoc_args, [ 'comment_meta' ] );
+
 		$assoc_args = wp_slash( $assoc_args );
 		parent::_create(
 			$args,
@@ -137,6 +184,52 @@ class Comment_Command extends CommandWithDBObject {
 	 * <id>...
 	 * : One or more IDs of comments to update.
 	 *
+	 * [--comment_agent=<comment_agent>]
+	 * : The HTTP user agent of the comment author.
+	 *
+	 * [--comment_approved=<comment_approved>]
+	 * : Whether the comment has been approved.
+	 *
+	 * [--comment_author=<comment_author>]
+	 * : The name of the author of the comment.
+	 *
+	 * [--comment_author_email=<comment_author_email>]
+	 * : The email address of the comment author.
+	 *
+	 * [--comment_author_IP=<comment_author_IP>]
+	 * : The IP address of the comment author.
+	 *
+	 * [--comment_author_url=<comment_author_url>]
+	 * : The URL address of the comment author.
+	 *
+	 * [--comment_content=<comment_content>]
+	 * : The content of the comment.
+	 *
+	 * [--comment_date=<yyyy-mm-dd-hh-ii-ss>]
+	 * : The date the comment was submitted.
+	 *
+	 * [--comment_date_gmt=<yyyy-mm-dd-hh-ii-ss>]
+	 * : The date the comment was submitted in the GMT timezone. Note that
+	 * wp_update_comment() always recalculates this from 'comment_date'.
+	 *
+	 * [--comment_karma=<comment_karma>]
+	 * : The karma of the comment.
+	 *
+	 * [--comment_parent=<comment_parent>]
+	 * : ID of this comment's parent, if any.
+	 *
+	 * [--comment_post_ID=<comment_post_ID>]
+	 * : ID of the post that relates to the comment, if any.
+	 *
+	 * [--comment_type=<comment_type>]
+	 * : Comment type.
+	 *
+	 * [--comment_meta=<comment_meta>]
+	 * : Array in JSON format of comment meta values keyed by their comment meta key.
+	 *
+	 * [--user_id=<user_id>]
+	 * : ID of the user who submitted the comment.
+	 *
 	 * --<field>=<value>
 	 * : One or more fields to update. See wp_update_comment().
 	 *
@@ -150,6 +243,8 @@ class Comment_Command extends CommandWithDBObject {
 	 * @param array<string, mixed> $assoc_args Associative arguments.
 	 */
 	public function update( $args, $assoc_args ) {
+		$assoc_args = Utils\parse_shell_arrays( $assoc_args, [ 'comment_meta' ] );
+
 		$assoc_args = wp_slash( $assoc_args );
 		parent::_update(
 			$args,

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -127,6 +127,13 @@ class Post_Command extends CommandWithDBObject {
 	 * [--meta_input=<meta_input>]
 	 * : Array in JSON format of post meta values keyed by their post meta key. Default empty.
 	 *
+	 * [--page_template=<page_template>]
+	 * : Page template to use.
+	 *
+	 * [--import_id=<import_id>]
+	 * : The post ID to be used when inserting a new post. If specified, must not
+	 * match any existing post ID.
+	 *
 	 * [<file>]
 	 * : Read post content from <file>. If this value is present, the
 	 *     `--post_content` argument will be ignored.
@@ -337,6 +344,9 @@ class Post_Command extends CommandWithDBObject {
 	 *
 	 * [--meta_input=<meta_input>]
 	 * : Array in JSON format of post meta values keyed by their post meta key. Default empty.
+	 *
+	 * [--page_template=<page_template>]
+	 * : Page template to use.
 	 *
 	 * [<file>]
 	 * : Read post content from <file>. If this value is present, the

--- a/src/User_Application_Password_Command.php
+++ b/src/User_Application_Password_Command.php
@@ -357,8 +357,8 @@ final class User_Application_Password_Command {
 	 * <uuid>
 	 * : The universally unique ID of the application password.
 	 *
-	 * [--<field>=<value>]
-	 * : Update the <field> with a new <value>. Currently supported fields: name.
+	 * [--name=<name>]
+	 * : The new name of the application password.
 	 *
 	 * ## EXAMPLES
 	 *

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -538,11 +538,41 @@ class User_Command extends CommandWithDBObject {
 	 * [--rich_editing=<rich_editing>]
 	 * : A string for whether to enable the rich editor or not. False if not empty.
 	 *
+	 * [--syntax_highlighting=<syntax_highlighting>]
+	 * : Whether to enable the rich code editor for the user. Accepts 'true' or
+	 * 'false' as a string literal, not boolean.
+	 *
+	 * [--comment_shortcuts=<comment_shortcuts>]
+	 * : Whether to enable comment moderation keyboard shortcuts for the user.
+	 * Accepts 'true' or 'false' as a string literal, not boolean.
+	 *
+	 * [--admin_color=<admin_color>]
+	 * : Admin color scheme for the user.
+	 *
+	 * [--use_ssl=<use_ssl>]
+	 * : Whether the user should always access the admin over https.
+	 *
 	 * [--user_registered=<yyyy-mm-dd-hh-ii-ss>]
 	 * : The date the user registered.
 	 *
+	 * [--user_activation_key=<user_activation_key>]
+	 * : Password reset key.
+	 *
+	 * [--spam=<spam>]
+	 * : Multisite only. Whether the user is marked as spam.
+	 *
+	 * [--show_admin_bar_front=<show_admin_bar_front>]
+	 * : Whether to display the admin bar for the user on the site's front end.
+	 * Accepts 'true' or 'false' as a string literal, not boolean.
+	 *
 	 * [--role=<role>]
 	 * : A string used to set the user's role.
+	 *
+	 * [--locale=<locale>]
+	 * : The user's locale.
+	 *
+	 * [--meta_input=<meta_input>]
+	 * : Array in JSON format of user meta values keyed by their user meta key.
 	 *
 	 * --<field>=<value>
 	 * : One or more fields to update. For accepted fields, see wp_update_user().
@@ -583,6 +613,8 @@ class User_Command extends CommandWithDBObject {
 			add_filter( 'send_email_change_email', '__return_false' );
 			add_filter( 'send_password_change_email', '__return_false' );
 		}
+
+		$assoc_args = Utils\parse_shell_arrays( $assoc_args, [ 'meta_input' ] );
 
 		$assoc_args = wp_slash( $assoc_args );
 		parent::_update( $user_ids, $assoc_args, 'wp_update_user' );


### PR DESCRIPTION
Opened to make the documentation side of https://github.com/wp-cli/wp-cli/issues/5286 concrete. Pairs with wp-cli/wp-cli#6392, which adds the typo detection itself — but this PR stands on its own and is useful without it.

## Why this first

Every approach discussed on #5286 needs the same foundation: an accurate list of what each command actually accepts. Typo detection matches an unknown argument against the documented ones, so an incomplete docblock means either missed typos or false positives. `comment update` documented no fields at all.

**On its own this PR does not change validation.** The catch-all still suppresses unknown-parameter checking, so the added parameters only improve `wp help` output today. They are what gives the matcher something accurate to work with.

## Where the lists come from

The `wp_insert_user()`, `wp_insert_post()` and `wp_update_comment()` docblocks in core trunk, rather than the 2019 list on the issue — that one predates `user_activation_key` / `spam` (5.3) and `meta_input` (5.9).

| Command | Added |
|---|---|
| `user update` | `syntax_highlighting`, `comment_shortcuts`, `admin_color`, `use_ssl`, `user_activation_key`, `spam`, `show_admin_bar_front`, `locale`, `meta_input` |
| `post create` | `page_template`, `import_id` |
| `post update` | `page_template` |
| `comment create` | full column set (15 fields; previously catch-all only) |
| `comment update` | full column set (15 fields; previously **none**) |

## Two changes that are not documentation

Flagged separately because they are easy to drop if you'd rather keep this PR pure.

1. **`user application-password update`** advertised `--<field>=<value>` while its own text said only `name` was supported. Core's `WP_Application_Passwords::update_application_password()` only ever reads `$update['name']`, so extra keys were silently ignored. Replaced the catch-all with `[--name=<name>]`. That command is now validated immediately, without depending on the framework PR.

2. **`--meta_input` and `--comment_meta` take arrays**, so they go through `Utils\parse_shell_arrays()` the way `Post_Command::update()` already does. Without it a JSON value reaches core as a string. Documenting them without this would have meant documenting parameters that don't work.

The second one originally tripped PHPStan, because `parse_shell_arrays()` was annotated `array<string, string>` while `Comment_Command` correctly declares `array<string, mixed>`. That turned out to be an upstream annotation bug and is fixed in wp-cli/wp-cli#6393, so all four call sites in this repo are now the same plain one-liner. No release is needed for that — `composer.json` sets `minimum-stability: dev` and requires `^3.0`, which resolves to `dev-main`.

## Verification

`comment_author_IP` and `comment_post_ID` are mixed-case, so they depend on #6388. Against the parser before that fix they register truncated:

```
!! TRUNCATED: --comment_author_ parsed from <comment_author_IP>
```

Against current `main` all seven commands parse cleanly, with no truncated names and no unknown tokens:

```
user update                         assoc=21  flags=1  generic=1
post create                         assoc=28  flags=2  generic=1
post update                         assoc=26  flags=1  generic=1
comment create                      assoc=15  flags=1  generic=1
comment update                      assoc=15  flags=0  generic=1
user application-password update    assoc=1   flags=0  generic=0
```

## Two things I noticed but did not change

Both are pre-existing and orthogonal, and both now have tests and fixes in #637.

- **`post update --post_modified` / `--post_modified_gmt` are documented but ignored.** `wp_insert_post()` computes both itself and never reads them from `$postarr`.
- **`user create` documents `--user_nicename` and `--rich_editing` but never applies them.** `User_Command::create()` builds an explicit `stdClass` and neither property is set. That command has no catch-all, so it is strictly validated and still silently drops the value — the same failure as #5286, from the other direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SSZzqMJRDTiLiDxQEPYcL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded comment command documentation with supported fields for creating and updating comments.
  - Documented additional post options, including page templates and import IDs.
  - Clarified user application password updates with a dedicated name option.
  - Added documentation for more user update fields, including preferences, status, locale, and metadata.

- **Bug Fixes**
  - Improved handling of shell-array metadata when creating or updating comments and users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->