### PR TITLE
Document every argument `wp site list` accepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5443,7 +5443,7 @@ These fields are optionally available:
 Lists all sites in a multisite installation.
 
 ~~~
-wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--site__not_in=<value>] [--site_user=<value>] [--site-path=<path>] [--path__in=<value>] [--path__not_in=<value>] [--blog_id=<blog_id>|ID] [--site_id=<site_id>] [--network_id=<network_id>] [--network__in=<value>] [--network__not_in=<value>] [--domain=<domain>] [--domain__in=<value>] [--domain__not_in=<value>] [--registered=<date>] [--last_updated=<date>] [--public=<public>] [--archived=<archived>] [--mature=<mature>] [--spam=<spam>] [--deleted=<deleted>] [--lang_id=<lang_id>] [--lang__in=<value>] [--lang__not_in=<value>] [--search=<string>] [--search_columns=<columns>] [--meta_key=<meta_key>] [--meta_value=<meta_value>] [--meta_compare=<meta_compare>] [--meta_type=<meta_type>] [--number=<number>] [--offset=<offset>] [--no_found_rows=<no_found_rows>] [--update_site_cache=<update_site_cache>] [--update_site_meta_cache=<update_site_meta_cache>] [--orderby=<field>] [--order=<order>] [--field=<field>] [--fields=<fields>] [--format=<format>]
+wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--site__not_in=<value>] [--site_user=<value>] [--site-path=<path>] [--path__in=<value>] [--path__not_in=<value>] [--blog_id=<blog_id>|ID] [--site_id=<site_id>] [--network_id=<network_id>] [--network__in=<value>] [--network__not_in=<value>] [--domain=<domain>] [--domain__in=<value>] [--domain__not_in=<value>] [--registered=<date>] [--last_updated=<date>] [--public=<public>] [--archived=<archived>] [--mature=<mature>] [--spam=<spam>] [--deleted=<deleted>] [--lang_id=<lang_id>] [--lang__in=<value>] [--lang__not_in=<value>] [--search=<string>] [--search_columns=<columns>] [--meta_key=<meta_key>] [--meta_value=<meta_value>] [--meta_compare=<meta_compare>] [--meta_type=<meta_type>] [--meta_query=<meta_query>] [--date_query=<date_query>] [--number=<number>] [--offset=<offset>] [--no_found_rows=<no_found_rows>] [--update_site_cache=<update_site_cache>] [--update_site_meta_cache=<update_site_meta_cache>] [--orderby=<field>] [--order=<order>] [--field=<field>] [--fields=<fields>] [--format=<format>]
 ~~~
 
 **OPTIONS**
@@ -5555,6 +5555,15 @@ wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--site__
 
 	[--meta_type=<meta_type>]
 		Cast the meta value to this type, such as 'NUMERIC' or 'DATE'.
+
+	[--meta_query=<meta_query>]
+		A WP_Meta_Query clause list, as JSON, for conditions the meta_* arguments
+		above cannot express.
+
+	[--date_query=<date_query>]
+		A WP_Date_Query clause list, as JSON, for ranges `--registered` and
+		`--last_updated` cannot express. Giving those as well narrows this further
+		rather than replacing it.
 
 	[--number=<number>]
 		Limit the number of sites returned.

--- a/README.md
+++ b/README.md
@@ -5443,7 +5443,7 @@ These fields are optionally available:
 Lists all sites in a multisite installation.
 
 ~~~
-wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--site_user=<value>] [--site-path=<path>] [--blog_id=<blog_id>] [--site_id=<site_id>] [--domain=<domain>] [--registered=<date>] [--last_updated=<date>] [--public=<public>] [--archived=<archived>] [--mature=<mature>] [--spam=<spam>] [--deleted=<deleted>] [--lang_id=<lang_id>] [--field=<field>] [--fields=<fields>] [--format=<format>]
+wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--site__not_in=<value>] [--site_user=<value>] [--site-path=<path>] [--path__in=<value>] [--path__not_in=<value>] [--blog_id=<blog_id>|ID] [--site_id=<site_id>] [--network_id=<network_id>] [--network__in=<value>] [--network__not_in=<value>] [--domain=<domain>] [--domain__in=<value>] [--domain__not_in=<value>] [--registered=<date>] [--last_updated=<date>] [--public=<public>] [--archived=<archived>] [--mature=<mature>] [--spam=<spam>] [--deleted=<deleted>] [--lang_id=<lang_id>] [--lang__in=<value>] [--lang__not_in=<value>] [--search=<string>] [--search_columns=<columns>] [--meta_key=<meta_key>] [--meta_value=<meta_value>] [--meta_compare=<meta_compare>] [--meta_type=<meta_type>] [--number=<number>] [--offset=<offset>] [--no_found_rows=<no_found_rows>] [--update_site_cache=<update_site_cache>] [--update_site_meta_cache=<update_site_meta_cache>] [--orderby=<field>] [--order=<order>] [--field=<field>] [--fields=<fields>] [--format=<format>]
 ~~~
 
 **OPTIONS**
@@ -5453,8 +5453,7 @@ wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--site_u
 
 	[--<field>=<value>]
 		Filter by one or more fields (see "Available Fields" section), or pass any
