### PR TITLE
Guard the block subcommands on older WordPress and quiet the wp-compat false positives

### DIFF
--- a/features/post-block.feature
+++ b/features/post-block.feature
@@ -47,6 +47,27 @@ Feature: Manage blocks in post content
       """
     And the return code should be 1
 
+  @less-than-wp-5.0
+  Scenario: Checking for a specific block requires WordPress 5.0
+    Given a WP install
+    When I run `wp post create --post_title="Block Post" --post_content="<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    # has-blocks goes through the bundled WP_Block_Processor polyfill, so it keeps working.
+    When I run `wp post has-blocks {POST_ID}`
+    Then STDOUT should contain:
+      """
+      Success: Post {POST_ID} contains blocks.
+      """
+
+    # has-block relies on the has_block() function that WordPress only added in 5.0.
+    When I try `wp post has-block {POST_ID} core/paragraph`
+    Then STDERR should contain:
+      """
+      Error: Requires WordPress 5.0 or greater.
+      """
+    And the return code should be 1
+
   @require-wp-5.0
   Scenario: Parse blocks in a post
     Given a WP install

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,35 +20,49 @@ parameters:
     - identifier: missingType.parameter
     - identifier: missingType.return
 
+
     # johnbillion/wp-compat checks every WordPress symbol against the WordPress 4.9
     # baseline that wp-cli-tests configures. It only recognizes function_exists() and
     # method_exists() guards, so it cannot see the `before_invoke` version checks in
     # entity-command.php or the polyfills in src/Compat/, and reports those as errors.
+    #
+    # Every entry below matches on the message as well as the identifier, so that a call
+    # to something introduced later than the version a command is gated on still gets
+    # reported rather than swallowed by a file-wide ignore.
 
-    # `WP_Block_Processor` and its dependencies are polyfilled in src/Compat/ and
-    # loaded on demand through `BlockProcessorLoader::load()`, so they are available
-    # on every supported WordPress version, not just 6.9+.
+    # `WP_Block_Processor` and its dependencies are polyfilled in src/Compat/ and loaded
+    # on demand through `BlockProcessorLoader::load()`, so they are available on every
+    # supported WordPress version, not just 6.9+.
     -
       identifier: WPCompat.methodNotAvailable
+      message: '#^WP_Block_Processor::(allocate_and_return_parsed_attributes|extract_full_block_and_advance|get_block_type|get_delimiter_type|get_depth|get_span|next_block)\(\) is only available since WordPress version 6\.9\.0\.$#'
       path: src/Block_Processor_Helper.php
 
     # `wp font collection|face|family` aborts on WordPress < 6.5 via `before_invoke`.
     -
       identifier: WPCompat.methodNotAvailable
+      message: '#^(WP_Font_Collection::get_data|WP_Font_Library::(get_font_collection|get_font_collections|get_instance))\(\) is only available since WordPress version 6\.5\.0\.$#'
       paths:
         - src/Font_Collection_Command.php
         - src/Font_Family_Command.php
 
     # `wp user application-password` aborts on WordPress < 5.6 via `before_invoke`.
-    # The single WordPress 5.7 method is additionally behind a `wp_version_compare()`
-    # check in `application_name_exists_for_user()`.
     -
       identifier: WPCompat.methodNotAvailable
+      message: '#^WP_Application_Passwords::(create_new_application_password|delete_all_application_passwords|delete_application_password|get_user_application_password|get_user_application_passwords|record_application_password_usage|update_application_password)\(\) is only available since WordPress version 5\.6\.0\.$#'
+      path: src/User_Application_Password_Command.php
+
+    # The single WordPress 5.7 method is additionally behind a `wp_version_compare()`
+    # check in `application_name_exists_for_user()`, which reimplements it for 5.6.
+    -
+      identifier: WPCompat.methodNotAvailable
+      message: '#^WP_Application_Passwords::application_name_exists_for_user\(\) is only available since WordPress version 5\.7\.0\.$#'
       path: src/User_Application_Password_Command.php
 
     # `wp user privacy-request` aborts on WordPress < 4.9.6 via `before_invoke`.
     -
       identifier: WPCompat.functionNotAvailable
+      message: '#^(_wp_privacy_completed_request|wp_create_user_request|wp_get_user_request_data|wp_privacy_exports_dir|wp_privacy_generate_personal_data_export_file|wp_send_user_request)\(\) is only available since WordPress version 4\.9\.6\.$#'
       path: src/User_Privacy_Request_Command.php
 
     # `wp site meta` aborts via `before_invoke` unless `is_site_meta_supported()`
@@ -56,11 +70,12 @@ parameters:
     # along with the `*_site_meta()` functions used here.
     -
       identifier: WPCompat.functionNotAvailable
+      message: '#^(add_site_meta|delete_site_meta|get_site_meta|update_site_meta)\(\) is only available since WordPress version 5\.1\.0\.$#'
       path: src/Site_Meta_Command.php
 
-    # `wp post block` aborts on WordPress < 5.0 via `before_invoke`. Deliberately
-    # scoped to these three functions: `serialize_blocks()` is WordPress 5.3.1+ and is
-    # guarded separately, so it must keep being reported if that guard ever goes away.
+    # `wp post block` aborts on WordPress < 5.0 via `before_invoke`. `serialize_blocks()`
+    # is WordPress 5.3.1+ and is guarded separately in the mutating subcommands, so it
+    # must keep being reported if that guard ever goes away.
     -
       identifier: WPCompat.functionNotAvailable
       message: '#^(has_blocks|parse_blocks|render_block)\(\) is only available since WordPress version 5\.0\.0\.$#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,3 +19,99 @@ parameters:
     - identifier: missingType.property
     - identifier: missingType.parameter
     - identifier: missingType.return
+
+    # johnbillion/wp-compat checks every WordPress symbol against the WordPress 4.9
+    # baseline that wp-cli-tests configures. It only recognizes function_exists() and
+    # method_exists() guards, so it cannot see the `before_invoke` version checks in
+    # entity-command.php or the polyfills in src/Compat/, and reports those as errors.
+
+    # `WP_Block_Processor` and its dependencies are polyfilled in src/Compat/ and
+    # loaded on demand through `BlockProcessorLoader::load()`, so they are available
+    # on every supported WordPress version, not just 6.9+.
+    -
+      identifier: WPCompat.methodNotAvailable
+      path: src/Block_Processor_Helper.php
+
+    # `wp font collection|face|family` aborts on WordPress < 6.5 via `before_invoke`.
+    -
+      identifier: WPCompat.methodNotAvailable
+      paths:
+        - src/Font_Collection_Command.php
+        - src/Font_Family_Command.php
+
+    # `wp user application-password` aborts on WordPress < 5.6 via `before_invoke`.
+    # The single WordPress 5.7 method is additionally behind a `wp_version_compare()`
+    # check in `application_name_exists_for_user()`.
+    -
+      identifier: WPCompat.methodNotAvailable
+      path: src/User_Application_Password_Command.php
+
+    # `wp user privacy-request` aborts on WordPress < 4.9.6 via `before_invoke`.
+    -
+      identifier: WPCompat.functionNotAvailable
+      path: src/User_Privacy_Request_Command.php
+
+    # `wp site meta` aborts via `before_invoke` unless `is_site_meta_supported()`
+    # exists, which is the WordPress 5.1 function that introduced site meta support
+    # along with the `*_site_meta()` functions used here.
+    -
+      identifier: WPCompat.functionNotAvailable
+      path: src/Site_Meta_Command.php
+
+    # `wp post block` aborts on WordPress < 5.0 via `before_invoke`.
+    -
+      identifier: WPCompat.functionNotAvailable
+      message: '#^(has_blocks|parse_blocks|render_block)\(\) is only available since WordPress version 5\.0\.0\.$#'
+      path: src/Post_Block_Command.php
+
+    # Only the uppercase `'ID'` alias for the `$field` parameter of `get_term_by()`
+    # is WordPress 5.5+. These call sites pass `'id'`, `'term_id'` or `'slug'`, all
+    # supported since WordPress 2.3.
+    -
+      identifier: WPCompat.parameterNotAvailable.gettermby.field
+      paths:
+        - src/Menu_Item_Command.php
+        - src/Term_Command.php
+        - src/WP_CLI/CommandWithTerms.php
+
+    # WordPress 6.0 only formalized the already documented `...$args` parameter of
+    # `apply_filters()` by adding it to the function signature. Additional arguments
+    # were collected through `func_get_args()` before that.
+    -
+      identifier: WPCompat.parameterNotAvailable.applyfilters.args
+      path: src/Post_Block_Command.php
+
+    # Same for `wpdb::prepare()`, where WordPress 5.3 formalized the already
+    # documented `...$args` parameter. Passing a single array of values is even
+    # handled explicitly by `wpdb::prepare()` itself.
+    -
+      identifier: WPCompat.parameterNotAvailable.wpdbprepare.args
+      path: src/Site_Command.php
+
+    # The `$force_cache` parameter of `wp_load_alloptions()` is WordPress 5.3.1+, but
+    # older versions simply ignore the extra argument. The cache refresh in
+    # `wp option set-autoload` degrades to a no-op there instead of failing.
+    -
+      identifier: WPCompat.parameterNotAvailable.wploadalloptions.forcecache
+      path: src/Option_Command.php
+
+    # The two entries below are not false positives. They are real gaps against the
+    # WordPress 4.9 baseline, ignored here so that wp-compat stays enabled for the
+    # rest of these files.
+
+    # `serialize_blocks()` arrived in WordPress 5.3.1, later than the WordPress 5.0
+    # `before_invoke` check on `wp post block`, so the subcommands that write post
+    # content back fatal on WordPress 5.0 - 5.3.0. Raising that check to 5.3.1 fixes it.
+    -
+      identifier: WPCompat.functionNotAvailable
+      message: '#^serialize_blocks\(\) is only available since WordPress version 5\.3\.1\.$#'
+      path: src/Post_Block_Command.php
+
+    # `wp post` has no `before_invoke` version check, so `wp post has-block` fatals on
+    # WordPress < 5.0. Its sibling `wp post has-blocks` goes through
+    # `Block_Processor_Helper::has_blocks()`; `Block_Processor_Helper::has_block()`
+    # exists and would do the same job here.
+    -
+      identifier: WPCompat.functionNotAvailable
+      message: '#^has_block\(\) is only available since WordPress version 5\.0\.0\.$#'
+      path: src/Post_Command.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -58,7 +58,9 @@ parameters:
       identifier: WPCompat.functionNotAvailable
       path: src/Site_Meta_Command.php
 
-    # `wp post block` aborts on WordPress < 5.0 via `before_invoke`.
+    # `wp post block` aborts on WordPress < 5.0 via `before_invoke`. Deliberately
+    # scoped to these three functions: `serialize_blocks()` is WordPress 5.3.1+ and is
+    # guarded separately, so it must keep being reported if that guard ever goes away.
     -
       identifier: WPCompat.functionNotAvailable
       message: '#^(has_blocks|parse_blocks|render_block)\(\) is only available since WordPress version 5\.0\.0\.$#'
@@ -94,24 +96,3 @@ parameters:
     -
       identifier: WPCompat.parameterNotAvailable.wploadalloptions.forcecache
       path: src/Option_Command.php
-
-    # The two entries below are not false positives. They are real gaps against the
-    # WordPress 4.9 baseline, ignored here so that wp-compat stays enabled for the
-    # rest of these files.
-
-    # `serialize_blocks()` arrived in WordPress 5.3.1, later than the WordPress 5.0
-    # `before_invoke` check on `wp post block`, so the subcommands that write post
-    # content back fatal on WordPress 5.0 - 5.3.0. Raising that check to 5.3.1 fixes it.
-    -
-      identifier: WPCompat.functionNotAvailable
-      message: '#^serialize_blocks\(\) is only available since WordPress version 5\.3\.1\.$#'
-      path: src/Post_Block_Command.php
-
-    # `wp post` has no `before_invoke` version check, so `wp post has-block` fatals on
-    # WordPress < 5.0. Its sibling `wp post has-blocks` goes through
-    # `Block_Processor_Helper::has_blocks()`; `Block_Processor_Helper::has_block()`
-    # exists and would do the same job here.
-    -
-      identifier: WPCompat.functionNotAvailable
-      message: '#^has_block\(\) is only available since WordPress version 5\.0\.0\.$#'
-      path: src/Post_Command.php

--- a/src/Post_Block_Command.php
+++ b/src/Post_Block_Command.php
@@ -280,7 +280,7 @@ class Post_Block_Command extends WP_CLI_Command {
 		$blocks[ $original_idx ] = $block;
 
 		// @phpstan-ignore argument.type
-		$new_content = serialize_blocks( $blocks );
+		$new_content = $this->serialize_blocks( $blocks );
 		$result      = wp_update_post(
 			[
 				'ID'           => $post->ID,
@@ -398,7 +398,7 @@ class Post_Block_Command extends WP_CLI_Command {
 		// Insert at new position.
 		array_splice( $blocks, $insert_pos, 0, [ $block_to_move ] );
 
-		$new_content = serialize_blocks( $blocks );
+		$new_content = $this->serialize_blocks( $blocks );
 		$result      = wp_update_post(
 			[
 				'ID'           => $post->ID,
@@ -691,7 +691,7 @@ class Post_Block_Command extends WP_CLI_Command {
 			}
 		}
 
-		$new_content = serialize_blocks( $blocks );
+		$new_content = $this->serialize_blocks( $blocks );
 		$result      = wp_update_post(
 			[
 				'ID'           => $post->ID,
@@ -975,7 +975,7 @@ class Post_Block_Command extends WP_CLI_Command {
 		array_splice( $blocks, (int) $insert_pos, 0, [ $cloned_block ] );
 
 		// @phpstan-ignore argument.type
-		$new_content = serialize_blocks( $blocks );
+		$new_content = $this->serialize_blocks( $blocks );
 
 		$result = wp_update_post(
 			[
@@ -1424,7 +1424,7 @@ class Post_Block_Command extends WP_CLI_Command {
 		}
 
 		// @phpstan-ignore argument.type
-		$new_content = serialize_blocks( $blocks );
+		$new_content = $this->serialize_blocks( $blocks );
 		$result      = wp_update_post(
 			[
 				'ID'           => $post->ID,
@@ -1567,7 +1567,7 @@ class Post_Block_Command extends WP_CLI_Command {
 			return;
 		}
 
-		$new_content = serialize_blocks( $blocks );
+		$new_content = $this->serialize_blocks( $blocks );
 		$result      = wp_update_post(
 			[
 				'ID'           => $post->ID,
@@ -1681,7 +1681,7 @@ class Post_Block_Command extends WP_CLI_Command {
 		}
 
 		// @phpstan-ignore argument.type
-		$new_content = serialize_blocks( $blocks );
+		$new_content = $this->serialize_blocks( $blocks );
 		$result      = wp_update_post(
 			[
 				'ID'           => $post->ID,
@@ -1700,6 +1700,25 @@ class Post_Block_Command extends WP_CLI_Command {
 			$block_word = 1 === $replaced_count ? 'block' : 'blocks';
 			WP_CLI::success( "Replaced {$replaced_count} {$block_word} in post {$post->ID}." );
 		}
+	}
+
+	/**
+	 * Serializes blocks back into post content.
+	 *
+	 * The command itself requires WordPress 5.0, but `serialize_blocks()` was only
+	 * introduced in WordPress 5.3.1.
+	 *
+	 * @param array $blocks Array of blocks.
+	 * @return string Serialized post content.
+	 *
+	 * @phpstan-param array<int|string, array{blockName: string|null, attrs: array, innerBlocks: array[], innerHTML: string, innerContent: array}> $blocks
+	 */
+	private function serialize_blocks( $blocks ) {
+		if ( ! function_exists( 'serialize_blocks' ) ) {
+			WP_CLI::error( 'Requires WordPress 5.3.1 or greater.' );
+		}
+
+		return serialize_blocks( $blocks );
 	}
 
 	/**

--- a/src/Post_Block_Command.php
+++ b/src/Post_Block_Command.php
@@ -224,6 +224,10 @@ class Post_Block_Command extends WP_CLI_Command {
 	 * @subcommand update
 	 */
 	public function update( $args, $assoc_args ) {
+		if ( ! function_exists( 'serialize_blocks' ) ) {
+			WP_CLI::error( 'Requires WordPress 5.3.1 or greater.' );
+		}
+
 		$post   = $this->fetcher->get_check( $args[0] );
 		$index  = (int) $args[1];
 		$blocks = parse_blocks( $post->post_content );
@@ -280,7 +284,7 @@ class Post_Block_Command extends WP_CLI_Command {
 		$blocks[ $original_idx ] = $block;
 
 		// @phpstan-ignore argument.type
-		$new_content = $this->serialize_blocks( $blocks );
+		$new_content = serialize_blocks( $blocks );
 		$result      = wp_update_post(
 			[
 				'ID'           => $post->ID,
@@ -340,6 +344,10 @@ class Post_Block_Command extends WP_CLI_Command {
 	 * @subcommand move
 	 */
 	public function move( $args, $assoc_args ) {
+		if ( ! function_exists( 'serialize_blocks' ) ) {
+			WP_CLI::error( 'Requires WordPress 5.3.1 or greater.' );
+		}
+
 		$post       = $this->fetcher->get_check( $args[0] );
 		$from_index = (int) $args[1];
 		$to_index   = (int) $args[2];
@@ -398,7 +406,7 @@ class Post_Block_Command extends WP_CLI_Command {
 		// Insert at new position.
 		array_splice( $blocks, $insert_pos, 0, [ $block_to_move ] );
 
-		$new_content = $this->serialize_blocks( $blocks );
+		$new_content = serialize_blocks( $blocks );
 		$result      = wp_update_post(
 			[
 				'ID'           => $post->ID,
@@ -607,6 +615,10 @@ class Post_Block_Command extends WP_CLI_Command {
 	 * @subcommand import
 	 */
 	public function import( $args, $assoc_args ) {
+		if ( ! function_exists( 'serialize_blocks' ) ) {
+			WP_CLI::error( 'Requires WordPress 5.3.1 or greater.' );
+		}
+
 		$post     = $this->fetcher->get_check( $args[0] );
 		$file     = Utils\get_flag_value( $assoc_args, 'file', null );
 		$position = Utils\get_flag_value( $assoc_args, 'position', 'end' );
@@ -691,7 +703,7 @@ class Post_Block_Command extends WP_CLI_Command {
 			}
 		}
 
-		$new_content = $this->serialize_blocks( $blocks );
+		$new_content = serialize_blocks( $blocks );
 		$result      = wp_update_post(
 			[
 				'ID'           => $post->ID,
@@ -914,6 +926,10 @@ class Post_Block_Command extends WP_CLI_Command {
 	 * @subcommand clone
 	 */
 	public function clone_block( $args, $assoc_args ) {
+		if ( ! function_exists( 'serialize_blocks' ) ) {
+			WP_CLI::error( 'Requires WordPress 5.3.1 or greater.' );
+		}
+
 		$post         = $this->fetcher->get_check( $args[0] );
 		$source_index = (int) $args[1];
 		$position     = Utils\get_flag_value( $assoc_args, 'position', 'after' );
@@ -975,7 +991,7 @@ class Post_Block_Command extends WP_CLI_Command {
 		array_splice( $blocks, (int) $insert_pos, 0, [ $cloned_block ] );
 
 		// @phpstan-ignore argument.type
-		$new_content = $this->serialize_blocks( $blocks );
+		$new_content = serialize_blocks( $blocks );
 
 		$result = wp_update_post(
 			[
@@ -1393,6 +1409,10 @@ class Post_Block_Command extends WP_CLI_Command {
 	 * @subcommand insert
 	 */
 	public function insert( $args, $assoc_args ) {
+		if ( ! function_exists( 'serialize_blocks' ) ) {
+			WP_CLI::error( 'Requires WordPress 5.3.1 or greater.' );
+		}
+
 		$post       = $this->fetcher->get_check( $args[0] );
 		$block_name = $args[1];
 		$content    = Utils\get_flag_value( $assoc_args, 'content', '' );
@@ -1424,7 +1444,7 @@ class Post_Block_Command extends WP_CLI_Command {
 		}
 
 		// @phpstan-ignore argument.type
-		$new_content = $this->serialize_blocks( $blocks );
+		$new_content = serialize_blocks( $blocks );
 		$result      = wp_update_post(
 			[
 				'ID'           => $post->ID,
@@ -1492,6 +1512,10 @@ class Post_Block_Command extends WP_CLI_Command {
 	 * @subcommand remove
 	 */
 	public function remove( $args, $assoc_args ) {
+		if ( ! function_exists( 'serialize_blocks' ) ) {
+			WP_CLI::error( 'Requires WordPress 5.3.1 or greater.' );
+		}
+
 		$post       = $this->fetcher->get_check( $args[0] );
 		$block_name = isset( $args[1] ) ? $args[1] : null;
 		$indices    = Utils\get_flag_value( $assoc_args, 'index', null );
@@ -1567,7 +1591,7 @@ class Post_Block_Command extends WP_CLI_Command {
 			return;
 		}
 
-		$new_content = $this->serialize_blocks( $blocks );
+		$new_content = serialize_blocks( $blocks );
 		$result      = wp_update_post(
 			[
 				'ID'           => $post->ID,
@@ -1637,6 +1661,10 @@ class Post_Block_Command extends WP_CLI_Command {
 	 * @subcommand replace
 	 */
 	public function replace( $args, $assoc_args ) {
+		if ( ! function_exists( 'serialize_blocks' ) ) {
+			WP_CLI::error( 'Requires WordPress 5.3.1 or greater.' );
+		}
+
 		$post           = $this->fetcher->get_check( $args[0] );
 		$old_block_name = $args[1];
 		$new_block_name = $args[2];
@@ -1681,7 +1709,7 @@ class Post_Block_Command extends WP_CLI_Command {
 		}
 
 		// @phpstan-ignore argument.type
-		$new_content = $this->serialize_blocks( $blocks );
+		$new_content = serialize_blocks( $blocks );
 		$result      = wp_update_post(
 			[
 				'ID'           => $post->ID,
@@ -1700,25 +1728,6 @@ class Post_Block_Command extends WP_CLI_Command {
 			$block_word = 1 === $replaced_count ? 'block' : 'blocks';
 			WP_CLI::success( "Replaced {$replaced_count} {$block_word} in post {$post->ID}." );
 		}
-	}
-
-	/**
-	 * Serializes blocks back into post content.
-	 *
-	 * The command itself requires WordPress 5.0, but `serialize_blocks()` was only
-	 * introduced in WordPress 5.3.1.
-	 *
-	 * @param array $blocks Array of blocks.
-	 * @return string Serialized post content.
-	 *
-	 * @phpstan-param array<int|string, array{blockName: string|null, attrs: array, innerBlocks: array[], innerHTML: string, innerContent: array}> $blocks
-	 */
-	private function serialize_blocks( $blocks ) {
-		if ( ! function_exists( 'serialize_blocks' ) ) {
-			WP_CLI::error( 'Requires WordPress 5.3.1 or greater.' );
-		}
-
-		return serialize_blocks( $blocks );
 	}
 
 	/**

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -1430,6 +1430,10 @@ class Post_Command extends CommandWithDBObject {
 	 * @subcommand has-block
 	 */
 	public function has_block( $args, $assoc_args ) {
+		if ( ! function_exists( 'has_block' ) ) {
+			WP_CLI::error( 'Requires WordPress 5.0 or greater.' );
+		}
+
 		$post       = $this->fetcher->get_check( $args[0] );
 		$block_name = $args[1];
 


### PR DESCRIPTION
The `johnbillion/wp-compat` PHPStan extension that now ships with `wp-cli-tests` reported 106 errors. It checks every WordPress symbol against the WordPress 4.9 baseline that `wp-cli-tests` configures, and only recognizes `function_exists()` and `method_exists()` guards — so it cannot see the `before_invoke` version checks in `entity-command.php`, the `wp_version_compare()` calls in the commands, or the polyfills in `src/Compat/`.

98 are false positives. 8 are real, and are fixed in code rather than ignored.

## The real ones

Worth noting up front: raising a `before_invoke` version would **not** have silenced either of these. wp-compat measures against the 4.9 baseline and never looks at `before_invoke`, so the errors would have stayed and the ignores would have had to stay with them. `function_exists()` is the guard it does understand, so here it doubles as the runtime fix and the reason the ignore can go.

**`serialize_blocks()` is WordPress 5.3.1**, later than the WordPress 5.0 `before_invoke` check on `wp post block`. `update`, `insert`, `remove`, `move`, `replace`, `clone` and `import` therefore fataled on WordPress 5.0 - 5.3.0. Each now checks for the function as its first statement, so they abort before fetching the post, parsing blocks, or firing the `wp_cli_post_block_update_html` filter — which previously ran third-party callbacks for a command that was always going to fail. Keeping the check in the subcommands rather than raising `before_invoke` leaves the read-only subcommands (`list`, `parse`, `get`, `count`, `export`, `render`) working on WordPress 5.0 - 5.3.0.

**`wp post` carries no `before_invoke` check at all**, so `wp post has-block` fataled on WordPress 4.9 through core's `has_block()`. It now checks for the function up front and reports the requirement. A `before_invoke` was not an option, since it would apply to every `wp post` subcommand.

## The false positives

| Count | Where | Why it is a false positive |
| --- | --- | --- |
| 35 | `Block_Processor_Helper.php` | `WP_Block_Processor` is polyfilled in `src/Compat/` and loaded on demand via `BlockProcessorLoader::load()` |
| 17 | `Font_Collection_Command.php`, `Font_Family_Command.php` | `wp font *` aborts below WordPress 6.5 via `before_invoke` |
| 15 | `Post_Block_Command.php` | `parse_blocks()` / `render_block()` / `has_blocks()` — `wp post block` aborts below WordPress 5.0 via `before_invoke` |
| 9 | `User_Application_Password_Command.php` | Aborts below WordPress 5.6 via `before_invoke`; the one 5.7 method sits behind a `wp_version_compare()` check |
| 8 | `User_Privacy_Request_Command.php` | Aborts below WordPress 4.9.6 via `before_invoke` |
| 7 | `Term_Command.php`, `Menu_Item_Command.php`, `CommandWithTerms.php` | Only the uppercase `'ID'` alias for `get_term_by()`'s `$field` is WordPress 5.5+; these pass `'id'`, `'term_id'` or `'slug'`, and `--by` accepts only `slug` or `id` |
| 4 | `Site_Meta_Command.php` | `wp site meta` aborts unless `function_exists( 'is_site_meta_supported' )` — the WordPress 5.1 function that shipped alongside the `*_site_meta()` functions used here |
| 1 | `Post_Block_Command.php` | WordPress 6.0 only "formalized the existing and already documented `...$args` parameter" of `apply_filters()` |
| 1 | `Site_Command.php` | Same for `wpdb::prepare()` in 5.3; passing a single array of values is explicitly documented behaviour |
| 1 | `Option_Command.php` | `$force_cache` on `wp_load_alloptions()` is 5.3.1+, but older versions silently drop the extra argument, so the cache refresh in `wp option set-autoload` degrades to a no-op instead of failing |

Each of these is ignored in `phpstan.neon.dist` by error identifier **and** message, naming both the symbols involved and the version the command is gated on, with the reason documented per group. Matching the version is what makes the entries safe: scoping by class name alone would still have swallowed, say, a `WP_Font_Library` method introduced in 6.7. A call to anything newer than a command's gate keeps being reported instead.

That also splits the application-password group in two, which reflects the code more honestly — seven WordPress 5.6 methods covered by `before_invoke`, and `application_name_exists_for_user()` at 5.7, which has its own inline `wp_version_compare()` check with a 5.6 reimplementation.

## Tests

The functional matrix runs WordPress 4.9, so `post-block.feature` gains a `@less-than-wp-5.0` scenario asserting that `wp post has-block` reports the requirement. The same scenario pins the deliberate asymmetry between the two subcommands: `wp post has-blocks` keeps working there because it goes through the bundled polyfill.

The `serialize_blocks()` guard cannot be covered the same way. It only triggers between WordPress 5.0 and 5.3.0, and the matrix runs 4.9, 6.9, latest and trunk, so a scenario for it would never execute.

## Verification

Run locally against the same dependency versions CI resolves (`johnbillion/wp-compat` 2.0.0, `php-stubs/wordpress-stubs` v6.9.4, `wp-cli/wp-cli-tests` v5.2.3):

- `composer phpstan` — all 106 wp-compat errors resolved, and no unmatched ignore entries
- `composer phpcs` — clean, including the `testVersion 7.2-` PHPCompatibility rules against the polyfill path, since the 4.9 matrix entry runs PHP 7.2
- `composer phpunit` — 132/132
- `gherkin-lint` 4.2.4 with the org ruleset — clean
- As a control on the scoping, temporarily rewriting the font entry to expect `6.6.0` makes those errors resurface, confirming the version match is load-bearing rather than decorative

Two caveats worth stating plainly. Behat could not be run in my environment (its harness needs a provisioned database), so the new scenario has been linted but never executed. And GitHub Actions was failing to allocate runners across the org while this was written, so CI may need a re-run once that clears.

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility across supported WordPress versions and configurations.
  * Added clearer messages when block serialization requires WordPress 5.3.1 or newer.
  * Added clearer messages when block detection requires WordPress 5.0 or newer.
  * Improved reliability for block editing commands and legacy WordPress APIs.
  * Reduced compatibility warnings for supported WordPress features and backward-compatible parameters.
  * Prevented block-related operations from running when required WordPress capabilities are unavailable.
