### PR TITLE
Document the remaining WP_Query arguments `wp post list` accepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3169,7 +3169,8 @@ Only shows post types marked as post by default.
 
 	[--title=<title>|post_title]
 		Filter by post title, matched in full. `--post_title` is the name of the
-		column this filters and is accepted as an alias.
+		column this filters and is accepted as an alias. Needs WordPress 4.4 or
+		later.
 
 	[--name=<slug>|post_name]
 		Filter by post slug. `--post_name` is the name of the column this filters
@@ -3222,7 +3223,7 @@ Only shows post types marked as post by default.
 		Filter by ping status. Accepts 'open' or 'closed'.
 
 	[--comment_count=<comment_count>]
-		Filter by number of comments.
+		Filter by number of comments. Needs WordPress 4.9 or later.
 
 	[--s=<string>]
 		Only list the posts matching this search term.
@@ -3275,7 +3276,8 @@ Only shows post types marked as post by default.
 
 	[--post_name__in=<slugs>]
 		Only list the posts with these slugs (comma-separated). Unlike `--name`
-		this is not a single-post query, so it reaches drafts as well.
+		this is not a single-post query, so it reaches drafts as well. Needs
+		WordPress 4.4 or later.
 
 	[--post_parent__in=<ids>]
 		Only list the posts whose parent is one of these IDs (comma-separated).
@@ -3347,7 +3349,7 @@ Only shows post types marked as post by default.
 
 	[--search_columns=<columns>]
 		Comma-separated list of columns `--s` looks in. Accepts 'post_title',
-		'post_excerpt' and 'post_content'.
+		'post_excerpt' and 'post_content'. Needs WordPress 6.2 or later.
 
 	[--perm=<perm>]
 		Filter by what the current user may do with the post. Accepts

--- a/README.md
+++ b/README.md
@@ -3150,7 +3150,7 @@ wp post get <id> [--field=<field>] [--fields=<fields>] [--format=<format>]
 Gets a list of posts.
 
 ~~~