-		other argument accepted by WP_Site_Query, such as 'search', 'site__not_in',
-		'number', 'offset', 'orderby' or 'order'. However, 'url' isn't an available
+		other argument accepted by WP_Site_Query. However, 'url' isn't an available
 		filter, as it comes from 'home' in wp_options.
 		Note: '--path' conflicts with the global parameter of the same name; use
 		'--site-path' to filter by path instead.
@@ -5462,21 +5461,47 @@ wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--site_u
 	[--site__in=<value>]
 		Only list the sites with these blog_id values (comma-separated).
 
+	[--site__not_in=<value>]
+		Exclude the sites with these blog_id values (comma-separated).
+
 	[--site_user=<value>]
 		Only list the sites with this user.
 
 	[--site-path=<path>]
 		Filter by path. Avoids conflict with the global `--path` parameter.
 
-	[--blog_id=<blog_id>]
-		Filter by site ID.
+	[--path__in=<value>]
+		Only list the sites with these paths (comma-separated).
+
+	[--path__not_in=<value>]
+		Exclude the sites with these paths (comma-separated).
+
+	[--blog_id=<blog_id>|ID]
+		Filter by site ID. `--ID` is WP_Site_Query's name for the same filter
+		and is accepted as an alias.
 
 	[--site_id=<site_id>]
-		Filter by the ID of the network the site belongs to. `--network` is an
-		alias for this, and takes precedence when both are given.
+		Filter by the ID of the network the site belongs to. `--network` and
+		`--network_id` are aliases for this; `--network` takes precedence when
+		more than one is given.
+
+	[--network_id=<network_id>]
+		Filter by the ID of the network the site belongs to.
+
+	[--network__in=<value>]
+		Only list the sites belonging to these network IDs (comma-separated).
+
+	[--network__not_in=<value>]
+		Exclude the sites belonging to these network IDs (comma-separated).
 
 	[--domain=<domain>]
 		Filter by domain.
+
+	[--domain__in=<value>]
+		Only list the sites with these domains (comma-separated).
+
+	[--domain__not_in=<value>]
+		Exclude the sites with these domains (comma-separated).
 
 	[--registered=<date>]
 		Filter by the date the site was registered. Accepts a timestamp or a
@@ -5503,6 +5528,62 @@ wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--site_u
 
 	[--lang_id=<lang_id>]
 		Filter by language ID.
+
+	[--lang__in=<value>]
+		Only list the sites with these language IDs (comma-separated).
+
+	[--lang__not_in=<value>]
+		Exclude the sites with these language IDs (comma-separated).
+
+	[--search=<string>]
+		Only list the sites matching this search term. Searches the domain and
+		path columns unless `--search_columns` narrows it.
+
+	[--search_columns=<columns>]
+		Comma-separated list of columns `--search` looks in. Accepts 'domain'
+		and 'path'.
+
+	[--meta_key=<meta_key>]
+		Filter by this site meta key.
+
+	[--meta_value=<meta_value>]
+		Filter by this site meta value. Used together with `--meta_key`.
+
+	[--meta_compare=<meta_compare>]
+		Operator to test the meta value against. Accepts the operators
+		WP_Meta_Query supports, such as '=', '!=', 'LIKE' or 'IN'.
+
+	[--meta_type=<meta_type>]
+		Cast the meta value to this type, such as 'NUMERIC' or 'DATE'.
+
+	[--number=<number>]
+		Limit the number of sites returned.
+
+	[--offset=<offset>]
+		Number of sites to skip. Used together with `--number`.
+
+	[--no_found_rows=<no_found_rows>]
+		Whether to skip counting the total rows the query matches. Accepts 1 or 0.
+
+	[--update_site_cache=<update_site_cache>]
+		Whether to prime the object cache with the sites found. Accepts 1 or 0.
+		Turning it off saves work when listing a large network once.
+
+	[--update_site_meta_cache=<update_site_meta_cache>]
+		Whether to prime the object cache with the site meta of the sites found.
+		Accepts 1 or 0.
+
+	[--orderby=<field>]
+		Order the results by this field, such as 'blog_id', 'domain', 'path',
+		'registered', 'last_updated' or 'site__in'.
+
+	[--order=<order>]
+		Whether to order the results ascending or descending.
+		---
+		options:
+		  - asc
+		  - desc
+		---
 
 	[--field=<field>]
 		Prints the value of a single field for each site.

