### PR TITLE
Stop documenting 'filter' as an available field

### DIFF
--- a/README.md
+++ b/README.md
@@ -3210,7 +3210,6 @@ These fields are optionally available:
 * post_type
 * post_mime_type
 * comment_count
-* filter
 * url
 
 **EXAMPLES**
@@ -8076,7 +8075,6 @@ These fields are optionally available:
 * caps
 * cap_key
 * allcaps
-* filter
 * url
 
 **EXAMPLES**

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -668,7 +668,6 @@ class Post_Command extends CommandWithDBObject {
 	 * * post_type
 	 * * post_mime_type
 	 * * comment_count
-	 * * filter
 	 * * url
 	 *
 	 * ## EXAMPLES

--- a/src/User_Command.php
+++ b/src/User_Command.php
@@ -115,7 +115,6 @@ class User_Command extends CommandWithDBObject {
 	 * * caps
 	 * * cap_key
 	 * * allcaps
-	 * * filter
 	 * * url
 	 *
 	 * ## EXAMPLES


### PR DESCRIPTION
`filter` is a property of `WP_Post` and `WP_User`, not a column of either table. Core's own docblock says so: *"Stores the post object's sanitization level. Does not correspond to a DB field."* It holds `raw`, `edit`, `display` and so on — how the object was sanitized, nothing about the post or the user.

In practice it is a constant:

| Command | What `filter` prints |
| --- | --- |
| `wp post list` | `raw`, for every row |
| `wp user list` | empty, for every row |
| `wp post get` | never shown |

`wp post get` has never displayed it, so advertising it only for the list commands was inconsistent as well as useless.

This drops it from the documented fields on `wp post list` and `wp user list` and leaves the commands themselves alone. The property is still on the objects, so asking for it by name still yields what it always did — nothing advertises it any more.

### The field list was never exhaustive

Worth knowing when reading this diff: "documented" and "works" have never been the same set for these commands. `WP_Post` resolves anything it does not declare through `__isset()`/`__get()`, so all of the following work as fields on `wp post list` today, and none of them are listed under AVAILABLE FIELDS:

| Field | Result today | Documented |
| --- | --- | --- |
| `post_category` | `[1]` | no |
| `tags_input` | works | no |
| `page_template` | works | no |
| `ancestors` | works | no |
| any post meta key | e.g. `my_meta` → `hello` | no |

So AVAILABLE FIELDS is the useful subset rather than a whitelist, and removing an entry from it says "this is not worth reaching for" rather than "this no longer resolves". `filter` simply joins the group above.

### Why documentation only

I first tried actually suppressing it, and that turned out to be the wrong trade. Removing it from a `WP_Post` means either unsetting the property or building an array of the object's properties, and both cost more than they are worth:

- `unset( $post->filter )` does not remove the field. `property_exists()` still returns `true` for a declared property after unsetting it, so the formatter still reports it accessible; and `WP_Post::__isset()` falls through to `metadata_exists( 'post', $this->ID, $key )`, so the name becomes a post-meta lookup — a query per row, returning a post meta value literally named `filter` if one existed.
- `get_object_vars( $post )` drops every field in the table above. `wp post list --fields=ID,post_category` returns `[1]` today and would return an empty column with a warning.

`wp post get` lacks those magic fields precisely because it does build an array, so making `list` match `get` would mean `list` losing something real. Not worth it to hide a field that no longer appears in the docs.

Refs wp-cli/wp-cli#5286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `wp post list` and `wp user list` documentation to remove `filter` from the listed optional fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->