### PR TITLE
Fix PHPStan errors with WordPress 7.1 stubs

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -49,13 +49,13 @@ parameters:
     # `wp icon` and `wp icon collection` abort on WordPress < 7.1 via `before_invoke`.
     -
       identifier: WPCompat.methodNotAvailable
-      message: '#^WP_Icon_Collections_Registry::get_instance\(\) is only available since WordPress version 7\.1\.0\.$#'
+      message: '#^WP_Icon_Collections_Registry::(get_all_registered|get_instance|get_registered|is_registered)\(\) is only available since WordPress version 7\.1\.0\.$#'
       paths:
         - src/Icon_Collection_Command.php
         - src/Icon_Command.php
     -
       identifier: WPCompat.methodNotAvailable
-      message: '#^WP_Icons_Registry::get_instance\(\) is only available since WordPress version 7\.0\.0\.$#'
+      message: '#^WP_Icons_Registry::(get_instance|get_registered_icon|get_registered_icons|is_registered)\(\) is only available since WordPress version 7\.0\.0\.$#'
       paths:
         - src/Icon_Collection_Command.php
         - src/Icon_Command.php
@@ -129,19 +129,3 @@ parameters:
     -
       identifier: WPCompat.parameterNotAvailable.wploadalloptions.forcecache
       path: src/Option_Command.php
-
-    # The Icons API introduced in WordPress 7.0 and 7.1 is not covered by the WordPress
-    # stubs yet, so PHPStan does not know these symbols at all. `reportUnmatched` keeps
-    # the entries from turning into errors themselves once the stubs catch up.
-    -
-      identifier: class.notFound
-      message: '#^Call to static method get_instance\(\) on an unknown class WP_(Icons_Registry|Icon_Collections_Registry)\.$#'
-      reportUnmatched: false
-      paths:
-        - src/Icon_Collection_Command.php
-        - src/Icon_Command.php
-    -
-      identifier: function.notFound
-      message: '#^Function wp_get_icon not found\.$#'
-      reportUnmatched: false
-      path: src/Icon_Command.php