--- a/README.md
+++ b/README.md
@@ -5538,7 +5538,8 @@ wp site list [--network=<id>|site_id|network_id] [--<field>=<value>] [--site__in
 		and 'path'.
 
 	[--meta_key=<meta_key>]
-		Filter by this site meta key.
+		Filter by this site meta key. The site meta arguments need WordPress 5.1
+		or later, which is where multisite gained the table they read.
 
 	[--meta_value=<meta_value>]
 		Filter by this site meta value. Used together with `--meta_key`.

--- a/README.md
+++ b/README.md
@@ -5443,13 +5443,15 @@ These fields are optionally available:
 Lists all sites in a multisite installation.
 
 ~~~
-wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--site__not_in=<value>] [--site_user=<value>] [--site-path=<path>] [--path__in=<value>] [--path__not_in=<value>] [--blog_id=<blog_id>|ID] [--site_id=<site_id>] [--network_id=<network_id>] [--network__in=<value>] [--network__not_in=<value>] [--domain=<domain>] [--domain__in=<value>] [--domain__not_in=<value>] [--registered=<date>] [--last_updated=<date>] [--public=<public>] [--archived=<archived>] [--mature=<mature>] [--spam=<spam>] [--deleted=<deleted>] [--lang_id=<lang_id>] [--lang__in=<value>] [--lang__not_in=<value>] [--search=<string>] [--search_columns=<columns>] [--meta_key=<meta_key>] [--meta_value=<meta_value>] [--meta_compare=<meta_compare>] [--meta_type=<meta_type>] [--meta_query=<meta_query>] [--date_query=<date_query>] [--number=<number>] [--offset=<offset>] [--no_found_rows=<no_found_rows>] [--update_site_cache=<update_site_cache>] [--update_site_meta_cache=<update_site_meta_cache>] [--orderby=<field>] [--order=<order>] [--field=<field>] [--fields=<fields>] [--format=<format>]
+wp site list [--network=<id>|site_id|network_id] [--<field>=<value>] [--site__in=<value>] [--site__not_in=<value>] [--site_user=<value>] [--site-path=<path>] [--path__in=<value>] [--path__not_in=<value>] [--blog_id=<blog_id>|ID] [--network__in=<value>] [--network__not_in=<value>] [--domain=<domain>] [--domain__in=<value>] [--domain__not_in=<value>] [--registered=<date>] [--last_updated=<date>] [--public=<public>] [--archived=<archived>] [--mature=<mature>] [--spam=<spam>] [--deleted=<deleted>] [--lang_id=<lang_id>] [--lang__in=<value>] [--lang__not_in=<value>] [--search=<string>] [--search_columns=<columns>] [--meta_key=<meta_key>] [--meta_value=<meta_value>] [--meta_compare=<meta_compare>] [--meta_type=<meta_type>] [--meta_query=<meta_query>] [--date_query=<date_query>] [--number=<number>] [--offset=<offset>] [--no_found_rows=<no_found_rows>] [--update_site_cache=<update_site_cache>] [--update_site_meta_cache=<update_site_meta_cache>] [--orderby=<field>] [--order=<order>] [--field=<field>] [--fields=<fields>] [--format=<format>]
 ~~~
 
 **OPTIONS**
 
-	[--network=<id>]
-		The network to which the sites belong.
+	[--network=<id>|site_id|network_id]
+		The network to which the sites belong. `--site_id` is the name of the
+		column this filters, `--network_id` is WP_Site_Query's name for it, and
+		both are accepted as aliases. `--network` wins when more than one is given.
 
 	[--<field>=<value>]
 		Filter by one or more fields (see "Available Fields" section), or pass any
