### PR TITLE
Document the list filters these commands implement themselves

### DIFF
--- a/features/site.feature
+++ b/features/site.feature
@@ -936,3 +936,58 @@ Feature: Manage sites in a multisite installation
       """
       1
       """
+
+  Scenario: Filter the site list by columns of the sites table
+    Given a WP multisite install
+
+    When I run `wp site create --slug=first --porcelain`
+    Then STDOUT should be a number
+
+    When I run `wp site list --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    # site_id is the ID of the network the site belongs to, not the site's own ID.
+    When I run `wp site list --site_id=1 --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp site list --site_id=2 --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `wp site list --blog_id=2 --field=blog_id`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp site list --public=1 --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp site list --archived=0 --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp site list --deleted=1 --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `wp site list --spam=0 --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """

--- a/features/site.feature
+++ b/features/site.feature
@@ -942,36 +942,42 @@ Feature: Manage sites in a multisite installation
 
     When I run `wp site create --slug=first --porcelain`
     Then STDOUT should be a number
+    And save STDOUT as {FIRST_ID}
+
+    When I run `wp site create --slug=second --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {SECOND_ID}
+
+    # Give the two new sites contrasting statuses, so each filter below has
+    # something to discriminate on and cannot pass by matching every site.
+    When I run `wp site archive {FIRST_ID}`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp site private {SECOND_ID}`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp site spam {SECOND_ID}`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
 
     When I run `wp site list --format=count`
     Then STDOUT should be:
       """
-      2
+      3
       """
 
-    # site_id is the ID of the network the site belongs to, not the site's own ID.
-    When I run `wp site list --site_id=1 --format=count`
+    When I run `wp site list --archived=1 --field=blog_id`
     Then STDOUT should be:
       """
-      2
-      """
-
-    When I run `wp site list --site_id=2 --format=count`
-    Then STDOUT should be:
-      """
-      0
-      """
-
-    When I run `wp site list --blog_id=2 --field=blog_id`
-    Then STDOUT should be:
-      """
-      2
-      """
-
-    When I run `wp site list --public=1 --format=count`
-    Then STDOUT should be:
-      """
-      2
+      {FIRST_ID}
       """
 
     When I run `wp site list --archived=0 --format=count`
@@ -980,14 +986,58 @@ Feature: Manage sites in a multisite installation
       2
       """
 
-    When I run `wp site list --deleted=1 --format=count`
+    When I run `wp site list --public=0 --field=blog_id`
     Then STDOUT should be:
       """
-      0
+      {SECOND_ID}
+      """
+
+    When I run `wp site list --public=1 --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp site list --spam=1 --field=blog_id`
+    Then STDOUT should be:
+      """
+      {SECOND_ID}
       """
 
     When I run `wp site list --spam=0 --format=count`
     Then STDOUT should be:
       """
       2
+      """
+
+    When I run `wp site list --deleted=0 --format=count`
+    Then STDOUT should be:
+      """
+      3
+      """
+
+    When I run `wp site list --blog_id={FIRST_ID} --field=blog_id`
+    Then STDOUT should be:
+      """
+      {FIRST_ID}
+      """
+
+    # site_id is the ID of the network the site belongs to, not the site's own ID.
+    When I run `wp site list --site_id=1 --format=count`
+    Then STDOUT should be:
+      """
+      3
+      """
+
+    When I run `wp site list --site_id=2 --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    # --network is an alias for site_id and takes precedence over it.
+    When I run `wp site list --site_id=2 --network=1 --format=count`
+    Then STDOUT should be:
+      """
+      3
       """

--- a/features/user-application-password.feature
+++ b/features/user-application-password.feature
@@ -315,3 +315,52 @@ Feature: Manage user custom fields
       """
       true
       """
+
+  Scenario: Filter application passwords by field
+    Given a WP install
+
+    When I run `wp user application-password create 1 myapp --app-id=abc123 --porcelain`
+    Then STDOUT should not be empty
+
+    When I run `wp user application-password create 1 otherapp --porcelain`
+    Then STDOUT should not be empty
+
+    When I run `wp user application-password list 1 --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp user application-password list 1 --app_id=abc123 --field=name`
+    Then STDOUT should be:
+      """
+      myapp
+      """
+
+    When I run `wp user application-password list 1 --app-id=abc123 --field=name`
+    Then STDOUT should be:
+      """
+      myapp
+      """
+
+    When I run `wp user application-password list 1 --name=otherapp --field=name`
+    Then STDOUT should be:
+      """
+      otherapp
+      """
+
+    When I run `wp user application-password list 1 --name=myapp --field=uuid`
+    Then STDOUT should not be empty
+    And save STDOUT as {UUID}
+
+    When I run `wp user application-password list 1 --uuid={UUID} --field=name`
+    Then STDOUT should be:
+      """
+      myapp
+      """
+
+    When I run `wp user application-password list 1 --app_id=nosuchapp --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """

