### PR TITLE
Query sites through WP_Site_Query in `wp site list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5351,8 +5351,10 @@ wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--site_u
 		The network to which the sites belong.
 
 	[--<field>=<value>]
-		Filter by one or more fields (see "Available Fields" section). However,
-		'url' isn't an available filter, as it comes from 'home' in wp_options.
+		Filter by one or more fields (see "Available Fields" section), or pass any
+		other argument accepted by WP_Site_Query, such as 'search', 'site__not_in',
+		'number', 'offset', 'orderby' or 'order'. However, 'url' isn't an available
+		filter, as it comes from 'home' in wp_options.
 		Note: '--path' conflicts with the global parameter of the same name; use
 		'--site-path' to filter by path instead.
 
@@ -5410,6 +5412,15 @@ These fields are optionally available:
     # Output a simple list of site URLs
     $ wp site list --field=url
     http://www.example.com/
+    http://www.example.com/subdir/
+
+    # Output site URLs, most recently registered first
+    $ wp site list --orderby=registered --order=desc --field=url
+    http://www.example.com/subdir/
+    http://www.example.com/
+
+    # Search for sites by domain or path
+    $ wp site list --search=subdir --field=url
     http://www.example.com/subdir/
 
 

--- a/README.md
+++ b/README.md
@@ -5355,6 +5355,8 @@ wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--site_u
 		other argument accepted by WP_Site_Query, such as 'search', 'site__not_in',
 		'number', 'offset', 'orderby' or 'order'. However, 'url' isn't an available
 		filter, as it comes from 'home' in wp_options.
+		'--registered' and '--last_updated' take a timestamp or a date; a value
+		carrying no time of day matches that whole day.
 		Note: '--path' conflicts with the global parameter of the same name; use
 		'--site-path' to filter by path instead.
 

--- a/README.md
+++ b/README.md
@@ -5342,7 +5342,7 @@ These fields are optionally available:
 Lists all sites in a multisite installation.
 
 ~~~
-wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--site_user=<value>] [--site-path=<path>] [--blog_id=<blog_id>] [--site_id=<site_id>] [--domain=<domain>] [--registered=<yyyy-mm-dd-hh-ii-ss>] [--last_updated=<yyyy-mm-dd-hh-ii-ss>] [--public=<public>] [--archived=<archived>] [--mature=<mature>] [--spam=<spam>] [--deleted=<deleted>] [--lang_id=<lang_id>] [--field=<field>] [--fields=<fields>] [--format=<format>]
+wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--site_user=<value>] [--site-path=<path>] [--blog_id=<blog_id>] [--site_id=<site_id>] [--domain=<domain>] [--registered=<date>] [--last_updated=<date>] [--public=<public>] [--archived=<archived>] [--mature=<mature>] [--spam=<spam>] [--deleted=<deleted>] [--lang_id=<lang_id>] [--field=<field>] [--fields=<fields>] [--format=<format>]
 ~~~
 
 **OPTIONS**
@@ -5355,8 +5355,6 @@ wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--site_u
 		other argument accepted by WP_Site_Query, such as 'search', 'site__not_in',
 		'number', 'offset', 'orderby' or 'order'. However, 'url' isn't an available
 		filter, as it comes from 'home' in wp_options.
-		'--registered' and '--last_updated' take a timestamp or a date; a value
-		carrying no time of day matches that whole day.
 		Note: '--path' conflicts with the global parameter of the same name; use
 		'--site-path' to filter by path instead.
 
@@ -5379,11 +5377,13 @@ wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--site_u
 	[--domain=<domain>]
 		Filter by domain.
 
-	[--registered=<yyyy-mm-dd-hh-ii-ss>]
-		Filter by the date the site was registered.
+	[--registered=<date>]
+		Filter by the date the site was registered. Accepts a timestamp or a
+		date; a value carrying no time of day matches that whole day.
 
-	[--last_updated=<yyyy-mm-dd-hh-ii-ss>]
-		Filter by the date the site was last updated.
+	[--last_updated=<date>]
+		Filter by the date the site was last updated. Accepts a timestamp or a
+		date; a value carrying no time of day matches that whole day.
 
 	[--public=<public>]
 		Filter by whether the site is public. Accepts 1 or 0.

--- a/features/site.feature
+++ b/features/site.feature
@@ -1060,11 +1060,18 @@ Feature: Manage sites in a multisite installation
       {ALPHA_ID}
       """
 
-    # A value carrying no time of day matches every site registered that day.
+    # A value carrying no time of day matches every site registered that day, and
+    # only those - a day nothing was registered on comes back empty.
     When I run `wp site list --registered={REGISTERED_DAY} --field=blog_id`
     Then STDOUT should contain:
       """
       {ALPHA_ID}
+      """
+
+    When I run `wp site list --registered=1999-01-01 --format=count`
+    Then STDOUT should be:
+      """
+      0
       """
 
     When I run `wp site list --registered='1999-01-01 00:00:00' --format=count`

--- a/features/site.feature
+++ b/features/site.feature
@@ -936,3 +936,135 @@ Feature: Manage sites in a multisite installation
       """
       1
       """
+
+  Scenario: List sites using WP_Site_Query arguments
+    Given a WP multisite install
+
+    When I run `wp site create --slug=alpha --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {ALPHA_ID}
+
+    When I run `wp site create --slug=beta --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {BETA_ID}
+
+    # --search, --site__not_in, --number, --offset and --orderby all come from
+    # WP_Site_Query and were silently ignored before.
+    When I run `wp site list --search=alpha --field=blog_id`
+    Then STDOUT should be:
+      """
+      {ALPHA_ID}
+      """
+
+    When I run `wp site list --site__not_in={ALPHA_ID} --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp site list --number=1 --format=count`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp site list --number=1 --offset=1 --field=blog_id`
+    Then STDOUT should be:
+      """
+      {ALPHA_ID}
+      """
+
+    When I run `wp site list --orderby=id --order=desc --field=blog_id`
+    Then STDOUT should be:
+      """
+      {BETA_ID}
+      {ALPHA_ID}
+      1
+      """
+
+  Scenario: Existing site list filters keep working against WP_Site_Query
+    Given a WP multisite install
+
+    When I run `wp site create --slug=alpha --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {ALPHA_ID}
+
+    When I run `wp site create --slug=beta --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {BETA_ID}
+
+    # --site__in returns rows in the order the IDs were given.
+    When I run `wp site list --site__in={BETA_ID},{ALPHA_ID} --field=blog_id`
+    Then STDOUT should be:
+      """
+      {BETA_ID}
+      {ALPHA_ID}
+      """
+
+    When I run `wp site list --blog_id={ALPHA_ID} --field=blog_id`
+    Then STDOUT should be:
+      """
+      {ALPHA_ID}
+      """
+
+    When I run `wp site list --site_id=1 --format=count`
+    Then STDOUT should be:
+      """
+      3
+      """
+
+    When I run `wp site list --site_id=2 --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `wp site list --site-path=/alpha/ --field=blog_id`
+    Then STDOUT should be:
+      """
+      {ALPHA_ID}
+      """
+
+    # admin belongs to every site, bobby only to the one they were created on, so the
+    # two counts differ and neither can pass by accident.
+    When I run `wp site list --site_user=admin --format=count`
+    Then STDOUT should be:
+      """
+      3
+      """
+
+    When I run `wp user create bobby bobby@example.com --role=author --porcelain`
+    Then STDOUT should be a number
+
+    When I run `wp site list --site_user=bobby --field=blog_id`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    # registered matches exactly, which WP_Site_Query only supports via date_query.
+    When I run `wp site list --blog_id={ALPHA_ID} --field=registered`
+    Then STDOUT should not be empty
+    And save STDOUT as {REGISTERED}
+
+    When I run `wp site list --registered='{REGISTERED}' --field=blog_id`
+    Then STDOUT should contain:
+      """
+      {ALPHA_ID}
+      """
+
+    When I run `wp site list --registered='1999-01-01 00:00:00' --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `wp site list --blog_id={ALPHA_ID} --field=last_updated`
+    Then STDOUT should not be empty
+    And save STDOUT as {LAST_UPDATED}
+
+    When I run `wp site list --last_updated='{LAST_UPDATED}' --field=blog_id`
+    Then STDOUT should contain:
+      """
+      {ALPHA_ID}
+      """