@@ -5479,14 +5481,6 @@ wp site list [--network=<id>] [--<field>=<value>] [--site__in=<value>] [--site__
 	[--blog_id=<blog_id>|ID]
 		Filter by site ID. `--ID` is WP_Site_Query's name for the same filter
 		and is accepted as an alias.
-
-	[--site_id=<site_id>]
-		Filter by the ID of the network the site belongs to. `--network` and
-		`--network_id` are aliases for this; `--network` takes precedence when
-		more than one is given.
-
-	[--network_id=<network_id>]
-		Filter by the ID of the network the site belongs to.
 
 	[--network__in=<value>]
 		Only list the sites belonging to these network IDs (comma-separated).

--- a/features/site.feature
+++ b/features/site.feature
@@ -1169,35 +1169,7 @@ Feature: Manage sites in a multisite installation
       3
       """
 
-    When I run `wp site meta add {ALPHA_ID} colour blue`
-    Then STDOUT should not be empty
-
-    When I run `wp site list --meta_key=colour --meta_value=blue --field=blog_id`
-    Then STDOUT should be:
-      """
-      {ALPHA_ID}
-      """
-
-    When I run `wp site list --meta_key=colour --meta_value=red --format=count`
-    Then STDOUT should be:
-      """
-      0
-      """
-
-    # --meta_query and --date_query are nested arrays, so they are given as JSON.
-    When I run `wp site list --meta_query='[{"key":"colour","value":"blue"}]' --field=blog_id`
-    Then STDOUT should be:
-      """
-      {ALPHA_ID}
-      """
-
-    When I run `wp site list --meta_query='[{"key":"colour","compare":"NOT EXISTS"}]' --field=blog_id`
-    Then STDOUT should be:
-      """
-      1
-      {BETA_ID}
-      """
-
+    # --date_query is a nested array, so it is given as JSON.
     When I run `wp site list --date_query='[{"column":"registered","after":"1999-01-01"}]' --format=count`
     Then STDOUT should be:
       """
@@ -1236,6 +1208,21 @@ Feature: Manage sites in a multisite installation
       0
       """
 
+    When I run `wp site list --blog_id={ALPHA_ID} --field=last_updated`
+    Then save STDOUT as {ALPHA_UPDATED}
+
+    When I run `wp site list --blog_id={ALPHA_ID} --last_updated='{ALPHA_UPDATED}' --format=count`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp site list --blog_id={ALPHA_ID} --date_query='{"relation":"OR","0":{"column":"last_updated","before":"1999-01-01"},"1":{"column":"last_updated","before":"1998-01-01"}}' --last_updated='{ALPHA_UPDATED}' --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
     When I try `wp site list --meta_query=notjson`
     Then STDERR should contain:
       """
@@ -1249,6 +1236,49 @@ Feature: Manage sites in a multisite installation
       Invalid JSON passed to --date_query.
       """
     And the return code should be 1
+
+  # WP_Site_Query gained the meta_* parameters, and multisite gained the site meta
+  # table they read, in WordPress 5.1.
+  @require-wp-5.1
+  Scenario: Filter the site list by site meta
+    Given a WP multisite install
+
+    When I run `wp site create --slug=alpha --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {ALPHA_ID}
+
+    When I run `wp site create --slug=beta --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {BETA_ID}
+
+    When I run `wp site meta add {ALPHA_ID} colour blue`
+    Then STDOUT should not be empty
+
+    When I run `wp site list --meta_key=colour --meta_value=blue --field=blog_id`
+    Then STDOUT should be:
+      """
+      {ALPHA_ID}
+      """
+
+    When I run `wp site list --meta_key=colour --meta_value=red --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    # --meta_query is a nested array, so it is given as JSON.
+    When I run `wp site list --meta_query='[{"key":"colour","value":"blue"}]' --field=blog_id`
+    Then STDOUT should be:
+      """
+      {ALPHA_ID}
+      """
+
+    When I run `wp site list --meta_query='[{"key":"colour","compare":"NOT EXISTS"}]' --field=blog_id`
+    Then STDOUT should be:
+      """
+      1
+      {BETA_ID}
+      """
 
   Scenario: Existing site list filters keep working against WP_Site_Query
     Given a WP multisite install

--- a/features/site.feature
+++ b/features/site.feature
@@ -1087,6 +1087,103 @@ Feature: Manage sites in a multisite installation
       1
       """
 
+  Scenario: List sites using the WP_Site_Query arguments that take a list
+    Given a WP multisite install
+
+    When I run `wp site create --slug=alpha --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {ALPHA_ID}
+
+    When I run `wp site create --slug=beta --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {BETA_ID}
+
+    # WP_Site_Query reads these through is_array(), so before they were split
+    # they were skipped without a word and every site came back.
+    When I run `wp site list --path__in=/alpha/,/beta/ --field=blog_id`
+    Then STDOUT should be:
+      """
+      {ALPHA_ID}
+      {BETA_ID}
+      """
+
+    When I run `wp site list --path__not_in=/alpha/,/beta/ --field=blog_id`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp site list --domain__in=example.com --format=count`
+    Then STDOUT should be:
+      """
+      3
+      """
+
+    When I run `wp site list --domain__not_in=example.com --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    # --search_columns reaches array_intersect(), which is fatal on a string.
+    When I run `wp site list --search=alpha --search_columns=path --field=blog_id`
+    Then STDOUT should be:
+      """
+      {ALPHA_ID}
+      """
+
+    When I run `wp site list --search=alpha --search_columns=domain --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    # The remaining newly documented filters.
+    When I run `wp site list --network__in=1 --format=count`
+    Then STDOUT should be:
+      """
+      3
+      """
+
+    When I run `wp site list --network__not_in=1 --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `wp site list --lang__in=0 --format=count`
+    Then STDOUT should be:
+      """
+      3
+      """
+
+    When I run `wp site list --ID={ALPHA_ID} --field=blog_id`
+    Then STDOUT should be:
+      """
+      {ALPHA_ID}
+      """
+
+    When I run `wp site list --network_id=1 --format=count`
+    Then STDOUT should be:
+      """
+      3
+      """
+
+    When I run `wp site meta add {ALPHA_ID} colour blue`
+    Then STDOUT should not be empty
+
+    When I run `wp site list --meta_key=colour --meta_value=blue --field=blog_id`
+    Then STDOUT should be:
+      """
+      {ALPHA_ID}
+      """
+
+    When I run `wp site list --meta_key=colour --meta_value=red --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
   Scenario: Existing site list filters keep working against WP_Site_Query
     Given a WP multisite install
 

--- a/features/site.feature
+++ b/features/site.feature
@@ -1184,6 +1184,63 @@ Feature: Manage sites in a multisite installation
       0
       """
 
+    # --meta_query and --date_query are nested arrays, so they are given as JSON.
+    When I run `wp site list --meta_query='[{"key":"colour","value":"blue"}]' --field=blog_id`
+    Then STDOUT should be:
+      """
+      {ALPHA_ID}
+      """
+
+    When I run `wp site list --meta_query='[{"key":"colour","compare":"NOT EXISTS"}]' --field=blog_id`
+    Then STDOUT should be:
+      """
+      1
+      {BETA_ID}
+      """
+
+    When I run `wp site list --date_query='[{"column":"registered","after":"1999-01-01"}]' --format=count`
+    Then STDOUT should be:
+      """
+      3
+      """
+
+    When I run `wp site list --date_query='[{"column":"registered","before":"1999-01-01"}]' --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    # --registered narrows a --date_query of its own rather than replacing it. The
+    # date on its own has to match first, or the pair below would prove nothing.
+    When I run `wp site list --blog_id={ALPHA_ID} --field=registered`
+    Then save STDOUT as {ALPHA_REGISTERED}
+
+    When I run `wp site list --blog_id={ALPHA_ID} --registered='{ALPHA_REGISTERED}' --format=count`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp site list --blog_id={ALPHA_ID} --date_query='[{"column":"registered","before":"1999-01-01"}]' --registered='{ALPHA_REGISTERED}' --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I try `wp site list --meta_query=notjson`
+    Then STDERR should contain:
+      """
+      Invalid JSON passed to --meta_query.
+      """
+    And the return code should be 1
+
+    When I try `wp site list --date_query=notjson`
+    Then STDERR should contain:
+      """
+      Invalid JSON passed to --date_query.
+      """
+    And the return code should be 1
+
   Scenario: Existing site list filters keep working against WP_Site_Query
     Given a WP multisite install
 

--- a/features/site.feature
+++ b/features/site.feature
@@ -1227,6 +1227,15 @@ Feature: Manage sites in a multisite installation
       0
       """
 
+    # The relation of a given --date_query governs only its own clauses. Appending
+    # to the same list would let an 'OR' reach the clause --registered adds and
+    # match a site that satisfies neither half of what was asked for.
+    When I run `wp site list --blog_id={ALPHA_ID} --date_query='{"relation":"OR","0":{"column":"registered","before":"1999-01-01"},"1":{"column":"registered","before":"1998-01-01"}}' --registered='{ALPHA_REGISTERED}' --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
     When I try `wp site list --meta_query=notjson`
     Then STDERR should contain:
       """

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -1090,6 +1090,15 @@ class Site_Command extends CommandWithDBObject {
 	 * [--meta_type=<meta_type>]
 	 * : Cast the meta value to this type, such as 'NUMERIC' or 'DATE'.
 	 *
+	 * [--meta_query=<meta_query>]
+	 * : A WP_Meta_Query clause list, as JSON, for conditions the meta_* arguments
+	 * above cannot express.
+	 *
+	 * [--date_query=<date_query>]
+	 * : A WP_Date_Query clause list, as JSON, for ranges `--registered` and
+	 * `--last_updated` cannot express. Giving those as well narrows this further
+	 * rather than replacing it.
+	 *
 	 * [--number=<number>]
 	 * : Limit the number of sites returned.
 	 *
@@ -1198,15 +1207,32 @@ class Site_Command extends CommandWithDBObject {
 		//
 		// 'count' is withheld deliberately: it makes get_sites() return an integer
 		// rather than a list, and '--format=count' is how this command spells it.
-		// 'meta_query' and 'date_query' are withheld because they are nested arrays
-		// with no command-line spelling; the meta_* and date arguments above cover
-		// what can be expressed here.
 		$query_args = array_diff_key(
 			$assoc_args,
 			array_flip(
-				[ 'format', 'fields', 'field', 'count', 'meta_query', 'date_query', 'blog_id', 'site_id', 'site_user', 'site-path', 'network', 'registered', 'last_updated' ]
+				[ 'format', 'fields', 'field', 'count', 'blog_id', 'site_id', 'site_user', 'site-path', 'network', 'registered', 'last_updated' ]
 			)
 		);
+
+		// 'meta_query' and 'date_query' are nested arrays, so they are given as JSON.
+		// The decoded values go straight into the query arguments rather than back
+		// into $assoc_args, which the rest of this method reads as strings.
+		//
+		// parse_shell_arrays() leaves anything that is not JSON alone, and a string
+		// reaching either of these is ignored without a word. Say so instead.
+		$decoded_args = Utils\parse_shell_arrays( $assoc_args, [ 'meta_query', 'date_query' ] );
+
+		foreach ( [ 'meta_query', 'date_query' ] as $json_arg ) {
+			if ( ! isset( $decoded_args[ $json_arg ] ) ) {
+				continue;
+			}
+
+			if ( ! is_array( $decoded_args[ $json_arg ] ) ) {
+				WP_CLI::error( "Invalid JSON passed to --{$json_arg}." );
+			}
+
+			$query_args[ $json_arg ] = $decoded_args[ $json_arg ];
+		}
 
 		// Arguments this command spells differently to WP_Site_Query.
 		if ( isset( $assoc_args['blog_id'] ) ) {
@@ -1257,8 +1283,14 @@ class Site_Command extends CommandWithDBObject {
 			}
 		}
 
+		// A '--date_query' of its own is kept rather than replaced, so '--registered'
+		// and '--last_updated' narrow it the way every other filter here narrows the
+		// result instead of quietly winning.
 		if ( ! empty( $date_query ) ) {
-			$query_args['date_query'] = $date_query;
+			$given                    = isset( $query_args['date_query'] ) && is_array( $query_args['date_query'] )
+				? $query_args['date_query']
+				: [];
+			$query_args['date_query'] = array_merge( $given, $date_query );
 		}
 
 		if ( isset( $assoc_args['site_user'] ) ) {

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -987,8 +987,7 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * [--<field>=<value>]
 	 * : Filter by one or more fields (see "Available Fields" section), or pass any
-	 * other argument accepted by WP_Site_Query, such as 'search', 'site__not_in',
-	 * 'number', 'offset', 'orderby' or 'order'. However, 'url' isn't an available
+	 * other argument accepted by WP_Site_Query. However, 'url' isn't an available
 	 * filter, as it comes from 'home' in wp_options.
 	 * Note: '--path' conflicts with the global parameter of the same name; use
 	 * '--site-path' to filter by path instead.
@@ -996,21 +995,47 @@ class Site_Command extends CommandWithDBObject {
 	 * [--site__in=<value>]
 	 * : Only list the sites with these blog_id values (comma-separated).
 	 *
+	 * [--site__not_in=<value>]
+	 * : Exclude the sites with these blog_id values (comma-separated).
+	 *
 	 * [--site_user=<value>]
 	 * : Only list the sites with this user.
 	 *
 	 * [--site-path=<path>]
 	 * : Filter by path. Avoids conflict with the global `--path` parameter.
 	 *
-	 * [--blog_id=<blog_id>]
-	 * : Filter by site ID.
+	 * [--path__in=<value>]
+	 * : Only list the sites with these paths (comma-separated).
+	 *
+	 * [--path__not_in=<value>]
+	 * : Exclude the sites with these paths (comma-separated).
+	 *
+	 * [--blog_id=<blog_id>|ID]
+	 * : Filter by site ID. `--ID` is WP_Site_Query's name for the same filter
+	 * and is accepted as an alias.
 	 *
 	 * [--site_id=<site_id>]
-	 * : Filter by the ID of the network the site belongs to. `--network` is an
-	 * alias for this, and takes precedence when both are given.
+	 * : Filter by the ID of the network the site belongs to. `--network` and
+	 * `--network_id` are aliases for this; `--network` takes precedence when
+	 * more than one is given.
+	 *
+	 * [--network_id=<network_id>]
+	 * : Filter by the ID of the network the site belongs to.
+	 *
+	 * [--network__in=<value>]
+	 * : Only list the sites belonging to these network IDs (comma-separated).
+	 *
+	 * [--network__not_in=<value>]
+	 * : Exclude the sites belonging to these network IDs (comma-separated).
 	 *
 	 * [--domain=<domain>]
 	 * : Filter by domain.
+	 *
+	 * [--domain__in=<value>]
+	 * : Only list the sites with these domains (comma-separated).
+	 *
+	 * [--domain__not_in=<value>]
+	 * : Exclude the sites with these domains (comma-separated).
 	 *
 	 * [--registered=<date>]
 	 * : Filter by the date the site was registered. Accepts a timestamp or a
@@ -1037,6 +1062,62 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * [--lang_id=<lang_id>]
 	 * : Filter by language ID.
+	 *
+	 * [--lang__in=<value>]
+	 * : Only list the sites with these language IDs (comma-separated).
+	 *
+	 * [--lang__not_in=<value>]
+	 * : Exclude the sites with these language IDs (comma-separated).
+	 *
+	 * [--search=<string>]
+	 * : Only list the sites matching this search term. Searches the domain and
+	 * path columns unless `--search_columns` narrows it.
+	 *
+	 * [--search_columns=<columns>]
+	 * : Comma-separated list of columns `--search` looks in. Accepts 'domain'
+	 * and 'path'.
+	 *
+	 * [--meta_key=<meta_key>]
+	 * : Filter by this site meta key.
+	 *
+	 * [--meta_value=<meta_value>]
+	 * : Filter by this site meta value. Used together with `--meta_key`.
+	 *
+	 * [--meta_compare=<meta_compare>]
+	 * : Operator to test the meta value against. Accepts the operators
+	 * WP_Meta_Query supports, such as '=', '!=', 'LIKE' or 'IN'.
+	 *
+	 * [--meta_type=<meta_type>]
+	 * : Cast the meta value to this type, such as 'NUMERIC' or 'DATE'.
+	 *
+	 * [--number=<number>]
+	 * : Limit the number of sites returned.
+	 *
+	 * [--offset=<offset>]
+	 * : Number of sites to skip. Used together with `--number`.
+	 *
+	 * [--no_found_rows=<no_found_rows>]
+	 * : Whether to skip counting the total rows the query matches. Accepts 1 or 0.
+	 *
+	 * [--update_site_cache=<update_site_cache>]
+	 * : Whether to prime the object cache with the sites found. Accepts 1 or 0.
+	 * Turning it off saves work when listing a large network once.
+	 *
+	 * [--update_site_meta_cache=<update_site_meta_cache>]
+	 * : Whether to prime the object cache with the site meta of the sites found.
+	 * Accepts 1 or 0.
+	 *
+	 * [--orderby=<field>]
+	 * : Order the results by this field, such as 'blog_id', 'domain', 'path',
+	 * 'registered', 'last_updated' or 'site__in'.
+	 *
+	 * [--order=<order>]
+	 * : Whether to order the results ascending or descending.
+	 * ---
+	 * options:
+	 *   - asc
+	 *   - desc
+	 * ---
 	 *
 	 * [--field=<field>]
 	 * : Prints the value of a single field for each site.
@@ -1117,10 +1198,13 @@ class Site_Command extends CommandWithDBObject {
 		//
 		// 'count' is withheld deliberately: it makes get_sites() return an integer
 		// rather than a list, and '--format=count' is how this command spells it.
+		// 'meta_query' and 'date_query' are withheld because they are nested arrays
+		// with no command-line spelling; the meta_* and date arguments above cover
+		// what can be expressed here.
 		$query_args = array_diff_key(
 			$assoc_args,
 			array_flip(
-				[ 'format', 'fields', 'field', 'count', 'blog_id', 'site_id', 'site_user', 'site-path', 'network', 'registered', 'last_updated' ]
+				[ 'format', 'fields', 'field', 'count', 'meta_query', 'date_query', 'blog_id', 'site_id', 'site_user', 'site-path', 'network', 'registered', 'last_updated' ]
 			)
 		);
 
@@ -1131,6 +1215,16 @@ class Site_Command extends CommandWithDBObject {
 
 		if ( isset( $assoc_args['site__in'] ) ) {
 			$query_args['site__in'] = array_map( 'trim', explode( ',', $assoc_args['site__in'] ) );
+		}
+
+		// WP_Site_Query reads these through is_array() or array_intersect(), so a
+		// comma-separated string reaches them as a value they cannot use: the domain
+		// and path clauses are skipped without a word, and 'search_columns' is fatal.
+		// Splitting them here is what makes them mean anything from the command line.
+		foreach ( [ 'domain__in', 'domain__not_in', 'path__in', 'path__not_in', 'search_columns' ] as $list_arg ) {
+			if ( isset( $assoc_args[ $list_arg ] ) && ! is_array( $assoc_args[ $list_arg ] ) ) {
+				$query_args[ $list_arg ] = array_map( 'trim', explode( ',', (string) $assoc_args[ $list_arg ] ) );
+			}
 		}
 
 		if ( isset( $assoc_args['site_id'] ) ) {

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -1072,7 +1072,8 @@ class Site_Command extends CommandWithDBObject {
 	 * and 'path'.
 	 *
 	 * [--meta_key=<meta_key>]
-	 * : Filter by this site meta key.
+	 * : Filter by this site meta key. The site meta arguments need WordPress 5.1
+	 * or later, which is where multisite gained the table they read.
 	 *
 	 * [--meta_value=<meta_value>]
 	 * : Filter by this site meta value. Used together with `--meta_key`.
@@ -1290,7 +1291,13 @@ class Site_Command extends CommandWithDBObject {
 
 			$query_args['date_query'] = empty( $given )
 				? $date_query
-				: array_merge( [ 'relation' => 'AND', $given ], $date_query );
+				: array_merge(
+					[
+						'relation' => 'AND',
+						$given,
+					],
+					$date_query
+				);
 		}
 
 		if ( isset( $assoc_args['site_user'] ) ) {

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -982,8 +982,10 @@ class Site_Command extends CommandWithDBObject {
 	 *
 	 * ## OPTIONS
 	 *
-	 * [--network=<id>]
-	 * : The network to which the sites belong.
+	 * [--network=<id>|site_id|network_id]
+	 * : The network to which the sites belong. `--site_id` is the name of the
+	 * column this filters, `--network_id` is WP_Site_Query's name for it, and
+	 * both are accepted as aliases. `--network` wins when more than one is given.
 	 *
 	 * [--<field>=<value>]
 	 * : Filter by one or more fields (see "Available Fields" section), or pass any
@@ -1013,14 +1015,6 @@ class Site_Command extends CommandWithDBObject {
 	 * [--blog_id=<blog_id>|ID]
 	 * : Filter by site ID. `--ID` is WP_Site_Query's name for the same filter
 	 * and is accepted as an alias.
-	 *
-	 * [--site_id=<site_id>]
-	 * : Filter by the ID of the network the site belongs to. `--network` and
-	 * `--network_id` are aliases for this; `--network` takes precedence when
-	 * more than one is given.
-	 *
-	 * [--network_id=<network_id>]
-	 * : Filter by the ID of the network the site belongs to.
 	 *
 	 * [--network__in=<value>]
 	 * : Only list the sites belonging to these network IDs (comma-separated).
@@ -1253,11 +1247,10 @@ class Site_Command extends CommandWithDBObject {
 			}
 		}
 
-		if ( isset( $assoc_args['site_id'] ) ) {
-			$query_args['network_id'] = $assoc_args['site_id'];
-		}
-
-		// '--network' has always taken precedence over '--site_id'.
+		// '--site_id' and '--network_id' are aliases of '--network', so they have
+		// already been resolved to it by the time the command runs. wp-cli lets the
+		// canonical name win when more than one is given, which is the precedence
+		// '--network' has always had over '--site_id'.
 		if ( isset( $assoc_args['network'] ) ) {
 			$query_args['network_id'] = $assoc_args['network'];
 		}
@@ -1286,11 +1279,18 @@ class Site_Command extends CommandWithDBObject {
 		// A '--date_query' of its own is kept rather than replaced, so '--registered'
 		// and '--last_updated' narrow it the way every other filter here narrows the
 		// result instead of quietly winning.
+		//
+		// It is nested a level down rather than appended to, because its 'relation'
+		// governs whatever shares its list: an 'OR' would reach the clauses added
+		// here and match a site that satisfies neither half of what was asked for.
 		if ( ! empty( $date_query ) ) {
-			$given                    = isset( $query_args['date_query'] ) && is_array( $query_args['date_query'] )
+			$given = isset( $query_args['date_query'] ) && is_array( $query_args['date_query'] )
 				? $query_args['date_query']
 				: [];
-			$query_args['date_query'] = array_merge( $given, $date_query );
+
+			$query_args['date_query'] = empty( $given )
+				? $date_query
+				: array_merge( [ 'relation' => 'AND', $given ], $date_query );
 		}
 
 		if ( isset( $assoc_args['site_user'] ) ) {


### PR DESCRIPTION
Follows #639, which handed every unrecognised argument to `WP_Site_Query` and so left the command accepting a good deal more than it described. The aim here is a single property: **an argument works if and only if it is documented**, in both directions.

Writing the set down is what turned up the problems. Five arguments were reachable but did not do what their name says, and documenting them as they stood would have promised behaviour that never happens — the silent no-op that wp-cli/wp-cli#5286 is about.

## What was broken

| Argument | Behaviour | Why |
|---|---|---|
| `domain__in`, `domain__not_in` | silently ignored | read through `is_array()`, which a command-line string never satisfies |
| `path__in`, `path__not_in` | silently ignored | same |
| `search_columns` | fatal `TypeError` | reaches `array_intersect()` unguarded |

Measured rather than assumed — every value below is a string, which is all the command line can hand over:

```
domain__in     = example.com  -> 3 sites (unfiltered is also 3)
domain__not_in = example.com  -> 3 sites
path__in       = /alpha/      -> 3 sites
path__not_in   = /alpha/      -> 3 sites
search_columns = domain       -> THROWS: TypeError
```

They are split on commas before the query runs, which is what makes them mean anything here.

## `meta_query` and `date_query`

These are nested arrays, so no flat string can describe one. `Utils\parse_shell_arrays()` is how this package already takes such arguments — `wp comment create --comment_meta` and `wp user update --meta_input` both use it — so they are given the same way:

```
$ wp site list --meta_query='[{"key":"colour","value":"blue"}]'
$ wp site list --date_query='[{"column":"registered","after":"2020-01-01"}]'
```

`parse_shell_arrays()` deliberately leaves a value that is not JSON alone, which would put a string where `WP_Site_Query` expects an array and have it ignored without a word, so that case is an error instead.

A `--date_query` given directly is **kept** when `--registered` or `--last_updated` are given as well, so those narrow it rather than quietly winning. It is nested a level down under an outer `AND` rather than appended to, because a date query's `relation` governs whatever shares its list — appending let an `OR` reach the clauses `--registered` adds and match a site satisfying neither half of the request. Thanks to @coderabbitai for catching that; the reproduction and fix are in the thread.

## Aliases

Two filters had more than one name for the same thing, so they are declared as aliases rather than separate entries:

- `[--blog_id=<blog_id>|ID]` — `ID` is `WP_Site_Query`'s name for this command's `--blog_id`.
- `[--network=<id>|site_id|network_id]` — `site_id` is the column, `network_id` is `WP_Site_Query`'s name. `--network` stays canonical because wp-cli lets the canonical name win when several are given, which is the precedence `--network` has always had over `--site_id`.

## What is left withheld

`count` alone, and it has to be: it makes `get_sites()` return an integer rather than a list, and `--format=count` is how this command spells that.

Every other `WP_Site_Query` argument is documented, across 42 option entries covering 44 names. Nothing the command accepts is left undescribed, and nothing described fails to work.

The site meta filters need WordPress 5.1, which is where multisite gained the table they read and `WP_Site_Query` gained the `meta_*` parameters; the docblock says so and their scenario is tagged for it. Everything else here dates from 4.6, or 4.8 for the `lang_*` filters.

## Why the exactness matters

wp-cli/wp-cli#6392 would reject an argument that is undocumented but within edit distance 2 of one that is documented. Checked against the full query-var list:

```
WP_Site_Query vars: 37 | documented names: 44
withheld: count (changes the return type)
reachable but undocumented: 0
No collisions.
```

`--lang__in` was the specific case raised on that PR; it is documented now, so it works and does not warn.

## Testing

Two scenarios added, covering the newly working list arguments, the JSON arguments, the date-query nesting, the invalid-JSON errors, and the site meta filters.

| Backend | Result |
|---|---|
| MariaDB 10.11 | 40 scenarios, 568 steps, all passed |
| SQLite 3.45 | 40 scenarios, 568 steps, all passed |

Each new assertion was checked against the regression it is meant to catch, by reverting only the source change:

- Dropping the comma split makes `--path__in=/alpha/,/beta/` return all three sites instead of two.
- Restoring the flat date-query merge makes the `OR` assertions return 1 instead of 0.

That second check earned its keep twice. The first merge assertion passed either way — both paths returned 0 for the case it used — so it proved nothing until it was rewritten. The rewritten one still used the default `AND` relation, which is exactly why the `OR` defect got through to review.

PHPCS clean. PHPStan back to the `origin/main` total with the same two pre-existing `Site_Command.php` findings; assigning `parse_shell_arrays()` straight back to `$assoc_args` widens it to `mixed` and cascades five errors into the `explode`, `get_check()` and `array_map` calls downstream, so the decoded value goes into the query arguments instead.

## Two judgement calls

Both easy to change if you would rather they went the other way:

- `--registered`/`--last_updated` **narrow** a supplied `--date_query` rather than replacing it.
- The cache and paging knobs (`no_found_rows`, `update_site_cache`, `update_site_meta_cache`) are documented as "Accepts 1 or 0", matching the existing boolean filters, rather than being withheld as internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SSZzqMJRDTiLiDxQEPYcL