--- a/features/user-application-password.feature
+++ b/features/user-application-password.feature
@@ -316,6 +316,7 @@ Feature: Manage user custom fields
       true
       """
 
+  @require-wp-5.6
   Scenario: Filter application passwords by field
     Given a WP install
 
@@ -363,4 +364,44 @@ Feature: Manage user custom fields
     Then STDOUT should be:
       """
       0
+      """
+
+    # 'created' and 'last_used' are integers in core but strings on the command
+    # line, so these only match if the comparison normalizes them.
+    When I run `wp user application-password list 1 --name=myapp --field=created`
+    Then STDOUT should not be empty
+    And save STDOUT as {CREATED}
+
+    When I run `wp user application-password list 1 --created={CREATED} --field=name`
+    Then STDOUT should contain:
+      """
+      myapp
+      """
+
+    When I run `wp user application-password list 1 --created=1 --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `wp user application-password record-usage 1 {UUID}`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp user application-password list 1 --name=myapp --field=last_used`
+    Then STDOUT should not be empty
+    And save STDOUT as {LAST_USED}
+
+    When I run `wp user application-password list 1 --last_used={LAST_USED} --field=name`
+    Then STDOUT should be:
+      """
+      myapp
+      """
+
+    When I run `wp user application-password list 1 --last-used={LAST_USED} --field=name`
+    Then STDOUT should be:
+      """
+      myapp
       """

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -1001,6 +1001,40 @@ class Site_Command extends CommandWithDBObject {
 	 * [--site-path=<path>]
 	 * : Filter by path. Avoids conflict with the global `--path` parameter.
 	 *
+	 * [--blog_id=<blog_id>]
+	 * : Filter by site ID.
+	 *
+	 * [--site_id=<site_id>]
+	 * : Filter by the ID of the network the site belongs to. `--network` is an
+	 * alias for this, and takes precedence when both are given.
+	 *
+	 * [--domain=<domain>]
+	 * : Filter by domain.
+	 *
+	 * [--registered=<yyyy-mm-dd-hh-ii-ss>]
+	 * : Filter by the date the site was registered.
+	 *
+	 * [--last_updated=<yyyy-mm-dd-hh-ii-ss>]
+	 * : Filter by the date the site was last updated.
+	 *
+	 * [--public=<public>]
+	 * : Filter by whether the site is public. Accepts 1 or 0.
+	 *
+	 * [--archived=<archived>]
+	 * : Filter by whether the site is archived. Accepts 1 or 0.
+	 *
+	 * [--mature=<mature>]
+	 * : Filter by whether the site is flagged as mature. Accepts 1 or 0.
+	 *
+	 * [--spam=<spam>]
+	 * : Filter by whether the site is flagged as spam. Accepts 1 or 0.
+	 *
+	 * [--deleted=<deleted>]
+	 * : Filter by whether the site is flagged as deleted. Accepts 1 or 0.
+	 *
+	 * [--lang_id=<lang_id>]
+	 * : Filter by language ID.
+	 *
 	 * [--field=<field>]
 	 * : Prints the value of a single field for each site.
 	 *

--- a/src/User_Application_Password_Command.php
+++ b/src/User_Application_Password_Command.php
@@ -81,6 +81,29 @@ final class User_Application_Password_Command {
 	 * [--<field>=<value>]
 	 * : Filter the list by a specific field.
 	 *
+	 * [--uuid=<uuid>]
+	 * : Filter by the universally unique ID of the application password.
+	 *
+	 * [--app_id=<app_id>]
+	 * : Filter by the application ID. `--app-id` is also accepted.
+	 *
+	 * [--name=<name>]
+	 * : Filter by the name of the application password.
+	 *
+	 * [--password=<password>]
+	 * : Filter by the hashed password.
+	 *
+	 * [--created=<created>]
+	 * : Filter by the Unix timestamp the application password was created at.
+	 *
+	 * [--last_used=<last_used>]
+	 * : Filter by the Unix timestamp the application password was last used at.
+	 * `--last-used` is also accepted.
+	 *
+	 * [--last_ip=<last_ip>]
+	 * : Filter by the IP address the application password was last used from.
+	 * `--last-ip` is also accepted.
+	 *
 	 * [--field=<field>]
 	 * : Prints the value of a single field for each application password.
 	 *

--- a/src/User_Application_Password_Command.php
+++ b/src/User_Application_Password_Command.php
@@ -209,10 +209,18 @@ final class User_Application_Password_Command {
 
 			$value = Utils\get_flag_value( $assoc_args, $field );
 
+			// 'created' and 'last_used' come back from core as integers, while an
+			// argument always arrives as a string, so compare them as strings.
+			$filter_value = is_scalar( $value ) ? (string) $value : '';
+
 			$application_passwords = array_filter(
 				$application_passwords,
-				static function ( $application_password ) use ( $field, $value ) {
-					return $application_password[ $field ] === $value;
+				static function ( $application_password ) use ( $field, $filter_value ) {
+					$item_value = isset( $application_password[ $field ] ) && is_scalar( $application_password[ $field ] )
+						? (string) $application_password[ $field ]
+						: '';
+
+					return $item_value === $filter_value;
 				}
 			);
 		}


### PR DESCRIPTION
Follow-up to the question of why #636 covered only the write commands. Independent of it — branched off `main`, reviewable on its own, and justified as documentation rather than as groundwork for anything.

## What is undocumented

`Site_Command::list_()` filters on a list defined in its own code:

```php
$site_cols = [ 'blog_id', 'last_updated', 'registered', 'site_id', 'domain', 'path',
               'public', 'archived', 'mature', 'spam', 'deleted', 'lang_id' ];
```

`User_Application_Password_Command::list_()` does the same with its `APPLICATION_PASSWORD_FIELDS`. Between them that is nineteen working filters, none of which appear as parameters — users are left to infer them from `--<field>=<value>` plus the "Available Fields" section.

These are not obscure. This repo's own tests already depend on several: `site.feature` uses `--site_id` and `--blog_id`, `user-application-password.feature` uses `--name`. They are supported behaviour that simply is not written down.

| Command | Documented before | After |
|---|---|---|
| `site list` | 7 | 18 |
| `user application-password list` | 5 | 12 |

## A bug found while documenting

`--created` and `--last_used` on `user application-password list` never matched anything. Core returns those two fields as integers, a command-line argument always arrives as a string, and the filter compared with `===`. Documenting them as-is would have added two more parameters that accept a value and quietly discard it — the exact failure mode this line of work is about.

Fixed by comparing as strings, the way `Signup_Command::list_()` already does for the same reason. Confirmed by reverting just the source change and re-running the scenario, which then fails on the `--created` step.

## Two deliberate omissions

**`path` on `site list`.** It is in `$site_cols` but unreachable, because the global `--path` is consumed before the command sees it. The existing `--site-path` parameter covers it and already explains why.

**Every other list command.** `post list`, `comment list`, `user list`, `term list`, `post-type list` and `taxonomy list` hand their arguments to `WP_Query`, `WP_Comment_Query`, `get_users()`, `get_terms()`, `get_post_types()` and `get_taxonomies()`. Those accept an open-ended set that plugins extend, so there is no fixed list to write down. That is the real reason the catch-all exists on those commands, and it is why #636 stopped at the write commands, where the accepted set genuinely is enumerable from core's docblocks.

`signup list` is a third case, left for a follow-up: its columns are fixed, but it also filters on arbitrary keys unserialized from the signup meta, so only part of its surface can be documented.

## Correction to an earlier version of this description

An earlier revision claimed that documenting these fields fixes `wp site list --site_id=2` under wp-cli/wp-cli#6392 but introduces a new collision on `--lang__in` / `--lang_id`. **The second half of that was wrong**, and I would rather correct it here than leave it in the record.

`site list` does not use `WP_Site_Query` at all — it queries `$wpdb->blogs` directly through a `TableIterator`, with a `WHERE` clause built only from `$site_cols`, `site__in`, `site_user`, `site-path` and `network`. `--lang__in` is a `WP_Site_Query` argument, so it is silently ignored by this command today and is not a supported filter. I had built the comparison corpus by merging `WP_Site_Query`'s variables into `site list`'s argument set, which was an assumption I never checked.

What follows from the corrected picture:

- The `--site_id` regression under #6392 is real, and this PR resolves it by making `--site_id` a documented parameter.
- `site list` has a **closed** argument set, so once it is fully documented there is no residual collision on this command.
- The open-ended argument only holds for the commands that genuinely pass through to core's query classes — `post list`, `comment list`, `user list`, `term list` — and `WP_Query`'s own vocabulary is where the dense collisions actually live (`cat`/`tag`/`day`, `m`/`p`/`s`/`tb`).

## Testing

Behat scenarios added for both commands, exercising the newly documented filters, the dashed `--app-id` and `--last-used` spellings the command normalizes, and `--network` taking precedence over `--site_id`. The site filters operate on sites given contrasting statuses, so each assertion fails if its filter stops working rather than matching the whole set.

| Suite | Result |
|---|---|
| `site.feature` | 35 scenarios, 431 steps, all passed |
| `user-application-password.feature` | 6 scenarios, 4 passed, **2 pre-existing failures** |

Those two failures — "User application passwords are disabled for WordPress lower than 5.6" and one of the two "Get particular user application password hash" scenarios — are version-gated and fail identically with `src/` and `features/` checked out at `origin/main` (5 scenarios, 3 passed, 2 failed). Not caused by this change.

Run on SQLite against WordPress trunk. PHPCS clean; PHPStan unchanged at the `origin/main` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SSZzqMJRDTiLiDxQEPYcL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded `wp site list` documentation with filters for site identifiers, domains, dates, visibility, status, and language.
  * Documented application-password filters for app ID, name, UUID, password, creation and usage details, and IP address.
  * Added hyphenated aliases for supported application-password filtering options.

* **Tests**
  * Added coverage for site filtering by identifiers, status, visibility, and network behavior.
  * Added coverage for application-password filters, alternate option formats, value comparisons, usage tracking, and empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->