### PR TITLE
Remove obsolete get_term_by() PHPStan ignore entry

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -99,16 +99,6 @@ parameters:
       message: '#^(has_blocks|parse_blocks|render_block)\(\) is only available since WordPress version 5\.0\.0\.$#'
       path: src/Post_Block_Command.php
 
-    # Only the uppercase `'ID'` alias for the `$field` parameter of `get_term_by()`
-    # is WordPress 5.5+. These call sites pass `'id'`, `'term_id'` or `'slug'`, all
-    # supported since WordPress 2.3.
-    -
-      identifier: WPCompat.parameterNotAvailable.gettermby.field
-      paths:
-        - src/Menu_Item_Command.php
-        - src/Term_Command.php
-        - src/WP_CLI/CommandWithTerms.php
-
     # WordPress 6.0 only formalized the already documented `...$args` parameter of
     # `apply_filters()` by adding it to the function signature. Additional arguments
     # were collected through `func_get_args()` before that.


### PR DESCRIPTION
`johnbillion/wp-compat` 2.0.1 stopped reporting the `$field` parameter of `get_term_by()` as version-gated, fixing the false positive that the `WPCompat.parameterNotAvailable.gettermby.field` entry existed to suppress.

With nothing left to match, PHPStan now fails with a non-ignorable `Ignored error pattern ... was not matched in reported errors`, which is what broke the scheduled Code Quality run on `main` ([run 33288290118](https://github.com/wp-cli/entity-command/actions/runs/33288290118)). Removing the entry restores a clean analysis.

---
_Generated by [Claude Code](https://claude.ai/code/session_018PGksEeKBJuBAjUKEV3B9j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static analysis coverage by enabling reporting for previously suppressed compatibility warnings.
  * No end-user functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->