-wp post list [--<field>=<value>] [--p=<id>|ID] [--title=<title>|post_title] [--name=<slug>|post_name] [--author=<author>|post_author] [--author_name=<author_name>] [--cat=<cat>] [--category_name=<category_name>] [--tag=<tag>] [--post_type=<post_type>] [--post_status=<post_status>] [--post_parent=<post_parent>] [--post_mime_type=<post_mime_type>] [--menu_order=<menu_order>] [--comment_status=<comment_status>] [--ping_status=<ping_status>] [--comment_count=<comment_count>] [--s=<string>] [--year=<year>] [--monthnum=<monthnum>] [--day=<day>] [--hour=<hour>] [--minute=<minute>] [--second=<second>] [--m=<yearmonth>] [--w=<week>] [--meta_key=<meta_key>] [--meta_value=<meta_value>] [--has_password=<has_password>] [--post_password=<post_password>] [--orderby=<orderby>] [--order=<order>] [--field=<field>] [--fields=<fields>] [--format=<format>]
+wp post list [--<field>=<value>] [--p=<id>|ID] [--title=<title>|post_title] [--name=<slug>|post_name] [--author=<author>|post_author] [--author_name=<author_name>] [--cat=<cat>] [--category_name=<category_name>] [--tag=<tag>] [--post_type=<post_type>] [--post_status=<post_status>] [--post_parent=<post_parent>] [--post_mime_type=<post_mime_type>] [--menu_order=<menu_order>] [--comment_status=<comment_status>] [--ping_status=<ping_status>] [--comment_count=<comment_count>] [--s=<string>] [--year=<year>] [--monthnum=<monthnum>] [--day=<day>] [--hour=<hour>] [--minute=<minute>] [--second=<second>] [--m=<yearmonth>] [--w=<week>] [--meta_key=<meta_key>] [--meta_value=<meta_value>] [--orderby=<orderby>] [--order=<order>] [--post__in=<ids>] [--post__not_in=<ids>] [--post_name__in=<slugs>] [--post_parent__in=<ids>] [--post_parent__not_in=<ids>] [--author__in=<ids>] [--author__not_in=<ids>] [--category__in=<ids>] [--category__and=<ids>] [--category__not_in=<ids>] [--tag_id=<tag_id>] [--tag__in=<ids>] [--tag__and=<ids>] [--tag__not_in=<ids>] [--tag_slug__in=<slugs>] [--tag_slug__and=<slugs>] [--page_id=<page_id>] [--pagename=<pagename>] [--attachment_id=<attachment_id>] [--date_query=<json>] [--meta_query=<json>] [--tax_query=<json>] [--meta_compare=<meta_compare>] [--sentence=<sentence>] [--exact=<exact>] [--search_columns=<columns>] [--perm=<perm>] [--posts_per_page=<number>] [--paged=<paged>] [--offset=<offset>] [--nopaging=<nopaging>] [--field=<field>] [--fields=<fields>] [--format=<format>]
 ~~~
 
 Display posts based on all arguments supported by [WP_Query()](https://developer.wordpress.org/reference/classes/wp_query/).
@@ -3259,12 +3259,6 @@ Only shows post types marked as post by default.
 		Filter by this meta value. Needs `--meta_key` to say which key it
 		belongs to.
 
-	[--has_password=<has_password>]
-		Filter by whether the post has a password. Accepts 1 or 0.
-
-	[--post_password=<post_password>]
-		Filter by the post's password, matched in full.
-
 	[--orderby=<orderby>]
 		Order the results by this field. Accepts what WP_Query accepts, e.g.
 		'date', 'title', 'ID', 'menu_order', 'rand', or 'meta_value' alongside
@@ -3272,6 +3266,106 @@ Only shows post types marked as post by default.
 
 	[--order=<order>]
 		Direction to order by. Accepts 'ASC' or 'DESC'.
+
+	[--post__in=<ids>]
+		Only list the posts with these IDs (comma-separated).
+
+	[--post__not_in=<ids>]
+		Exclude the posts with these IDs (comma-separated).
+
+	[--post_name__in=<slugs>]
+		Only list the posts with these slugs (comma-separated). Unlike `--name`
+		this is not a single-post query, so it reaches drafts as well.
+
+	[--post_parent__in=<ids>]
+		Only list the posts whose parent is one of these IDs (comma-separated).
+
+	[--post_parent__not_in=<ids>]
+		Exclude the posts whose parent is one of these IDs (comma-separated).
+
+	[--author__in=<ids>]
+		Only list the posts by these author IDs (comma-separated).
+
+	[--author__not_in=<ids>]
+		Exclude the posts by these author IDs (comma-separated).
+
+	[--category__in=<ids>]
+		Only list the posts in these category IDs (comma-separated).
+
+	[--category__and=<ids>]
+		Only list the posts in all of these category IDs (comma-separated).
+
+	[--category__not_in=<ids>]
+		Exclude the posts in these category IDs (comma-separated).
+
+	[--tag_id=<tag_id>]
+		Filter by tag ID.
+
+	[--tag__in=<ids>]
+		Only list the posts with these tag IDs (comma-separated).
+
+	[--tag__and=<ids>]
+		Only list the posts with all of these tag IDs (comma-separated).
+
+	[--tag__not_in=<ids>]
+		Exclude the posts with these tag IDs (comma-separated).
+
+	[--tag_slug__in=<slugs>]
+		Only list the posts with these tag slugs (comma-separated).
+
+	[--tag_slug__and=<slugs>]
+		Only list the posts with all of these tag slugs (comma-separated).
+
+	[--page_id=<page_id>]
+		Filter by page ID. Needs `--post_type=page` to match anything.
+
+	[--pagename=<pagename>]
+		Filter by page slug. Needs `--post_type=page` to match anything.
+
+	[--attachment_id=<attachment_id>]
+		Filter by attachment ID. Needs `--post_type=attachment` to match
+		anything.
+
+	[--date_query=<json>]
+		Filter by a date query, given as JSON. See WP_Date_Query.
+
+	[--meta_query=<json>]
+		Filter by a meta query, given as JSON. See WP_Meta_Query.
+
+	[--tax_query=<json>]
+		Filter by a taxonomy query, given as JSON. See WP_Tax_Query.
+
+	[--meta_compare=<meta_compare>]
+		Operator to test `--meta_value` with, e.g. '=', '!=', '>' or 'LIKE'.
+
+	[--sentence=<sentence>]
+		Match `--s` as one phrase rather than as separate words. Accepts 1 or 0.
+
+	[--exact=<exact>]
+		Match `--s` against the whole column rather than part of it. Accepts 1
+		or 0.
+
+	[--search_columns=<columns>]
+		Comma-separated list of columns `--s` looks in. Accepts 'post_title',
+		'post_excerpt' and 'post_content'.
+
+	[--perm=<perm>]
+		Filter by what the current user may do with the post. Accepts
+		'readable' or 'editable'; pair it with the global `--user` argument,
+		since WP-CLI is no user by default.
+
+	[--posts_per_page=<number>]
+		How many posts to return. Defaults to -1, meaning every post.
+
+	[--paged=<paged>]
+		Which page of results to return, counted in `--posts_per_page` steps.
+
+	[--offset=<offset>]
+		How many posts to skip. Needs `--posts_per_page` set to something other
+		than -1, which otherwise takes precedence.
+
+	[--nopaging=<nopaging>]
+		Return every post, ignoring `--posts_per_page`. Accepts 1 or 0.
 
 	[--field=<field>]
 		Prints the value of a single field for each post.

--- a/README.md
+++ b/README.md
@@ -3169,8 +3169,7 @@ Only shows post types marked as post by default.
 
 	[--title=<title>|post_title]
 		Filter by post title, matched in full. `--post_title` is the name of the
-		column this filters and is accepted as an alias. Needs WordPress 4.4 or
-		later.
+		column this filters and is accepted as an alias.
 
 	[--name=<slug>|post_name]
 		Filter by post slug. `--post_name` is the name of the column this filters
@@ -3223,7 +3222,7 @@ Only shows post types marked as post by default.
 		Filter by ping status. Accepts 'open' or 'closed'.
 
 	[--comment_count=<comment_count>]
-		Filter by number of comments. Needs WordPress 4.9 or later.
+		Filter by number of comments.
 
 	[--s=<string>]
 		Only list the posts matching this search term.
@@ -3276,8 +3275,7 @@ Only shows post types marked as post by default.
 
 	[--post_name__in=<slugs>]
 		Only list the posts with these slugs (comma-separated). Unlike `--name`
-		this is not a single-post query, so it reaches drafts as well. Needs
-		WordPress 4.4 or later.
+		this is not a single-post query, so it reaches drafts as well.
 
 	[--post_parent__in=<ids>]
 		Only list the posts whose parent is one of these IDs (comma-separated).

--- a/README.md
+++ b/README.md
@@ -3150,7 +3150,7 @@ wp post get <id> [--field=<field>] [--fields=<fields>] [--format=<format>]
 Gets a list of posts.
 
 ~~~
-wp post list [--<field>=<value>] [--p=<id>|ID] [--title=<title>|post_title] [--name=<slug>|post_name] [--author=<author>|post_author] [--author_name=<author_name>] [--cat=<cat>] [--category_name=<category_name>] [--tag=<tag>] [--post_type=<post_type>] [--post_status=<post_status>] [--post_parent=<post_parent>] [--post_mime_type=<post_mime_type>] [--menu_order=<menu_order>] [--comment_status=<comment_status>] [--ping_status=<ping_status>] [--comment_count=<comment_count>] [--s=<string>] [--year=<year>] [--monthnum=<monthnum>] [--day=<day>] [--m=<yearmonth>] [--w=<week>] [--field=<field>] [--fields=<fields>] [--format=<format>]
+wp post list [--<field>=<value>] [--p=<id>|ID] [--title=<title>|post_title] [--name=<slug>|post_name] [--author=<author>|post_author] [--author_name=<author_name>] [--cat=<cat>] [--category_name=<category_name>] [--tag=<tag>] [--post_type=<post_type>] [--post_status=<post_status>] [--post_parent=<post_parent>] [--post_mime_type=<post_mime_type>] [--menu_order=<menu_order>] [--comment_status=<comment_status>] [--ping_status=<ping_status>] [--comment_count=<comment_count>] [--s=<string>] [--year=<year>] [--monthnum=<monthnum>] [--day=<day>] [--hour=<hour>] [--minute=<minute>] [--second=<second>] [--m=<yearmonth>] [--w=<week>] [--meta_key=<meta_key>] [--meta_value=<meta_value>] [--has_password=<has_password>] [--post_password=<post_password>] [--orderby=<orderby>] [--order=<order>] [--field=<field>] [--fields=<fields>] [--format=<format>]
 ~~~
 
 Display posts based on all arguments supported by [WP_Query()](https://developer.wordpress.org/reference/classes/wp_query/).
@@ -3236,11 +3236,42 @@ Only shows post types marked as post by default.
 	[--day=<day>]
 		Filter by day of the month, 1 to 31.
 
+	[--hour=<hour>]
+		Filter by hour, 0 to 23.
+
+	[--minute=<minute>]
+		Filter by minute, 0 to 59.
+
+	[--second=<second>]
+		Filter by second, 0 to 59.
+
 	[--m=<yearmonth>]
 		Filter by year and month together, e.g. 202401.
 
 	[--w=<week>]
 		Filter by week of the year, 0 to 53.
+
+	[--meta_key=<meta_key>]
+		Filter by posts having this meta key. Pair it with `--meta_value` to
+		filter on the value as well.
+
+	[--meta_value=<meta_value>]
+		Filter by this meta value. Needs `--meta_key` to say which key it
+		belongs to.
+
+	[--has_password=<has_password>]
+		Filter by whether the post has a password. Accepts 1 or 0.
+
+	[--post_password=<post_password>]
+		Filter by the post's password, matched in full.
+
+	[--orderby=<orderby>]
+		Order the results by this field. Accepts what WP_Query accepts, e.g.
+		'date', 'title', 'ID', 'menu_order', 'rand', or 'meta_value' alongside
+		`--meta_key`.
+
+	[--order=<order>]
+		Direction to order by. Accepts 'ASC' or 'DESC'.
 
 	[--field=<field>]
 		Prints the value of a single field for each post.

--- a/README.md
+++ b/README.md
@@ -3150,7 +3150,7 @@ wp post get <id> [--field=<field>] [--fields=<fields>] [--format=<format>]
 Gets a list of posts.
 
 ~~~
-wp post list [--<field>=<value>] [--p=<id>|ID] [--title=<title>|post_title] [--name=<slug>|post_name] [--author=<author>|post_author] [--author_name=<author_name>] [--post_type=<post_type>] [--post_status=<post_status>] [--post_parent=<post_parent>] [--post_mime_type=<post_mime_type>] [--menu_order=<menu_order>] [--comment_status=<comment_status>] [--ping_status=<ping_status>] [--comment_count=<comment_count>] [--s=<string>] [--year=<year>] [--monthnum=<monthnum>] [--day=<day>] [--m=<yearmonth>] [--w=<week>] [--field=<field>] [--fields=<fields>] [--format=<format>]
+wp post list [--<field>=<value>] [--p=<id>|ID] [--title=<title>|post_title] [--name=<slug>|post_name] [--author=<author>|post_author] [--author_name=<author_name>] [--cat=<cat>] [--category_name=<category_name>] [--tag=<tag>] [--post_type=<post_type>] [--post_status=<post_status>] [--post_parent=<post_parent>] [--post_mime_type=<post_mime_type>] [--menu_order=<menu_order>] [--comment_status=<comment_status>] [--ping_status=<ping_status>] [--comment_count=<comment_count>] [--s=<string>] [--year=<year>] [--monthnum=<monthnum>] [--day=<day>] [--m=<yearmonth>] [--w=<week>] [--field=<field>] [--fields=<fields>] [--format=<format>]
 ~~~
 
 Display posts based on all arguments supported by [WP_Query()](https://developer.wordpress.org/reference/classes/wp_query/).
@@ -3185,6 +3185,17 @@ Only shows post types marked as post by default.
 
 	[--author_name=<author_name>]
 		Filter by the 'user_nicename' of the post's author.
+
+	[--cat=<cat>]
+		Filter by category ID. Accepts a comma-separated list to match any of
+		them, and a negative ID excludes that category instead.
+
+	[--category_name=<category_name>]
+		Filter by category slug.
+
+	[--tag=<tag>]
+		Filter by tag slug. Accepts a comma-separated list to match any of them,
+		or a '+'-separated list to require all of them.
 
 	[--post_type=<post_type>]
 		Filter by post type. Defaults to 'post'. Accepts a comma-separated list,

--- a/features/post.feature
+++ b/features/post.feature
@@ -592,6 +592,7 @@ Feature: Manage WordPress posts
       {"block_version":1}
       """
 
+  @require-wp-4.4
   Scenario: Filtering by the wp_posts column names
     When I run `wp post create --post_title='Alpha' --post_status=publish --porcelain`
     Then STDOUT should be a number
@@ -781,7 +782,8 @@ Feature: Manage WordPress posts
       Hello world!
       """
 
-  Scenario: Filtering by lists, JSON queries and search columns
+  @require-wp-4.4
+  Scenario: Filtering by lists and JSON queries
     When I run `wp post create --post_title='Zebra Title' --post_content='nothing' --post_status=publish --porcelain`
     Then save STDOUT as {TITLED}
 
@@ -812,20 +814,7 @@ Feature: Manage WordPress posts
       Plain
       """
 
-    # --s searches every column; --search_columns narrows it.
     When I run `wp post list --s=zebra --format=count`
-    Then STDOUT should be:
-      """
-      2
-      """
-
-    When I run `wp post list --s=zebra --search_columns=post_title --field=post_title`
-    Then STDOUT should be:
-      """
-      Zebra Title
-      """
-
-    When I run `wp post list --s=zebra --search_columns=post_title,post_content --format=count`
     Then STDOUT should be:
       """
       2
@@ -855,4 +844,39 @@ Feature: Manage WordPress posts
     Then STDOUT should be:
       """
       3
+      """
+
+  # 'search_columns' is a WP_Query argument as of WordPress 6.2. Before that it
+  # is not recognised, so '--s' searches every column and the narrowing here
+  # would not happen.
+  @require-wp-6.2
+  Scenario: Narrowing a search to particular columns
+    When I run `wp post create --post_title='Zebra Title' --post_content='nothing' --post_status=publish --porcelain`
+    Then STDOUT should be a number
+
+    When I run `wp post create --post_title='Plain' --post_content='zebra in body' --post_status=publish --porcelain`
+    Then STDOUT should be a number
+
+    When I run `wp post list --s=zebra --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp post list --s=zebra --search_columns=post_title --field=post_title`
+    Then STDOUT should be:
+      """
+      Zebra Title
+      """
+
+    When I run `wp post list --s=zebra --search_columns=post_content --field=post_title`
+    Then STDOUT should be:
+      """
+      Plain
+      """
+
+    When I run `wp post list --s=zebra --search_columns=post_title,post_content --format=count`
+    Then STDOUT should be:
+      """
+      2
       """

--- a/features/post.feature
+++ b/features/post.feature
@@ -723,3 +723,72 @@ Feature: Manage WordPress posts
       """
       1
       """
+
+  Scenario: Filtering by meta, time of day, password and order
+    When I run `wp post create --post_title='Timed' --post_status=publish --post_date='2020-03-04 05:06:07' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {TIMED_ID}
+
+    When I run `wp post meta add {TIMED_ID} color blue`
+    Then STDOUT should not be empty
+
+    When I run `wp post create --post_title='Locked' --post_status=publish --post_password=secret --porcelain`
+    Then STDOUT should be a number
+
+    # Time of day, alongside the year/month/day filters already documented.
+    # Two units at once exercises the combined path; all three of hour, minute
+    # and second together is left out on purpose, because that path compares a
+    # DATE_FORMAT() string and the SQLite integration plugin does not emulate
+    # it the way MySQL does, so it matches nothing there.
+    When I run `wp post list --hour=5 --minute=6 --field=post_title`
+    Then STDOUT should be:
+      """
+      Timed
+      """
+
+    When I run `wp post list --second=7 --field=post_title`
+    Then STDOUT should be:
+      """
+      Timed
+      """
+
+    # A meta key on its own, then narrowed by its value.
+    When I run `wp post list --meta_key=color --field=post_title`
+    Then STDOUT should be:
+      """
+      Timed
+      """
+
+    When I run `wp post list --meta_key=color --meta_value=red --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `wp post list --has_password=1 --field=post_title`
+    Then STDOUT should be:
+      """
+      Locked
+      """
+
+    When I run `wp post list --post_password=secret --field=post_title`
+    Then STDOUT should be:
+      """
+      Locked
+      """
+
+    When I run `wp post list --orderby=title --order=ASC --field=post_title`
+    Then STDOUT should be:
+      """
+      Hello world!
+      Locked
+      Timed
+      """
+
+    When I run `wp post list --orderby=title --order=DESC --field=post_title`
+    Then STDOUT should be:
+      """
+      Timed
+      Locked
+      Hello world!
+      """

--- a/features/post.feature
+++ b/features/post.feature
@@ -688,3 +688,38 @@ Feature: Manage WordPress posts
       """
       {DOOMED_ID}
       """
+
+  Scenario: Filtering by category and tag
+    When I run `wp term create category 'Alpha Cat' --porcelain`
+    Then save STDOUT as {CAT_ID}
+
+    When I run `wp term create post_tag 'Alpha Tag' --slug=alpha-tag --porcelain`
+    Then save STDOUT as {TAG_ID}
+
+    When I run `wp post create --post_title='Tagged' --post_status=publish --post_category={CAT_ID} --tags_input=alpha-tag --porcelain`
+    Then STDOUT should be a number
+
+    When I run `wp post list --cat={CAT_ID} --format=count`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    # A negative ID excludes that category rather than selecting it.
+    When I run `wp post list --cat=-{CAT_ID} --field=post_title`
+    Then STDOUT should not contain:
+      """
+      Tagged
+      """
+
+    When I run `wp post list --tag=alpha-tag --format=count`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp post list --category_name=alpha-cat --format=count`
+    Then STDOUT should be:
+      """
+      1
+      """

--- a/features/post.feature
+++ b/features/post.feature
@@ -724,7 +724,7 @@ Feature: Manage WordPress posts
       1
       """
 
-  Scenario: Filtering by meta, time of day, password and order
+  Scenario: Filtering by meta, time of day and order
     When I run `wp post create --post_title='Timed' --post_status=publish --post_date='2020-03-04 05:06:07' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {TIMED_ID}
@@ -765,18 +765,6 @@ Feature: Manage WordPress posts
       0
       """
 
-    When I run `wp post list --has_password=1 --field=post_title`
-    Then STDOUT should be:
-      """
-      Locked
-      """
-
-    When I run `wp post list --post_password=secret --field=post_title`
-    Then STDOUT should be:
-      """
-      Locked
-      """
-
     When I run `wp post list --orderby=title --order=ASC --field=post_title`
     Then STDOUT should be:
       """
@@ -791,4 +779,80 @@ Feature: Manage WordPress posts
       Timed
       Locked
       Hello world!
+      """
+
+  Scenario: Filtering by lists, JSON queries and search columns
+    When I run `wp post create --post_title='Zebra Title' --post_content='nothing' --post_status=publish --porcelain`
+    Then save STDOUT as {TITLED}
+
+    When I run `wp post create --post_title='Plain' --post_name=plain --post_content='zebra in body' --post_status=publish --porcelain`
+    Then save STDOUT as {BODIED}
+
+    When I run `wp post meta add {TITLED} rank 5`
+    Then STDOUT should not be empty
+
+    # Arguments carrying '__' are split on commas before they reach WP_Query,
+    # which is what makes them usable from the command line at all.
+    When I run `wp post list --post__in={TITLED},{BODIED} --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp post list --post__not_in={TITLED},{BODIED} --format=count`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    # Unlike --name, this reaches a draft, because it is not a single-post query.
+    When I run `wp post list --post_name__in=plain --field=post_title`
+    Then STDOUT should be:
+      """
+      Plain
+      """
+
+    # --s searches every column; --search_columns narrows it.
+    When I run `wp post list --s=zebra --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp post list --s=zebra --search_columns=post_title --field=post_title`
+    Then STDOUT should be:
+      """
+      Zebra Title
+      """
+
+    When I run `wp post list --s=zebra --search_columns=post_title,post_content --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    # The nested queries are given as JSON, which this command decodes.
+    When I run `wp post list --meta_query='[{"key":"rank","value":"5"}]' --field=post_title`
+    Then STDOUT should be:
+      """
+      Zebra Title
+      """
+
+    When I run `wp post list --meta_key=rank --meta_value=4 --meta_compare=">" --field=post_title`
+    Then STDOUT should be:
+      """
+      Zebra Title
+      """
+
+    # --offset only means anything once --posts_per_page is bounded.
+    When I run `wp post list --posts_per_page=10 --offset=1 --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp post list --posts_per_page=1 --nopaging=1 --format=count`
+    Then STDOUT should be:
+      """
+      3
       """

--- a/features/post.feature
+++ b/features/post.feature
@@ -592,7 +592,6 @@ Feature: Manage WordPress posts
       {"block_version":1}
       """
 
-  @require-wp-4.4
   Scenario: Filtering by the wp_posts column names
     When I run `wp post create --post_title='Alpha' --post_status=publish --porcelain`
     Then STDOUT should be a number
@@ -782,7 +781,6 @@ Feature: Manage WordPress posts
       Hello world!
       """
 
-  @require-wp-4.4
   Scenario: Filtering by lists and JSON queries
     When I run `wp post create --post_title='Zebra Title' --post_content='nothing' --post_status=publish --porcelain`
     Then save STDOUT as {TITLED}

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -644,6 +644,17 @@ class Post_Command extends CommandWithDBObject {
 	 * [--author_name=<author_name>]
 	 * : Filter by the 'user_nicename' of the post's author.
 	 *
+	 * [--cat=<cat>]
+	 * : Filter by category ID. Accepts a comma-separated list to match any of
+	 * them, and a negative ID excludes that category instead.
+	 *
+	 * [--category_name=<category_name>]
+	 * : Filter by category slug.
+	 *
+	 * [--tag=<tag>]
+	 * : Filter by tag slug. Accepts a comma-separated list to match any of them,
+	 * or a '+'-separated list to require all of them.
+	 *
 	 * [--post_type=<post_type>]
 	 * : Filter by post type. Defaults to 'post'. Accepts a comma-separated list,
 	 * or 'any' for every type registered without 'exclude_from_search'.

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -694,11 +694,42 @@ class Post_Command extends CommandWithDBObject {
 	 * [--day=<day>]
 	 * : Filter by day of the month, 1 to 31.
 	 *
+	 * [--hour=<hour>]
+	 * : Filter by hour, 0 to 23.
+	 *
+	 * [--minute=<minute>]
+	 * : Filter by minute, 0 to 59.
+	 *
+	 * [--second=<second>]
+	 * : Filter by second, 0 to 59.
+	 *
 	 * [--m=<yearmonth>]
 	 * : Filter by year and month together, e.g. 202401.
 	 *
 	 * [--w=<week>]
 	 * : Filter by week of the year, 0 to 53.
+	 *
+	 * [--meta_key=<meta_key>]
+	 * : Filter by posts having this meta key. Pair it with `--meta_value` to
+	 * filter on the value as well.
+	 *
+	 * [--meta_value=<meta_value>]
+	 * : Filter by this meta value. Needs `--meta_key` to say which key it
+	 * belongs to.
+	 *
+	 * [--has_password=<has_password>]
+	 * : Filter by whether the post has a password. Accepts 1 or 0.
+	 *
+	 * [--post_password=<post_password>]
+	 * : Filter by the post's password, matched in full.
+	 *
+	 * [--orderby=<orderby>]
+	 * : Order the results by this field. Accepts what WP_Query accepts, e.g.
+	 * 'date', 'title', 'ID', 'menu_order', 'rand', or 'meta_value' alongside
+	 * `--meta_key`.
+	 *
+	 * [--order=<order>]
+	 * : Direction to order by. Accepts 'ASC' or 'DESC'.
 	 *
 	 * [--field=<field>]
 	 * : Prints the value of a single field for each post.

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -717,12 +717,6 @@ class Post_Command extends CommandWithDBObject {
 	 * : Filter by this meta value. Needs `--meta_key` to say which key it
 	 * belongs to.
 	 *
-	 * [--has_password=<has_password>]
-	 * : Filter by whether the post has a password. Accepts 1 or 0.
-	 *
-	 * [--post_password=<post_password>]
-	 * : Filter by the post's password, matched in full.
-	 *
 	 * [--orderby=<orderby>]
 	 * : Order the results by this field. Accepts what WP_Query accepts, e.g.
 	 * 'date', 'title', 'ID', 'menu_order', 'rand', or 'meta_value' alongside
@@ -730,6 +724,106 @@ class Post_Command extends CommandWithDBObject {
 	 *
 	 * [--order=<order>]
 	 * : Direction to order by. Accepts 'ASC' or 'DESC'.
+	 *
+	 * [--post__in=<ids>]
+	 * : Only list the posts with these IDs (comma-separated).
+	 *
+	 * [--post__not_in=<ids>]
+	 * : Exclude the posts with these IDs (comma-separated).
+	 *
+	 * [--post_name__in=<slugs>]
+	 * : Only list the posts with these slugs (comma-separated). Unlike `--name`
+	 * this is not a single-post query, so it reaches drafts as well.
+	 *
+	 * [--post_parent__in=<ids>]
+	 * : Only list the posts whose parent is one of these IDs (comma-separated).
+	 *
+	 * [--post_parent__not_in=<ids>]
+	 * : Exclude the posts whose parent is one of these IDs (comma-separated).
+	 *
+	 * [--author__in=<ids>]
+	 * : Only list the posts by these author IDs (comma-separated).
+	 *
+	 * [--author__not_in=<ids>]
+	 * : Exclude the posts by these author IDs (comma-separated).
+	 *
+	 * [--category__in=<ids>]
+	 * : Only list the posts in these category IDs (comma-separated).
+	 *
+	 * [--category__and=<ids>]
+	 * : Only list the posts in all of these category IDs (comma-separated).
+	 *
+	 * [--category__not_in=<ids>]
+	 * : Exclude the posts in these category IDs (comma-separated).
+	 *
+	 * [--tag_id=<tag_id>]
+	 * : Filter by tag ID.
+	 *
+	 * [--tag__in=<ids>]
+	 * : Only list the posts with these tag IDs (comma-separated).
+	 *
+	 * [--tag__and=<ids>]
+	 * : Only list the posts with all of these tag IDs (comma-separated).
+	 *
+	 * [--tag__not_in=<ids>]
+	 * : Exclude the posts with these tag IDs (comma-separated).
+	 *
+	 * [--tag_slug__in=<slugs>]
+	 * : Only list the posts with these tag slugs (comma-separated).
+	 *
+	 * [--tag_slug__and=<slugs>]
+	 * : Only list the posts with all of these tag slugs (comma-separated).
+	 *
+	 * [--page_id=<page_id>]
+	 * : Filter by page ID. Needs `--post_type=page` to match anything.
+	 *
+	 * [--pagename=<pagename>]
+	 * : Filter by page slug. Needs `--post_type=page` to match anything.
+	 *
+	 * [--attachment_id=<attachment_id>]
+	 * : Filter by attachment ID. Needs `--post_type=attachment` to match
+	 * anything.
+	 *
+	 * [--date_query=<json>]
+	 * : Filter by a date query, given as JSON. See WP_Date_Query.
+	 *
+	 * [--meta_query=<json>]
+	 * : Filter by a meta query, given as JSON. See WP_Meta_Query.
+	 *
+	 * [--tax_query=<json>]
+	 * : Filter by a taxonomy query, given as JSON. See WP_Tax_Query.
+	 *
+	 * [--meta_compare=<meta_compare>]
+	 * : Operator to test `--meta_value` with, e.g. '=', '!=', '>' or 'LIKE'.
+	 *
+	 * [--sentence=<sentence>]
+	 * : Match `--s` as one phrase rather than as separate words. Accepts 1 or 0.
+	 *
+	 * [--exact=<exact>]
+	 * : Match `--s` against the whole column rather than part of it. Accepts 1
+	 * or 0.
+	 *
+	 * [--search_columns=<columns>]
+	 * : Comma-separated list of columns `--s` looks in. Accepts 'post_title',
+	 * 'post_excerpt' and 'post_content'.
+	 *
+	 * [--perm=<perm>]
+	 * : Filter by what the current user may do with the post. Accepts
+	 * 'readable' or 'editable'; pair it with the global `--user` argument,
+	 * since WP-CLI is no user by default.
+	 *
+	 * [--posts_per_page=<number>]
+	 * : How many posts to return. Defaults to -1, meaning every post.
+	 *
+	 * [--paged=<paged>]
+	 * : Which page of results to return, counted in `--posts_per_page` steps.
+	 *
+	 * [--offset=<offset>]
+	 * : How many posts to skip. Needs `--posts_per_page` set to something other
+	 * than -1, which otherwise takes precedence.
+	 *
+	 * [--nopaging=<nopaging>]
+	 * : Return every post, ignoring `--posts_per_page`. Accepts 1 or 0.
 	 *
 	 * [--field=<field>]
 	 * : Prints the value of a single field for each post.

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -627,7 +627,8 @@ class Post_Command extends CommandWithDBObject {
 	 *
 	 * [--title=<title>|post_title]
 	 * : Filter by post title, matched in full. `--post_title` is the name of the
-	 * column this filters and is accepted as an alias.
+	 * column this filters and is accepted as an alias. Needs WordPress 4.4 or
+	 * later.
 	 *
 	 * [--name=<slug>|post_name]
 	 * : Filter by post slug. `--post_name` is the name of the column this filters
@@ -680,7 +681,7 @@ class Post_Command extends CommandWithDBObject {
 	 * : Filter by ping status. Accepts 'open' or 'closed'.
 	 *
 	 * [--comment_count=<comment_count>]
-	 * : Filter by number of comments.
+	 * : Filter by number of comments. Needs WordPress 4.9 or later.
 	 *
 	 * [--s=<string>]
 	 * : Only list the posts matching this search term.
@@ -733,7 +734,8 @@ class Post_Command extends CommandWithDBObject {
 	 *
 	 * [--post_name__in=<slugs>]
 	 * : Only list the posts with these slugs (comma-separated). Unlike `--name`
-	 * this is not a single-post query, so it reaches drafts as well.
+	 * this is not a single-post query, so it reaches drafts as well. Needs
+	 * WordPress 4.4 or later.
 	 *
 	 * [--post_parent__in=<ids>]
 	 * : Only list the posts whose parent is one of these IDs (comma-separated).
@@ -805,7 +807,7 @@ class Post_Command extends CommandWithDBObject {
 	 *
 	 * [--search_columns=<columns>]
 	 * : Comma-separated list of columns `--s` looks in. Accepts 'post_title',
-	 * 'post_excerpt' and 'post_content'.
+	 * 'post_excerpt' and 'post_content'. Needs WordPress 6.2 or later.
 	 *
 	 * [--perm=<perm>]
 	 * : Filter by what the current user may do with the post. Accepts

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -627,8 +627,7 @@ class Post_Command extends CommandWithDBObject {
 	 *
 	 * [--title=<title>|post_title]
 	 * : Filter by post title, matched in full. `--post_title` is the name of the
-	 * column this filters and is accepted as an alias. Needs WordPress 4.4 or
-	 * later.
+	 * column this filters and is accepted as an alias.
 	 *
 	 * [--name=<slug>|post_name]
 	 * : Filter by post slug. `--post_name` is the name of the column this filters
@@ -681,7 +680,7 @@ class Post_Command extends CommandWithDBObject {
 	 * : Filter by ping status. Accepts 'open' or 'closed'.
 	 *
 	 * [--comment_count=<comment_count>]
-	 * : Filter by number of comments. Needs WordPress 4.9 or later.
+	 * : Filter by number of comments.
 	 *
 	 * [--s=<string>]
 	 * : Only list the posts matching this search term.
@@ -734,8 +733,7 @@ class Post_Command extends CommandWithDBObject {
 	 *
 	 * [--post_name__in=<slugs>]
 	 * : Only list the posts with these slugs (comma-separated). Unlike `--name`
-	 * this is not a single-post query, so it reaches drafts as well. Needs
-	 * WordPress 4.4 or later.
+	 * this is not a single-post query, so it reaches drafts as well.
 	 *
 	 * [--post_parent__in=<ids>]
 	 * : Only list the posts whose parent is one of these IDs (comma-separated).


### PR DESCRIPTION
Follows #643. Started from @ekamran's note in [wp-cli/wp-cli#6392](https://github.com/wp-cli/wp-cli/pull/6392#issuecomment-5326674784) that `--cat` and `--tag` are undocumented, then took the argument list from the docblock on `WP_Query::parse_query()` — 75 entries — and documented the ones that make sense here.

Documentation only, no code. **63 options are documented now, every one of them in that docblock.**

### What was missing, and why

The list arguments — `post__in`, `author__in`, `category__in`, `tag__in` and relatives — were the largest gap, and I had earlier claimed they needed code before they could be documented, on the belief that a comma-separated value would reach `WP_Query` as a string and quietly match its first entry alone. **That was wrong.** `CommandWithDBObject::process_csv_arguments_to_arrays()` already splits every argument whose name contains `__`:

```
wp post list --post__in=4,5 --format=count   -> 2
wp post list --post_name__in=one,two         -> 2 posts
```

`date_query`, `meta_query` and `tax_query` were the same story from the other direction: `list_()` names all three for JSON decoding, and nothing documented them.

Everything documented here was run through the command with values shaped the way the shell delivers them, not assumed. Two behaviours worth writing down came out of that:

- `--offset` does nothing until `--posts_per_page` is bounded, because the command defaults it to `-1`.
- `--page_id`, `--pagename` and `--attachment_id` need a matching `--post_type` to return anything.

### What is left out of the 75, and why

**Not a `WP_Query` argument at all.** `has_password` and `post_password` were in an earlier revision of this PR. Both filter, so they looked right, but neither appears in the `parse_query` docblock. Removed.

**Internal bookkeeping**, where a CLI user has no reason to reach: `cache_results`, `no_found_rows`, `suppress_filters`, `update_post_meta_cache`, `update_post_term_cache`, `update_menu_item_cache`, `lazy_load_term_meta`.

**Means something other than it appears to for a list:** `page` paginates within a single post, and `comments_per_page` / `posts_per_archive_page` are not about this query.

**Not filters at all** — passing them changes nothing, so documenting them would advertise a no-op: `feed`, `tb`, `preview`, `error`, `embed`, `sticky`. `--feed` came up directly in #6392; it is the query var WordPress fills in when routing an RSS request.

### Documenting a family by halves is worse than documenting all of it

Measured against the near-match check in wp-cli/wp-cli#6392, over the whole query-var list:

| Documented set | False positives |
| --- | --- |
| `main` today | 4 — `--tag`→`--day`, `--cat`→`--day`, `--feed`→`--field`, `--tb`→`--p` |
| + the list arguments only | 3 — `tag_id` now looks like `tag__in` |
| + those and the id arguments | 3 — `paged` now looks like `page_id` |
| **this PR, complete** | **2** — `--feed`→`--field`, `--tb`→`--p` |

Every intermediate false positive was an artifact of documenting half a family and stranding a name whose neighbours had just become candidates. The two that survive are the two query vars that are not filters, which is the irreducible floor here.

### A backend difference worth knowing

`--hour`, `--minute` and `--second` work individually and in pairs. All three at once does **not** work under SQLite: for more than two units `WP_Date_Query::build_time_query()` compares a `DATE_FORMAT()` string instead of separate `HOUR()`/`MINUTE()`/`SECOND()` clauses, and the SQLite integration plugin does not emulate that identically.

```
wp post list --hour=5 --minute=6 --second=7 --format=count
MariaDB  -> 1
SQLite   -> 0
```

Not caused by this PR and not fixable here. The scenario asserts two units at a time, which behaves the same on both, with a comment saying why.

### One argument needs WordPress newer than this command's floor

`parse_query()`'s docblock also records when each argument arrived. Of everything documented here, only `search_columns` (6.2.0) postdates 4.9, the oldest WordPress this command is tested against — `title`, `post_name__in` (4.4.0) and `comment_count` (4.9.0) are at or below the floor and need no note. `search_columns`'s option carries a "Needs WordPress 6.2 or later" line, and its scenario is split out and tagged `@require-wp-6.2` rather than living inside a scenario that has to pass everywhere: before 6.2 the argument is not recognised, so `--s` searches every column and the narrowing that scenario asserts does not happen.

### Testing

Five new scenarios in `features/post.feature`.

| Backend | Result |
| --- | --- |
| SQLite | 26 scenarios, 354 steps, all passed |
| MariaDB 10.11 | 26 scenarios, 354 steps, all passed |

PHPCS clean. `README.md` is regenerated, not hand-edited.

Refs wp-cli/wp-cli#5286, wp-cli/wp-cli#6392