--- a/src/Comment_Command.php
+++ b/src/Comment_Command.php
@@ -525,13 +525,13 @@ class Comment_Command extends CommandWithDBObject {
 
 		if ( 'count' === $formatter->format ) {
 			/**
-			 * @var int $comments
+			 * @var int<0, max> $comments
 			 */
 			echo $comments;
 			return;
 		} else {
 			/**
-			 * @var array $comments
+			 * @var array<int<0, max>|\WP_Comment> $comments
 			 */
 
 			if ( 'ids' === $formatter->format ) {

--- a/src/Post_Command.php
+++ b/src/Post_Command.php
@@ -943,7 +943,7 @@ class Post_Command extends CommandWithDBObject {
 		} elseif ( 'count' === $formatter->format ) {
 			$query_args['fields'] = 'ids';
 			$query                = new WP_Query( $query_args );
-			$formatter->display_items( $query->posts );
+			$formatter->display_items( $query->posts ?? [] );
 		} else {
 			$query = new WP_Query( $query_args );
 			$posts = array_map(
@@ -956,7 +956,7 @@ class Post_Command extends CommandWithDBObject {
 					$post->url = get_permalink( $post->ID );
 					return $post;
 				},
-				$query->posts
+				$query->posts ?? []
 			);
 			$formatter->display_items( $posts );
 		}

--- a/src/Site_Command.php
+++ b/src/Site_Command.php
@@ -1366,6 +1366,16 @@ class Site_Command extends CommandWithDBObject {
 	 * @return \Generator<int, \WP_Site>
 	 */
 	private static function get_sites_iterator( $query_args ) {
+		// 'count' and 'fields' are pinned to the WP_Site_Query defaults, so that
+		// get_sites() always answers with the WP_Site objects this yields.
+		$query_args = array_merge(
+			$query_args,
+			[
+				'count'  => false,
+				'fields' => '',
+			]
+		);
+
 		if ( isset( $query_args['number'] ) ) {
 			// The arguments are whatever the user passed, so they cannot be narrowed
 			// to the shape get_sites() documents. WP_Site_Query validates them itself.

--- a/src/Term_Command.php
+++ b/src/Term_Command.php
@@ -150,6 +150,7 @@ class Term_Command extends WP_CLI_Command {
 					$assoc_args,
 					[
 						'taxonomy' => $args,
+						'fields'   => 'all',
 					]
 				)
 			);
@@ -158,10 +159,6 @@ class Term_Command extends WP_CLI_Command {
 			if ( is_wp_error( $terms ) ) {
 				WP_CLI::error( $terms );
 			}
-
-			/**
-			 * @var \WP_Term[] $terms
-			 */
 		}
 
 		$terms = array_map(
@@ -603,7 +600,7 @@ class Term_Command extends WP_CLI_Command {
 				WP_CLI::warning( $term );
 			} else {
 				$created[]        = $term['term_id'];
-				$previous_term_id = $term['term_id'];
+				$previous_term_id = absint( $term['term_id'] );
 				if ( 'ids' === $format ) {
 					echo $term['term_id'];
 					if ( $index < $max_id + $count ) {
@@ -827,9 +824,7 @@ class Term_Command extends WP_CLI_Command {
 			WP_CLI::error( "Taxonomy term '{$term_reference}' for taxonomy '{$original_taxonomy}' doesn't exist." );
 		}
 
-		$tax = get_taxonomy( $original_taxonomy );
-
-		if ( ! $tax ) {
+		if ( ! taxonomy_exists( $original_taxonomy ) ) {
 			WP_CLI::error( "Taxonomy '{$original_taxonomy}' doesn't exist." );
 		}
 
@@ -856,7 +851,7 @@ class Term_Command extends WP_CLI_Command {
 		/**
 		 * @var string[] $post_ids
 		 */
-		$post_ids   = get_objects_in_term( $term->term_id, $tax->name );
+		$post_ids   = get_objects_in_term( $term->term_id, $original_taxonomy );
 		$post_count = 0;
 
 		foreach ( $post_ids as $post_id ) {
@@ -881,7 +876,7 @@ class Term_Command extends WP_CLI_Command {
 
 		WP_CLI::log( "Term '{$term->slug}' migrated." );
 
-		$del = wp_delete_term( $term->term_id, $tax->name );
+		$del = wp_delete_term( $term->term_id, $original_taxonomy );
 
 		if ( is_wp_error( $del ) ) {
 			WP_CLI::error( "Failed to delete the term '{$term->slug}'. Reason: " . $del->get_error_message() );
@@ -889,7 +884,7 @@ class Term_Command extends WP_CLI_Command {
 
 		WP_CLI::log( "Old instance of term '{$term->slug}' removed from its original taxonomy." );
 		$post_plural = Utils\pluralize( 'post', $post_count );
-		WP_CLI::success( "Migrated the term '{$term->slug}' from taxonomy '{$tax->name}' to taxonomy '{$destination_taxonomy}' for {$post_count} {$post_plural}." );
+		WP_CLI::success( "Migrated the term '{$term->slug}' from taxonomy '{$original_taxonomy}' to taxonomy '{$destination_taxonomy}' for {$post_count} {$post_plural}." );
 	}
 
 	private function maybe_make_child() {


### PR DESCRIPTION
`php-stubs/wordpress-stubs` v7.1.0 tightened the types of several WordPress core functions, which surfaced 23 new PHPStan errors.

- `get_sites()` and `get_terms()` gained conditional return types, so `Site_Command::get_sites_iterator()` and `Term_Command::list_()` now pin `count`/`fields` to the query defaults they already relied on. Both keys are stripped from the query args before that anyway, so nothing changes at runtime.
- `WP_Query::$posts` is now nullable and `WP_Comment_Query::query()` returns non-negative ints, so the annotations in `Post_Command` and `Comment_Command` were corrected.
- `wp_insert_term()` wants a non-negative `parent` and `wp_delete_term()` a non-empty `$taxonomy`; `Term_Command::migrate()` now validates with `taxonomy_exists()` (equivalent to the `get_taxonomy()` check it replaces) and passes the taxonomy name straight through.
- Dropped two `@phpstan-ignore method.deprecated` comments that no longer match, and the Icons API `class.notFound`/`function.notFound` entries now that the stubs cover it. The `WPCompat` entries for the version-gated `wp icon` commands were extended to the methods that only became visible with those stubs.

---
_Generated by [Claude Code](https://claude.ai/code/session_018PGksEeKBJuBAjUKEV3B9j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post listing when no posts are returned.
  * Ensured site and term listings consistently return complete records.
  * Improved term migration validation and ID handling.
* **Refactor**
  * Updated compatibility checks for icon-related commands.
  * Refined internal type handling and static analysis annotations.
  * Simplified session handling checks without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->