### PR TITLE
Re-enable multisite `wp site create` tests on SQLite

### DIFF
--- a/features/site-create.feature
+++ b/features/site-create.feature
@@ -1,13 +1,5 @@
 Feature: Create a new site on a WP multisite
 
-  # Skipped on SQLite because of a bug in the SQLite plugin (as of v3.0.0):
-  # when `MULTISITE` is defined in wp-config.php but the database is still
-  # empty, the information schema reconstructor queries the `wp_blogs` table
-  # while establishing the connection. That table does not exist yet, so the
-  # connection fails with "One or more database tables are unavailable."
-  # See https://github.com/WordPress/sqlite-database-integration/issues/490.
-  # Once the bug is resolved, this tag can be removed again.
-  @skip-sqlite
   Scenario: Respect defined `$base` in wp-config
     Given an empty directory
     And WP files
@@ -55,8 +47,6 @@ Feature: Create a new site on a WP multisite
       | 1       | http://localhost/dev/         |
       | 2       | http://localhost/dev/newsite/ |
 
-  # See the note on the scenario above for why this is skipped on SQLite.
-  @skip-sqlite
   Scenario: Create new site with custom `$super_admins` global
     Given an empty directory
     And WP files


### PR DESCRIPTION
The two `Feature: Create a new site on a WP multisite` scenarios that
build a network from an empty database were tagged `@skip-sqlite` in
#635, because the SQLite integration plugin's information schema
reconstructor queried the not-yet-existing `wp_blogs` table while
establishing the connection, failing with "One or more database tables
are unavailable."

That bug is fixed in WordPress/sqlite-database-integration#492, released
in v3.0.1, so the tag and its explanatory comments can be removed again.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0161wAgnan6VrsWVW7dkkg2k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled multisite site-creation scenarios for SQLite.
  * Added coverage for base and custom super-admin configurations on SQLite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->