--- a/features/site.feature
+++ b/features/site.feature
@@ -1042,7 +1042,18 @@ Feature: Manage sites in a multisite installation
       1
       """
 
-    # registered matches exactly, which WP_Site_Query only supports via date_query.
+
+  # --registered and --last_updated go through WP_Date_Query, whose exact-timestamp
+  # SQL the SQLite integration does not translate. Reported upstream; skipped on
+  # SQLite until that is resolved.
+  @skip-sqlite
+  Scenario: Filter the site list by an exact registration or update date
+    Given a WP multisite install
+
+    When I run `wp site create --slug=alpha --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {ALPHA_ID}
+
     When I run `wp site list --blog_id={ALPHA_ID} --field=registered`
     Then STDOUT should not be empty
     And save STDOUT as {REGISTERED}
@@ -1068,3 +1079,10 @@ Feature: Manage sites in a multisite installation
       """
       {ALPHA_ID}
       """
+
+    When I try `wp site list --registered=notadate`
+    Then STDERR should contain:
+      """
+      Invalid date passed to --registered
+      """
+    And the return code should be 1

--- a/features/site.feature
+++ b/features/site.feature
@@ -1147,6 +1147,20 @@ Feature: Manage sites in a multisite installation
       1
       """
 
+    # --site__in and --site_user narrow each other rather than one replacing the
+    # other, so the pair keeps only the sites satisfying both.
+    When I run `wp site list --site__in={ALPHA_ID} --site_user=bobby --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `wp site list --site__in=1,{ALPHA_ID} --site_user=bobby --field=blog_id`
+    Then STDOUT should be:
+      """
+      1
+      """
+
   Scenario: Filter the site list by registration or update date
     Given a WP multisite install
 

--- a/features/site.feature
+++ b/features/site.feature
@@ -1042,12 +1042,7 @@ Feature: Manage sites in a multisite installation
       1
       """
 
-
-  # --registered and --last_updated go through WP_Date_Query, whose exact-timestamp
-  # SQL the SQLite integration does not translate. Reported upstream; skipped on
-  # SQLite until that is resolved.
-  @skip-sqlite
-  Scenario: Filter the site list by an exact registration or update date
+  Scenario: Filter the site list by registration or update date
     Given a WP multisite install
 
     When I run `wp site create --slug=alpha --porcelain`
@@ -1057,8 +1052,16 @@ Feature: Manage sites in a multisite installation
     When I run `wp site list --blog_id={ALPHA_ID} --field=registered`
     Then STDOUT should not be empty
     And save STDOUT as {REGISTERED}
+    And save STDOUT '(\d{4}-\d{2}-\d{2})' as {REGISTERED_DAY}
 
     When I run `wp site list --registered='{REGISTERED}' --field=blog_id`
+    Then STDOUT should contain:
+      """
+      {ALPHA_ID}
+      """
+
+    # A value carrying no time of day matches every site registered that day.
+    When I run `wp site list --registered={REGISTERED_DAY} --field=blog_id`
     Then STDOUT should contain:
       """
       {ALPHA_ID}
@@ -1080,9 +1083,10 @@ Feature: Manage sites in a multisite installation
       {ALPHA_ID}
       """
 
-    When I try `wp site list --registered=notadate`
-    Then STDERR should contain:
+    # Interpreting the value is left to WP_Date_Query, which resolves anything it
+    # cannot parse to a date no site can have registered on.
+    When I run `wp site list --registered=notadate --format=count`
+    Then STDOUT should be:
       """
-      Invalid date passed to --registered
+      0
       """
-    And the return code should be 1

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -3,7 +3,6 @@
 use WP_CLI\CommandWithDBObject;
 use WP_CLI\ExitException;
 use WP_CLI\Fetchers\Site as SiteFetcher;
-use WP_CLI\Iterators\Table as TableIterator;
 use WP_CLI\Utils;
 use WP_CLI\Formatter;
 use WP_CLI\Fetchers\User as UserFetcher;
@@ -1055,8 +1054,6 @@ class Site_Command extends CommandWithDBObject {
 			WP_CLI::error( 'This is not a multisite installation.' );
 		}
 
-		global $wpdb;
-
 		if ( isset( $assoc_args['fields'] ) ) {
 			$assoc_args['fields'] = preg_split( '/,[ \t]*/', $assoc_args['fields'] );
 		}
@@ -1067,31 +1064,57 @@ class Site_Command extends CommandWithDBObject {
 		];
 		$assoc_args = array_merge( $defaults, $assoc_args );
 
-		$where  = [];
-		$append = '';
+		// Anything the command does not consume itself is handed to WP_Site_Query,
+		// which is what makes its own arguments - search, site__not_in, date_query,
+		// lang__in and the rest - usable here.
+		//
+		// 'count' is withheld deliberately: it makes get_sites() return an integer
+		// rather than a list, and '--format=count' is how this command spells it.
+		$query_args = array_diff_key(
+			$assoc_args,
+			array_flip(
+				[ 'format', 'fields', 'field', 'count', 'blog_id', 'site_id', 'site_user', 'site-path', 'network', 'registered', 'last_updated' ]
+			)
+		);
 
-		$site_cols = [ 'blog_id', 'last_updated', 'registered', 'site_id', 'domain', 'path', 'public', 'archived', 'mature', 'spam', 'deleted', 'lang_id' ];
-		foreach ( $site_cols as $col ) {
-			if ( isset( $assoc_args[ $col ] ) ) {
-				$where[ $col ] = $assoc_args[ $col ];
-			}
-		}
-
-		if ( isset( $assoc_args['site-path'] ) ) {
-			$where['path'] = $assoc_args['site-path'];
+		// Arguments this command spells differently to WP_Site_Query.
+		if ( isset( $assoc_args['blog_id'] ) ) {
+			$query_args['site__in'] = [ $assoc_args['blog_id'] ];
 		}
 
 		if ( isset( $assoc_args['site__in'] ) ) {
-			$where['blog_id'] = explode( ',', $assoc_args['site__in'] );
-			$append           = 'ORDER BY FIELD( blog_id, ' . implode( ',', array_map( 'intval', $where['blog_id'] ) ) . ' )';
+			$query_args['site__in'] = array_map( 'trim', explode( ',', $assoc_args['site__in'] ) );
 		}
 
+		if ( isset( $assoc_args['site_id'] ) ) {
+			$query_args['network_id'] = $assoc_args['site_id'];
+		}
+
+		// '--network' has always taken precedence over '--site_id'.
 		if ( isset( $assoc_args['network'] ) ) {
-			$where['site_id'] = $assoc_args['network'];
+			$query_args['network_id'] = $assoc_args['network'];
+		}
+
+		if ( isset( $assoc_args['site-path'] ) ) {
+			$query_args['path'] = $assoc_args['site-path'];
+		}
+
+		// 'registered' and 'last_updated' match the stored value exactly. WP_Site_Query
+		// only filters on those two through a date query, and the SQL that
+		// WP_Date_Query emits for an exact timestamp is not translated by the SQLite
+		// integration, so matching them here keeps both backends behaving the same.
+		// '--date_query' remains available for the range queries it is meant for.
+		$exact_dates = [];
+
+		foreach ( [ 'registered', 'last_updated' ] as $column ) {
+			if ( isset( $assoc_args[ $column ] ) ) {
+				$exact_dates[ $column ] = (string) $assoc_args[ $column ];
+			}
 		}
 
 		if ( isset( $assoc_args['site_user'] ) ) {
-			$user = ( new UserFetcher() )->get_check( $assoc_args['site_user'] );
+			$user     = ( new UserFetcher() )->get_check( $assoc_args['site_user'] );
+			$user_ids = [];
 
 			if ( $user ) {
 				/**
@@ -1100,35 +1123,52 @@ class Site_Command extends CommandWithDBObject {
 				$blogs = get_blogs_of_user( $user->ID );
 
 				foreach ( $blogs as $blog ) {
-					$where['blog_id'][] = $blog->userblog_id;
+					$user_ids[] = $blog->userblog_id;
 				}
 			}
 
-			if ( ! isset( $where['blog_id'] ) || empty( $where['blog_id'] ) ) {
+			if ( isset( $query_args['site__in'] ) ) {
+				$user_ids = array_intersect( array_map( 'intval', $query_args['site__in'] ), $user_ids );
+			}
+
+			if ( empty( $user_ids ) ) {
 				$formatter = new Formatter( $assoc_args, [], 'site' );
 				$formatter->display_items( [] );
 				return;
 			}
 
-			$append = 'ORDER BY FIELD( blog_id, ' . implode( ',', array_map( 'intval', $where['blog_id'] ) ) . ' )';
+			$query_args['site__in'] = array_values( $user_ids );
 		}
 
-		$iterator_args = [
-			'table'  => $wpdb->blogs,
-			'where'  => $where,
-			'append' => $append,
-		];
+		// Listing by explicit IDs has always come back in the order they were given.
+		if ( isset( $query_args['site__in'] ) && ! isset( $assoc_args['orderby'] ) ) {
+			$query_args['orderby'] = 'site__in';
+		}
 
-		$iterator = new TableIterator( $iterator_args );
+		$sites = self::get_sites_iterator( $query_args );
 
-		/**
-		 * @var iterable $iterator
-		 */
+		if ( ! empty( $exact_dates ) ) {
+			$sites = new CallbackFilterIterator(
+				$sites,
+				static function ( $site ) use ( $exact_dates ) {
+					foreach ( $exact_dates as $column => $value ) {
+						if ( (string) $site->$column !== $value ) {
+							return false;
+						}
+					}
+
+					return true;
+				}
+			);
+		}
+
 		$iterator = Utils\iterator_map(
-			$iterator,
-			function ( $blog ) {
-				$blog->url = trailingslashit( get_home_url( $blog->blog_id ) );
-				return $blog;
+			$sites,
+			function ( $site ) {
+				$site_data        = $site->to_array();
+				$site_data['url'] = trailingslashit( get_home_url( $site->blog_id ) );
+
+				return (object) $site_data;
 			}
 		);
 
@@ -1141,6 +1181,55 @@ class Site_Command extends CommandWithDBObject {
 			$formatter = new Formatter( $assoc_args, null, 'site' );
 			$formatter->display_items( $iterator );
 		}
+	}
+
+	/**
+	 * Yields sites a page at a time.
+	 *
+	 * The previous implementation read $wpdb->blogs through a chunked iterator, so
+	 * listing a large network never held every row in memory at once. Page through
+	 * WP_Site_Query the same way, unless an explicit --number was given, in which
+	 * case that is the caller's own limit and is passed straight through.
+	 *
+	 * @param array<string, mixed> $query_args Arguments for WP_Site_Query.
+	 * @return \Generator<int, \WP_Site>
+	 */
+	private static function get_sites_iterator( $query_args ) {
+		if ( isset( $query_args['number'] ) ) {
+			// The arguments are whatever the user passed, so they cannot be narrowed
+			// to the shape get_sites() documents. WP_Site_Query validates them itself.
+			// @phpstan-ignore argument.type
+			foreach ( get_sites( $query_args ) as $site ) {
+				yield $site;
+			}
+
+			return;
+		}
+
+		$chunk_size = 500;
+		$offset     = isset( $query_args['offset'] ) && is_numeric( $query_args['offset'] )
+			? (int) $query_args['offset']
+			: 0;
+
+		do {
+			$page_args = array_merge(
+				$query_args,
+				[
+					'number' => $chunk_size,
+					'offset' => $offset,
+				]
+			);
+
+			// @phpstan-ignore argument.type
+			$sites = get_sites( $page_args );
+
+			foreach ( $sites as $site ) {
+				yield $site;
+			}
+
+			$fetched = count( $sites );
+			$offset += $chunk_size;
+		} while ( $fetched === $chunk_size );
 	}
 
 	/**

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -990,8 +990,6 @@ class Site_Command extends CommandWithDBObject {
 	 * other argument accepted by WP_Site_Query, such as 'search', 'site__not_in',
 	 * 'number', 'offset', 'orderby' or 'order'. However, 'url' isn't an available
 	 * filter, as it comes from 'home' in wp_options.
-	 * '--registered' and '--last_updated' take a timestamp or a date; a value
-	 * carrying no time of day matches that whole day.
 	 * Note: '--path' conflicts with the global parameter of the same name; use
 	 * '--site-path' to filter by path instead.
 	 *
@@ -1014,11 +1012,13 @@ class Site_Command extends CommandWithDBObject {
 	 * [--domain=<domain>]
 	 * : Filter by domain.
 	 *
-	 * [--registered=<yyyy-mm-dd-hh-ii-ss>]
-	 * : Filter by the date the site was registered.
+	 * [--registered=<date>]
+	 * : Filter by the date the site was registered. Accepts a timestamp or a
+	 * date; a value carrying no time of day matches that whole day.
 	 *
-	 * [--last_updated=<yyyy-mm-dd-hh-ii-ss>]
-	 * : Filter by the date the site was last updated.
+	 * [--last_updated=<date>]
+	 * : Filter by the date the site was last updated. Accepts a timestamp or a
+	 * date; a value carrying no time of day matches that whole day.
 	 *
 	 * [--public=<public>]
 	 * : Filter by whether the site is public. Accepts 1 or 0.

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -990,6 +990,8 @@ class Site_Command extends CommandWithDBObject {
 	 * other argument accepted by WP_Site_Query, such as 'search', 'site__not_in',
 	 * 'number', 'offset', 'orderby' or 'order'. However, 'url' isn't an available
 	 * filter, as it comes from 'home' in wp_options.
+	 * '--registered' and '--last_updated' take a timestamp or a date; a value
+	 * carrying no time of day matches that whole day.
 	 * Note: '--path' conflicts with the global parameter of the same name; use
 	 * '--site-path' to filter by path instead.
 	 *

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -986,8 +986,10 @@ class Site_Command extends CommandWithDBObject {
 	 * : The network to which the sites belong.
 	 *
 	 * [--<field>=<value>]
-	 * : Filter by one or more fields (see "Available Fields" section). However,
-	 * 'url' isn't an available filter, as it comes from 'home' in wp_options.
+	 * : Filter by one or more fields (see "Available Fields" section), or pass any
+	 * other argument accepted by WP_Site_Query, such as 'search', 'site__not_in',
+	 * 'number', 'offset', 'orderby' or 'order'. However, 'url' isn't an available
+	 * filter, as it comes from 'home' in wp_options.
 	 * Note: '--path' conflicts with the global parameter of the same name; use
 	 * '--site-path' to filter by path instead.
 	 *
@@ -1047,6 +1049,15 @@ class Site_Command extends CommandWithDBObject {
 	 *     http://www.example.com/
 	 *     http://www.example.com/subdir/
 	 *
+	 *     # Output site URLs, most recently registered first
+	 *     $ wp site list --orderby=registered --order=desc --field=url
+	 *     http://www.example.com/subdir/
+	 *     http://www.example.com/
+	 *
+	 *     # Search for sites by domain or path
+	 *     $ wp site list --search=subdir --field=url
+	 *     http://www.example.com/subdir/
+	 *
 	 * @subcommand list
 	 */
 	public function list_( $args, $assoc_args ) {
@@ -1099,30 +1110,25 @@ class Site_Command extends CommandWithDBObject {
 			$query_args['path'] = $assoc_args['site-path'];
 		}
 
-		// 'registered' and 'last_updated' match the stored value exactly, which
-		// WP_Site_Query expresses as a date query pinned to every component. Parsing
-		// and formatting both as UTC round-trips the given value unchanged, rather
-		// than shifting it by the server's timezone.
+		// WP_Site_Query only reaches the date columns through a date query. Bounding
+		// the range by the given value on both ends matches it as precisely as it was
+		// written: a full timestamp matches that second, a date matches that day.
+		// Interpreting the value is WP_Date_Query's job, so it is passed on as given.
+		$date_query = [];
+
 		foreach ( [ 'registered', 'last_updated' ] as $column ) {
-			if ( ! isset( $assoc_args[ $column ] ) ) {
-				continue;
+			if ( isset( $assoc_args[ $column ] ) ) {
+				$date_query[] = [
+					'column'    => $column,
+					'after'     => $assoc_args[ $column ],
+					'before'    => $assoc_args[ $column ],
+					'inclusive' => true,
+				];
 			}
+		}
 
-			$timestamp = strtotime( (string) $assoc_args[ $column ] . ' UTC' );
-
-			if ( false === $timestamp ) {
-				WP_CLI::error( "Invalid date passed to --{$column}: {$assoc_args[ $column ]}" );
-			}
-
-			$query_args['date_query'][] = [
-				'column' => $column,
-				'year'   => (int) gmdate( 'Y', $timestamp ),
-				'month'  => (int) gmdate( 'n', $timestamp ),
-				'day'    => (int) gmdate( 'j', $timestamp ),
-				'hour'   => (int) gmdate( 'G', $timestamp ),
-				'minute' => (int) gmdate( 'i', $timestamp ),
-				'second' => (int) gmdate( 's', $timestamp ),
-			];
+		if ( ! empty( $date_query ) ) {
+			$query_args['date_query'] = $date_query;
 		}
 
 		if ( isset( $assoc_args['site_user'] ) ) {

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -1099,17 +1099,30 @@ class Site_Command extends CommandWithDBObject {
 			$query_args['path'] = $assoc_args['site-path'];
 		}
 
-		// 'registered' and 'last_updated' match the stored value exactly. WP_Site_Query
-		// only filters on those two through a date query, and the SQL that
-		// WP_Date_Query emits for an exact timestamp is not translated by the SQLite
-		// integration, so matching them here keeps both backends behaving the same.
-		// '--date_query' remains available for the range queries it is meant for.
-		$exact_dates = [];
-
+		// 'registered' and 'last_updated' match the stored value exactly, which
+		// WP_Site_Query expresses as a date query pinned to every component. Parsing
+		// and formatting both as UTC round-trips the given value unchanged, rather
+		// than shifting it by the server's timezone.
 		foreach ( [ 'registered', 'last_updated' ] as $column ) {
-			if ( isset( $assoc_args[ $column ] ) ) {
-				$exact_dates[ $column ] = (string) $assoc_args[ $column ];
+			if ( ! isset( $assoc_args[ $column ] ) ) {
+				continue;
 			}
+
+			$timestamp = strtotime( (string) $assoc_args[ $column ] . ' UTC' );
+
+			if ( false === $timestamp ) {
+				WP_CLI::error( "Invalid date passed to --{$column}: {$assoc_args[ $column ]}" );
+			}
+
+			$query_args['date_query'][] = [
+				'column' => $column,
+				'year'   => (int) gmdate( 'Y', $timestamp ),
+				'month'  => (int) gmdate( 'n', $timestamp ),
+				'day'    => (int) gmdate( 'j', $timestamp ),
+				'hour'   => (int) gmdate( 'G', $timestamp ),
+				'minute' => (int) gmdate( 'i', $timestamp ),
+				'second' => (int) gmdate( 's', $timestamp ),
+			];
 		}
 
 		if ( isset( $assoc_args['site_user'] ) ) {
@@ -1145,25 +1158,8 @@ class Site_Command extends CommandWithDBObject {
 			$query_args['orderby'] = 'site__in';
 		}
 
-		$sites = self::get_sites_iterator( $query_args );
-
-		if ( ! empty( $exact_dates ) ) {
-			$sites = new CallbackFilterIterator(
-				$sites,
-				static function ( $site ) use ( $exact_dates ) {
-					foreach ( $exact_dates as $column => $value ) {
-						if ( (string) $site->$column !== $value ) {
-							return false;
-						}
-					}
-
-					return true;
-				}
-			);
-		}
-
 		$iterator = Utils\iterator_map(
-			$sites,
+			self::get_sites_iterator( $query_args ),
 			function ( $site ) {
 				$site_data        = $site->to_array();
 				$site_data['url'] = trailingslashit( get_home_url( $site->blog_id ) );


### PR DESCRIPTION
Draft, because this changes how a widely used command reaches the database.

Came out of #638: `site list` was the odd one out among the list commands, and the reason turned out to be that it never used `WP_Site_Query` at all.

## What it did

It read `$wpdb->blogs` directly through a chunked table iterator, with a `WHERE` clause assembled from a hardcoded column list. Consequences:

- Every `WP_Site_Query` argument beyond those columns was silently ignored — `search`, `site__not_in`, `network__in`, `lang__in`, `domain__in`, `date_query`, `orderby`, `number`, `offset`, meta queries.
- `pre_get_sites` and the other query filters never ran, so a plugin controlling which sites are visible had no effect here.
- Results were uncached.

This builds a `WP_Site_Query` argument set instead and hands it everything the command does not consume itself, so those arguments work now:

```
$ wp site list --search=alpha --field=blog_id
$ wp site list --site__not_in=2 --format=count
$ wp site list --number=1 --offset=1 --field=blog_id
$ wp site list --orderby=id --order=desc --field=blog_id
```

## Behaviour that is deliberately preserved

**This command's own argument names.** `--blog_id`, `--site__in`, `--site_id`, `--network`, `--site-path` and `--site_user` are mapped onto their `WP_Site_Query` equivalents. `--network` still takes precedence over `--site_id`, and listing by explicit IDs still returns them in the order given (`orderby => site__in`).

**Paging, for two separate reasons.** `WP_Site_Query::$number` defaults to **100**, so a plain `get_sites()` call would silently truncate a network to its first hundred sites — a data-correctness bug, not a performance one. Paging 500 at a time also preserves the memory profile of the chunked iterator this replaces. An explicit `--number` is the caller's own limit and is passed straight through without paging.

**`count` is withheld** from the query arguments, since it makes `get_sites()` return an integer rather than a list, and `--format=count` is how this command spells that.

Rows are still plain objects carrying the blogs columns plus `url`, so `--fields`, `--field` and the formatters are unaffected.

## Dates

`--registered` and `--last_updated` have no direct `WP_Site_Query` equivalent, so they become a `date_query` clause bounded by the given value on both ends (`before` and `after` with `inclusive`). Interpreting the value is left to `WP_Date_Query`, which means:

- A full timestamp matches that second, exactly as before.
- A value carrying no time of day — `2026`, `2026-08`, `2026-08-17` — matches that whole year, month or day.
- The SQL is a pair of plain comparisons rather than a component-wise `YEAR()`/`MONTH()`/`DATE_FORMAT()` match, so it works on SQLite as well. Nothing in this PR is skipped on any backend.
- A value WordPress cannot parse resolves to a date no site can carry, so the list comes back empty rather than erroring.

Since #638 landed, these two also have option entries of their own rather than being described inside the `--<field>=<value>` blurb. The `<yyyy-mm-dd-hh-ii-ss>` placeholder they arrived with implied a full timestamp was required, which is no longer true, so they take `<date>`.

## Testing

Three scenarios added: the newly available `WP_Site_Query` arguments; the existing filters still behaving — including `--site__in` ordering, `--site_user`, and the two of them intersecting rather than one replacing the other; and the date filters.

Run with the same tag filtering CI applies, on the merge of `main` (#636, #638 and the README regeneration are all in the base now). Nothing is skipped on either backend, so the two runs cover the same 38 scenarios:

| Backend | Result |
|---|---|
| MariaDB 10.11 | 38 scenarios, 498 steps, all passed |
| SQLite 3.45 | 38 scenarios, 498 steps, all passed |

Widened to every feature that exercises `wp site list` — `site`, `site-generate`, `site-empty`, `site-create`, `signup` — and diffed the failures against `origin/main` with `src/` and `features/` checked out at the base:

```
origin/main : 4 failures   (Empty a site, Empty a site and its uploads directory,
                            Create new site with custom $super_admins global,
                            Respect defined $base in wp-config)
this branch : the same 4
NEW: none    FIXED: none
```

Those four are pre-existing and unrelated.

The `--site_user` plus `--site__in` coverage was checked against the regression it is meant to catch: replacing the `array_intersect` in `list_()` with a plain overwrite makes it fail, while the 24 steps ahead of it in the scenario still pass.

PHPCS clean. PHPStan reports no new errors against `origin/main` — the same total on both sides, and the two findings in `Site_Command.php` are present on both. The dynamic argument array cannot be narrowed to the shape `get_sites()` documents, since it is whatever the user passed and `WP_Site_Query` validates it itself, so those two calls carry an `argument.type` ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SSZzqMJRDTiLiDxQEPYcL

## Summary by CodeRabbit

- **New Features**
  - Enhanced `wp site list` with broader filtering and ordering options, including search, exclusions, network, path, user, and registration or last-updated date filters.
  - Added support for pagination, result counts, and preserving explicitly requested site order.
  - Improved handling of combined filters and date-only matching.

- **Documentation**
  - Expanded command usage guidance with supported filters, date syntax, and practical examples.

- **Tests**
  - Added comprehensive coverage for filtering, pagination, ordering, counts, and invalid or nonmatching dates.